### PR TITLE
[trivial] Display live event server action error message

### DIFF
--- a/src/actions/actionCreateUserActionLiveEvent.ts
+++ b/src/actions/actionCreateUserActionLiveEvent.ts
@@ -74,13 +74,17 @@ async function _actionCreateUserActionLiveEvent(input: CreateActionLiveEventInpu
   ) {
     const currentTime = Date.now()
     const eventDuration = EVENT_DURATION[validatedInput.data.campaignName]
-    if (
-      currentTime < eventDuration.START_TIME.getTime() ||
-      currentTime > eventDuration.END_TIME.getTime()
-    ) {
+    if (currentTime < eventDuration.START_TIME.getTime()) {
       return {
         errors: {
-          campaignName: ['The campaign is not active'],
+          campaignName: ['The event is not live yet.'],
+        },
+      }
+    }
+    if (currentTime > eventDuration.END_TIME.getTime()) {
+      return {
+        errors: {
+          campaignName: ['This event is no longer live.'],
         },
       }
     }

--- a/src/actions/actionCreateUserActionLiveEvent.ts
+++ b/src/actions/actionCreateUserActionLiveEvent.ts
@@ -77,7 +77,7 @@ async function _actionCreateUserActionLiveEvent(input: CreateActionLiveEventInpu
     if (currentTime < eventDuration.START_TIME.getTime()) {
       return {
         errors: {
-          campaignName: ['The event is not live yet.'],
+          campaignName: ['This event is not live yet.'],
         },
       }
     }

--- a/src/components/app/userActionFormLiveEvent/claimNft.tsx
+++ b/src/components/app/userActionFormLiveEvent/claimNft.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react'
 import { UserActionType } from '@prisma/client'
 import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
 
 import {
   actionCreateUserActionLiveEvent,
@@ -19,7 +20,6 @@ import { UserActionLiveEventCampaignName } from '@/utils/shared/userActionCampai
 import { triggerServerActionForForm } from '@/utils/web/formUtils'
 import { identifyUserOnClient } from '@/utils/web/identifyUser'
 import { NFT_CLIENT_METADATA } from '@/utils/web/nft'
-import { toastGenericError } from '@/utils/web/toastUtils'
 
 interface Props extends UseSectionsReturn<SectionNames> {
   isLoggedIn: boolean
@@ -40,7 +40,11 @@ export function ClaimNft({ isLoggedIn, slug, goToSection }: Props) {
     const result = await triggerServerActionForForm(
       {
         formName: 'User Action Form Live Event',
-        onError: toastGenericError,
+        onError: (_, error) => {
+          toast.error(error.message, {
+            duration: 5000,
+          })
+        },
         analyticsProps: {
           'Campaign Name': data.campaignName,
           'User Action Type': UserActionType.LIVE_EVENT,


### PR DESCRIPTION
**What changed? Why?**

Display informative error message in live event action flow when the event is not live yet or inactive.

**UI changes**

_Web_
<img width="445" alt="Screenshot 2024-03-06 at 3 40 21 PM" src="https://github.com/Stand-With-Crypto/swc-web/assets/108414827/eeb21363-20e7-473b-a418-f93a3999e3b9">


**Notes to reviewers**

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

**How has it been tested?**

- [x] Locally
- [x] Development
- [ ] Unit test
- [ ] Functional test

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
