### PR TITLE
[bug] fix Coinbase Commerce webhook events <> Mixpanel and add additional user data for donation `UserAction`s

### DIFF
--- a/src/app/api/internal/commerce-webhook/route.ts
+++ b/src/app/api/internal/commerce-webhook/route.ts
@@ -10,7 +10,9 @@ import {
   extractPricingValues,
   storePaymentRequest,
 } from '@/utils/server/coinbaseCommerce/storePaymentRequest'
+import { prismaClient } from '@/utils/server/prismaClient'
 import { getServerAnalytics } from '@/utils/server/serverAnalytics'
+import { getLocalUserFromUser, ServerLocalUser } from '@/utils/server/serverLocalUser'
 import { SupportedFiatCurrencyCodes } from '@/utils/shared/currency'
 
 export async function POST(request: NextRequest) {
@@ -32,13 +34,27 @@ export async function POST(request: NextRequest) {
     })
   }
 
+  let localUser: ServerLocalUser | null = null
+  if (body.event.data.metadata.userId) {
+    const user = await prismaClient.user.findFirst({
+      where: {
+        id: body.event.data.metadata.userId,
+      },
+    })
+    if (user) {
+      localUser = getLocalUserFromUser(user)
+    }
+  }
   const analytics = getServerAnalytics({
-    localUser: null,
+    localUser,
     userId: body.event.data.metadata.userId,
   })
   try {
     const pricingValues = extractPricingValues(body)
-    analytics.track('Coinbase Commerce Payment', {
+
+    // Tracking the payment event regardless of type - the donation action is not created here.
+    analytics.track('Coinbase Commerce webhook event received', {
+      creationMethod: 'On Site',
       paymentExpire: body.event.data.expires_at,
       paymentId: body.id,
       paymentPrice: `${pricingValues.amountUsd} ${SupportedFiatCurrencyCodes.USD}`,

--- a/src/app/api/internal/commerce-webhook/route.ts
+++ b/src/app/api/internal/commerce-webhook/route.ts
@@ -35,10 +35,19 @@ export async function POST(request: NextRequest) {
   }
 
   let localUser: ServerLocalUser | null = null
-  if (body.event.data.metadata.userId) {
+  if (body.event.data.metadata.userId || body.event.data.metadata.sessionId) {
     const user = await prismaClient.user.findFirst({
       where: {
-        id: body.event.data.metadata.userId,
+        // Use the `userId` first if the field exists. Otherwise, use the `sessionId`.
+        ...(body.event.data.metadata.userId
+          ? { id: body.event.data.metadata.userId }
+          : body.event.data.metadata.sessionId && {
+              userSessions: {
+                some: {
+                  id: body.event.data.metadata.sessionId,
+                },
+              },
+            }),
       },
     })
     if (user) {

--- a/src/utils/server/coinbaseCommerce/paymentRequest.ts
+++ b/src/utils/server/coinbaseCommerce/paymentRequest.ts
@@ -8,8 +8,8 @@ interface CoinbaseCommercePaymentDetails {
   detected_at?: string
   value?: {
     // Emitted from legacy Commerce API and new (web3) Commerce API.
-    local: { amount: string; currency: string }
-    crypto: { amount: string; currency: string }
+    local?: { amount: string; currency: string }
+    crypto?: { amount: string; currency: string }
   }
   block?: {
     height: number
@@ -47,8 +47,8 @@ interface CoinbaseCommercePaymentEventData {
   }
   pricing?: {
     // Emitted from new (web3) Commerce API.
-    local: { amount: string; currency: string }
-    settlement: { amount: string; currency: string }
+    local?: { amount: string; currency: string }
+    settlement?: { amount: string; currency: string }
   }
   pricing_type: string
   payments: CoinbaseCommercePaymentDetails[]


### PR DESCRIPTION
**What changed? Why?**

Relates to #615.

This PR attempts to fix the Coinbase Commerce webhook events <> Mixpanel by getting the local user from the user. Why? Because we want to be able to associate webhook events to a user.

**Notes to reviewers**

Some other changes:
- this PR now track the UserAction creation for the donation
- this PR implements some bug fixes regarding fetching the pricing values from the webhook event
- this PR now correctly adds the other user data (crypto address, email address, and session if available) to the `UserAction`

**How has it been tested?**

<img width="1145" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/135282747/381549e5-01aa-45f0-a23f-b0ab599b85ad">

_Tested with logged-in user_:

https://github.com/Stand-With-Crypto/swc-web/assets/135282747/2923036e-85cc-4f0d-bd91-bd4b10548f54

_Tested with logged-out user_:

https://github.com/Stand-With-Crypto/swc-web/assets/135282747/800f2d15-a386-4798-b725-a7da67e2a0b1

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
