### PR TITLE
[feature] enable Cypress in pull requests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,14 +2,9 @@ name: Cypress Tests
 on:
   push:
     branches:
-      - feature/enable-local-mysql-for-cypress
-      - node-version-workflow
       - main
-# Ideally we run this on every PR. Currently the CI flow wipes the testing database to ensure that each run is deterministic
-# To support per-branch testing, we need to invest the eng effort in allowing someone to point thier branch to their local db
-# on:
-#   pull_request:
-#     types: ['opened', 'edited', 'reopened', 'synchronize', 'ready_for_review']
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize', 'ready_for_review']
 jobs:
   cypress-run:
     # if: github.event.pull_request.draft == false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -9,7 +9,7 @@ jobs:
   cypress-run:
     # if: github.event.pull_request.draft == false
     environment: preview
-    runs-on: ubuntu-latest-8core
+    runs-on: ubuntu-latest
     services:
       mysql:
         image: mysql:8.0

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,7 +7,7 @@ on:
     types: ['opened', 'edited', 'reopened', 'synchronize', 'ready_for_review']
 jobs:
   cypress-run:
-    # if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     environment: preview
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
**What changed? Why?**

This PR enables Cypress in pull requests. Why? Because we have recently implemented a local MySQL database _specifically_ for Cypress tests, so now we have a simple and deterministic way of accessing entries in a database for Cypress tests.

**How has it been tested?**

CI passes.

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
