### PR TITLE
remove sentry warnings, use mixpanel ratio report instead

### DIFF
--- a/src/actions/actionCreateUserActionCallCongressperson/index.ts
+++ b/src/actions/actionCreateUserActionCallCongressperson/index.ts
@@ -1,8 +1,7 @@
 'use server'
 import 'server-only'
 
-import { User, UserAction, UserActionType, UserInformationVisibility } from '@prisma/client'
-import * as Sentry from '@sentry/nextjs'
+import { User, UserActionType, UserInformationVisibility } from '@prisma/client'
 import { nativeEnum, object, z } from 'zod'
 
 import { getClientUser } from '@/clientModels/clientUser/clientUser'
@@ -100,8 +99,6 @@ async function _actionCreateUserActionCallCongressperson(
   if (recentUserAction) {
     logSpamActionSubmissions({
       validatedInput,
-      userAction: recentUserAction,
-      userId: user.id,
       sharedDependencies: { analytics },
     })
     await beforeFinish()
@@ -168,13 +165,9 @@ async function getRecentUserActionByUserId(
 
 function logSpamActionSubmissions({
   validatedInput,
-  userAction,
-  userId,
   sharedDependencies,
 }: {
   validatedInput: z.SafeParseSuccess<CreateActionCallCongresspersonInput>
-  userAction: UserAction
-  userId: User['id']
   sharedDependencies: Pick<SharedDependencies, 'analytics'>
 }) {
   sharedDependencies.analytics.trackUserActionCreatedIgnored({
@@ -184,13 +177,6 @@ function logSpamActionSubmissions({
     userState: 'Existing',
     ...convertAddressToAnalyticsProperties(validatedInput.data.address),
   })
-  Sentry.captureMessage(
-    `duplicate ${UserActionType.CALL} user action for campaign ${validatedInput.data.campaignName} submitted`,
-    {
-      extra: { validatedInput: validatedInput.data, userAction },
-      user: { id: userId },
-    },
-  )
 }
 
 async function createActionAndUpdateUser<U extends User>({

--- a/src/actions/actionCreateUserActionEmailCongressperson.ts
+++ b/src/actions/actionCreateUserActionEmailCongressperson.ts
@@ -11,7 +11,6 @@ import {
   UserEmailAddressSource,
   UserInformationVisibility,
 } from '@prisma/client'
-import * as Sentry from '@sentry/nextjs'
 import { z } from 'zod'
 
 import { getClientUser } from '@/clientModels/clientUser/clientUser'
@@ -116,10 +115,6 @@ async function _actionCreateUserActionEmailCongressperson(input: Input) {
       userState,
       ...convertAddressToAnalyticsProperties(validatedFields.data.address),
     })
-    Sentry.captureMessage(
-      `duplicate ${actionType} user action for campaign ${campaignName} submitted`,
-      { extra: { validatedFields, userAction }, user: { id: user.id } },
-    )
     await beforeFinish()
     return { user: getClientUser(user) }
   }

--- a/src/actions/actionCreateUserActionLiveEvent.ts
+++ b/src/actions/actionCreateUserActionLiveEvent.ts
@@ -1,8 +1,7 @@
 'use server'
 import 'server-only'
 
-import { User, UserAction, UserActionType, UserInformationVisibility } from '@prisma/client'
-import * as Sentry from '@sentry/nextjs'
+import { User, UserActionType, UserInformationVisibility } from '@prisma/client'
 import { nativeEnum, object, z } from 'zod'
 
 import { getClientUser } from '@/clientModels/clientUser/clientUser'
@@ -119,8 +118,6 @@ async function _actionCreateUserActionLiveEvent(input: CreateActionLiveEventInpu
   if (recentUserAction) {
     await logSpamActionSubmissions({
       validatedInput,
-      userAction: recentUserAction,
-      userId: user.id,
       sharedDependencies: { analytics },
     })
     return { user: getClientUser(user) }
@@ -185,13 +182,9 @@ async function getRecentUserActionByUserId(
 
 async function logSpamActionSubmissions({
   validatedInput,
-  userAction,
-  userId,
   sharedDependencies,
 }: {
   validatedInput: z.SafeParseSuccess<CreateActionLiveEventInput>
-  userAction: UserAction
-  userId: User['id']
   sharedDependencies: Pick<SharedDependencies, 'analytics'>
 }) {
   await sharedDependencies.analytics.trackUserActionCreatedIgnored({
@@ -199,10 +192,6 @@ async function logSpamActionSubmissions({
     campaignName: validatedInput.data.campaignName,
     reason: 'Too Many Recent',
     userState: 'Existing',
-  })
-  Sentry.captureMessage(`duplicate ${UserActionType.LIVE_EVENT} user action submitted`, {
-    extra: { validatedInput: validatedInput.data, userAction },
-    user: { id: userId },
   })
 }
 

--- a/src/actions/actionCreateUserActionTweet.ts
+++ b/src/actions/actionCreateUserActionTweet.ts
@@ -8,7 +8,6 @@ import {
   UserCryptoAddress,
   UserInformationVisibility,
 } from '@prisma/client'
-import * as Sentry from '@sentry/nextjs'
 
 import { getClientUser } from '@/clientModels/clientUser/clientUser'
 import { getMaybeUserAndMethodOfMatch } from '@/utils/server/getMaybeUserAndMethodOfMatch'
@@ -92,10 +91,6 @@ async function _actionCreateUserActionTweet() {
       creationMethod: 'On Site',
       userState,
     })
-    Sentry.captureMessage(
-      `duplicate ${actionType} user action for campaign ${campaignName} submitted`,
-      { extra: { userAction }, user: { id: user.id } },
-    )
     await beforeFinish()
     return { user: getClientUser(user) }
   }

--- a/src/actions/actionCreateUserActionVoterRegistration.ts
+++ b/src/actions/actionCreateUserActionVoterRegistration.ts
@@ -1,8 +1,7 @@
 'use server'
 import 'server-only'
 
-import { User, UserAction, UserActionType, UserInformationVisibility } from '@prisma/client'
-import * as Sentry from '@sentry/nextjs'
+import { User, UserActionType, UserInformationVisibility } from '@prisma/client'
 import { nativeEnum, object, z } from 'zod'
 
 import { getClientUser } from '@/clientModels/clientUser/clientUser'
@@ -96,8 +95,6 @@ async function _actionCreateUserActionVoterRegistration(input: CreateActionVoter
   if (recentUserAction) {
     logSpamActionSubmissions({
       validatedInput,
-      userAction: recentUserAction,
-      userId: user.id,
       sharedDependencies: { analytics },
     })
     await beforeFinish()
@@ -166,13 +163,9 @@ async function getRecentUserActionByUserId(
 
 function logSpamActionSubmissions({
   validatedInput,
-  userAction,
-  userId,
   sharedDependencies,
 }: {
   validatedInput: z.SafeParseSuccess<CreateActionVoterRegistrationInput>
-  userAction: UserAction
-  userId: User['id']
   sharedDependencies: Pick<SharedDependencies, 'analytics'>
 }) {
   sharedDependencies.analytics.trackUserActionCreatedIgnored({
@@ -182,13 +175,6 @@ function logSpamActionSubmissions({
     userState: 'Existing',
     usaState: validatedInput.data.usaState,
   })
-  Sentry.captureMessage(
-    `duplicate ${UserActionType.VOTER_REGISTRATION} user action for campaign ${validatedInput.data.campaignName} submitted`,
-    {
-      extra: { validatedInput: validatedInput.data, userAction },
-      user: { id: userId },
-    },
-  )
 }
 
 async function createAction<U extends User>({

--- a/src/data/verifiedSWCPartners/userActionOptIn.ts
+++ b/src/data/verifiedSWCPartners/userActionOptIn.ts
@@ -9,7 +9,6 @@ import {
   UserInformationVisibility,
   UserSession,
 } from '@prisma/client'
-import * as Sentry from '@sentry/nextjs'
 import { object, string, z } from 'zod'
 
 import { CAPITOL_CANARY_UPSERT_ADVOCATE_INNGEST_EVENT_NAME } from '@/inngest/functions/upsertAdvocateInCapitolCanary'
@@ -90,7 +89,7 @@ type Input = z.infer<typeof zodVerifiedSWCPartnersUserActionOptIn> & {
 export async function verifiedSWCPartnersUserActionOptIn(
   input: Input,
 ): Promise<VerifiedSWCPartnerApiResponse<VerifiedSWCPartnersUserActionOptInResult>> {
-  const { emailAddress, optInType, isVerifiedEmailAddress, campaignName } = input
+  const { emailAddress, optInType, campaignName } = input
   const actionType = UserActionType.OPT_IN
   const existingAction = await prismaClient.userAction.findFirst({
     include: {
@@ -123,10 +122,6 @@ export async function verifiedSWCPartnersUserActionOptIn(
   }
 
   if (existingAction) {
-    Sentry.captureMessage('verifiedSWCPartnersUserActionOptIn action already exists', {
-      extra: { emailAddress, isVerifiedEmailAddress },
-      tags: { optInType, actionType },
-    })
     analytics.trackUserActionCreatedIgnored({
       actionType,
       campaignName,

--- a/src/utils/server/serverAnalytics/serverAnalytics.ts
+++ b/src/utils/server/serverAnalytics/serverAnalytics.ts
@@ -129,15 +129,20 @@ export function getServerAnalytics(config: ServerAnalyticsConfig) {
     reason: 'Too Many Recent' | 'Already Exists'
     userState: AnalyticsUserActionUserState
   } & AnalyticProperties) => {
-    return trackAnalytic(config, ' Type Creation Ignored', {
-      ...currentSessionAnalytics,
-      'User Action Type': actionType,
-      'Campaign Name': campaignName,
-      'Creation Method': creationMethod,
-      'User State': userState,
-      Reason: reason,
-      ...other,
-    })
+    return trackAnalytic(
+      config,
+      // typo'ed this initially, do not change so we retain historical trend data
+      ' Type Creation Ignored',
+      {
+        ...currentSessionAnalytics,
+        'User Action Type': actionType,
+        'Campaign Name': campaignName,
+        'Creation Method': creationMethod,
+        'User State': userState,
+        Reason: reason,
+        ...other,
+      },
+    )
   }
 
   const track = (


### PR DESCRIPTION
**What changed? Why?**

We'll use [this report in mixpanel](https://mixpanel.com/project/3191713/view/3702825/app/insights#report/52770313/ratio-of-actions-created-to-duplicate-action-attempts) to flag any weird ratios of duplicate/real actions occurring

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
