### PR TITLE
Add new inngest function to update user primary crypto address

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -6,6 +6,7 @@ import { emailRepViaCapitolCanaryWithInngest } from '@/inngest/functions/emailRe
 import { monitorBaseETHBalances } from '@/inngest/functions/monitorBaseETHBalances'
 import { upsertAdvocateInCapitolCanaryWithInngest } from '@/inngest/functions/upsertAdvocateInCapitolCanary'
 import { inngest } from '@/inngest/inngest'
+import { setPrimaryCryptoAddressOfUserWithInngest } from '@/inngest/functions/setPrimaryCryptoAddressOfUser'
 
 export const { GET, POST, PUT } = serve({
   client: inngest,
@@ -15,5 +16,6 @@ export const { GET, POST, PUT } = serve({
     airdropNFTWithInngest,
     cleanupPostalCodesWithInngest,
     monitorBaseETHBalances,
+    setPrimaryCryptoAddressOfUserWithInngest,
   ],
 })

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -4,9 +4,9 @@ import { airdropNFTWithInngest } from '@/inngest/functions/airdropNFT'
 import { cleanupPostalCodesWithInngest } from '@/inngest/functions/cleanupPostalCodes'
 import { emailRepViaCapitolCanaryWithInngest } from '@/inngest/functions/emailRepViaCapitolCanary'
 import { monitorBaseETHBalances } from '@/inngest/functions/monitorBaseETHBalances'
+import { setPrimaryCryptoAddressOfUserWithInngest } from '@/inngest/functions/setPrimaryCryptoAddressOfUser'
 import { upsertAdvocateInCapitolCanaryWithInngest } from '@/inngest/functions/upsertAdvocateInCapitolCanary'
 import { inngest } from '@/inngest/inngest'
-import { setPrimaryCryptoAddressOfUserWithInngest } from '@/inngest/functions/setPrimaryCryptoAddressOfUser'
 
 export const { GET, POST, PUT } = serve({
   client: inngest,

--- a/src/bin/oneTimeScripts/cleanupPostalCodes.ts
+++ b/src/bin/oneTimeScripts/cleanupPostalCodes.ts
@@ -1,13 +1,5 @@
-import yargs from 'yargs'
-import { hideBin } from 'yargs/helpers'
-
-import { runBin } from '@/bin/runBin'
 import { prismaClient } from '@/utils/server/prismaClient'
 import { getLogger } from '@/utils/shared/logger'
-
-const params = yargs(hideBin(process.argv)).option('persist', {
-  type: 'boolean',
-})
 
 const logger = getLogger('cleanPostalCodes')
 
@@ -39,13 +31,3 @@ export async function cleanupPostalCodes(persist: boolean) {
   const affectedRows = await prismaClient.$executeRawUnsafe(sql)
   return { found: postalCodesWithSuffix.length, updated: affectedRows }
 }
-
-async function runCleanupPostalCodes() {
-  const { persist } = await params.argv
-  logger.info(`started with persist=${persist as any}`)
-  const result = await cleanupPostalCodes(persist ? persist : false)
-  logger.info(`updated ${result.updated} postal codes`)
-  return result
-}
-
-void runBin(runCleanupPostalCodes)

--- a/src/bin/oneTimeScripts/setPrimaryCryptoAddressOfUser.ts
+++ b/src/bin/oneTimeScripts/setPrimaryCryptoAddressOfUser.ts
@@ -1,13 +1,23 @@
+import { boolean, object, string, z } from 'zod'
+
 import { prismaClient } from '@/utils/server/prismaClient'
 import { getLogger } from '@/utils/shared/logger'
 
 const logger = getLogger('setPrimaryCryptoAddressOfUser')
 
+export const zodPrimaryCryptoAddressOfUserParameters = object({
+  userId: string(),
+  cryptoAddressId: string(),
+  persist: boolean(),
+})
+
 export async function setPrimaryCryptoAddressOfUser(
-  userId: string,
-  cryptoAddressId: string,
-  persist: boolean,
+  parameters: z.infer<typeof zodPrimaryCryptoAddressOfUserParameters>,
 ) {
+  zodPrimaryCryptoAddressOfUserParameters.parse(parameters)
+  const { userId, cryptoAddressId, persist } = parameters
+
+  logger.info(`userId:${userId} - cryptoAddressId: ${cryptoAddressId} `)
   const user = await prismaClient.user.findFirst({ where: { id: userId } })
   if (user === null) {
     throw new Error('No user found')

--- a/src/bin/oneTimeScripts/setPrimaryCryptoAddressOfUser.ts
+++ b/src/bin/oneTimeScripts/setPrimaryCryptoAddressOfUser.ts
@@ -1,0 +1,48 @@
+import { getLogger } from '@/utils/shared/logger'
+import { prismaClient } from '@/utils/server/prismaClient'
+
+const logger = getLogger('setPrimaryCryptoAddressOfUser')
+
+export async function setPrimaryCryptoAddressOfUser(
+  userId: string | undefined,
+  cryptoAddressId: string | undefined,
+  persist: boolean,
+) {
+  if (userId === undefined) {
+    throw new Error('userId cannot be undefined')
+  }
+  if (cryptoAddressId === undefined) {
+    throw new Error('cryptoAddressId cannot be undefined')
+  }
+
+  const user = await prismaClient.user.findFirst({ where: { id: userId } })
+
+  if (user === null) {
+    throw new Error('No user found')
+  }
+
+  logger.info('addressId ' + cryptoAddressId)
+  const cryptoAddress = await prismaClient.userCryptoAddress.findFirst({
+    where: { id: cryptoAddressId, userId: userId },
+  })
+  if (cryptoAddress === null) {
+    throw new Error("Crypto address not found or doesn't belong to user")
+  }
+
+  const userWithAddress = await prismaClient.user.findFirst({
+    where: { primaryUserCryptoAddressId: cryptoAddressId, id: { not: userId } },
+  })
+  if (userWithAddress != null) {
+    throw new Error('a user with the same primaryUserCryptoAddressId already exist')
+  }
+  if (!persist) {
+    logger.info('Dry run, exiting')
+  }
+
+  await prismaClient.user.update({
+    where: { id: userId },
+    data: {
+      primaryUserCryptoAddressId: cryptoAddressId,
+    },
+  })
+}

--- a/src/bin/oneTimeScripts/setPrimaryCryptoAddressOfUser.ts
+++ b/src/bin/oneTimeScripts/setPrimaryCryptoAddressOfUser.ts
@@ -4,24 +4,15 @@ import { getLogger } from '@/utils/shared/logger'
 const logger = getLogger('setPrimaryCryptoAddressOfUser')
 
 export async function setPrimaryCryptoAddressOfUser(
-  userId: string | undefined,
-  cryptoAddressId: string | undefined,
+  userId: string,
+  cryptoAddressId: string,
   persist: boolean,
 ) {
-  if (userId === undefined) {
-    throw new Error('userId cannot be undefined')
-  }
-  if (cryptoAddressId === undefined) {
-    throw new Error('cryptoAddressId cannot be undefined')
-  }
-
   const user = await prismaClient.user.findFirst({ where: { id: userId } })
-
   if (user === null) {
     throw new Error('No user found')
   }
 
-  logger.info('addressId ' + cryptoAddressId)
   const cryptoAddress = await prismaClient.userCryptoAddress.findFirst({
     where: { id: cryptoAddressId, userId: userId },
   })

--- a/src/bin/oneTimeScripts/setPrimaryCryptoAddressOfUser.ts
+++ b/src/bin/oneTimeScripts/setPrimaryCryptoAddressOfUser.ts
@@ -1,5 +1,5 @@
-import { getLogger } from '@/utils/shared/logger'
 import { prismaClient } from '@/utils/server/prismaClient'
+import { getLogger } from '@/utils/shared/logger'
 
 const logger = getLogger('setPrimaryCryptoAddressOfUser')
 
@@ -32,7 +32,7 @@ export async function setPrimaryCryptoAddressOfUser(
   const userWithAddress = await prismaClient.user.findFirst({
     where: { primaryUserCryptoAddressId: cryptoAddressId, id: { not: userId } },
   })
-  if (userWithAddress != null) {
+  if (userWithAddress !== null) {
     throw new Error('a user with the same primaryUserCryptoAddressId already exist')
   }
   if (!persist) {

--- a/src/inngest/functions/cleanupPostalCodes.ts
+++ b/src/inngest/functions/cleanupPostalCodes.ts
@@ -1,20 +1,9 @@
-import * as Sentry from '@sentry/nextjs'
-import { FailureEventArgs } from 'inngest'
-
 import { cleanupPostalCodes } from '@/bin/oneTimeScripts/cleanupPostalCodes'
 import { inngest } from '@/inngest/inngest'
+import { onScriptFailure } from '@/inngest/onScriptFaillure'
 
 export interface ScriptPayload {
   persist: boolean
-}
-
-async function onFailureCleanPostalCodes(failureEventArgs: FailureEventArgs) {
-  Sentry.captureException(failureEventArgs.error, {
-    level: 'error',
-    tags: {
-      functionId: failureEventArgs.event.data.function_id,
-    },
-  })
 }
 
 const CLEANUP_POSTAL_CODES_INNGEST_EVENT_NAME = 'script/cleanup-postal-codes'
@@ -23,7 +12,7 @@ export const cleanupPostalCodesWithInngest = inngest.createFunction(
   {
     id: CLEANUP_POSTAL_CODES_INNGEST_FUNCTION_ID,
     retries: 0,
-    onFailure: onFailureCleanPostalCodes,
+    onFailure: onScriptFailure,
   },
   { event: CLEANUP_POSTAL_CODES_INNGEST_EVENT_NAME },
   async ({ event, step }) => {

--- a/src/inngest/functions/setPrimaryCryptoAddressOfUser.ts
+++ b/src/inngest/functions/setPrimaryCryptoAddressOfUser.ts
@@ -1,14 +1,15 @@
 import * as Sentry from '@sentry/nextjs'
 import { FailureEventArgs } from 'inngest'
+import { boolean, object, string } from 'zod'
 
 import { setPrimaryCryptoAddressOfUser } from '@/bin/oneTimeScripts/setPrimaryCryptoAddressOfUser'
 import { inngest } from '@/inngest/inngest'
 
-export interface ScriptPayload {
-  userId: string
-  cryptoAddressId: string
-  persist: boolean
-}
+const scriptPayload = object({
+  userId: string(),
+  cryptoAddressId: string(),
+  persist: boolean(),
+})
 
 async function onFailureSetPrimaryCryptoAddressOfUser(failureEventArgs: FailureEventArgs) {
   Sentry.captureException(failureEventArgs.error, {
@@ -29,8 +30,7 @@ export const setPrimaryCryptoAddressOfUserWithInngest = inngest.createFunction(
   },
   { event: SET_CRYPTO_ADDRESS_OF_USER_INNGEST_EVENT_NAME },
   async ({ event, step }) => {
-    const payload = event.data as ScriptPayload
-
+    const payload = scriptPayload.parse(event.data)
     await step.run('execute-script', async () => {
       return await setPrimaryCryptoAddressOfUser(
         payload.userId,

--- a/src/inngest/functions/setPrimaryCryptoAddressOfUser.ts
+++ b/src/inngest/functions/setPrimaryCryptoAddressOfUser.ts
@@ -1,0 +1,46 @@
+import * as Sentry from '@sentry/nextjs'
+import { FailureEventArgs } from 'inngest'
+
+import { inngest } from '@/inngest/inngest'
+import { setPrimaryCryptoAddressOfUser } from '@/bin/oneTimeScripts/setPrimaryCryptoAddressOfUser'
+
+export interface ScriptPayload {
+  userId: string
+  cryptoAddressId: string
+  persist: boolean
+}
+
+async function onFailureSetPrimaryCryptoAddressOfUser(failureEventArgs: FailureEventArgs) {
+  Sentry.captureException(failureEventArgs.error, {
+    level: 'error',
+    tags: {
+      functionId: failureEventArgs.event.data.function_id,
+    },
+  })
+}
+
+const SET_CRYPTO_ADDRESS_OF_USER_INNGEST_EVENT_NAME = 'script/set-primary-crypto-address-of-user'
+const SET_CRYPTO_ADDRESS_OF_USER_INNGEST_FUNCTION_ID = 'script.set-primary-crypto-address-of-user'
+export const setPrimaryCryptoAddressOfUserWithInngest = inngest.createFunction(
+  {
+    id: SET_CRYPTO_ADDRESS_OF_USER_INNGEST_FUNCTION_ID,
+    retries: 0,
+    onFailure: onFailureSetPrimaryCryptoAddressOfUser,
+  },
+  { event: SET_CRYPTO_ADDRESS_OF_USER_INNGEST_EVENT_NAME },
+  async ({ event, step }) => {
+    const payload = event.data as ScriptPayload
+
+    await step.run('execute-script', async () => {
+      return await setPrimaryCryptoAddressOfUser(
+        payload.userId,
+        payload.cryptoAddressId,
+        payload.persist,
+      )
+    })
+
+    return {
+      dryRun: !payload.persist,
+    }
+  },
+)

--- a/src/inngest/functions/setPrimaryCryptoAddressOfUser.ts
+++ b/src/inngest/functions/setPrimaryCryptoAddressOfUser.ts
@@ -1,23 +1,11 @@
-import * as Sentry from '@sentry/nextjs'
-import { FailureEventArgs } from 'inngest'
-import { boolean, object, string } from 'zod'
-
 import { setPrimaryCryptoAddressOfUser } from '@/bin/oneTimeScripts/setPrimaryCryptoAddressOfUser'
 import { inngest } from '@/inngest/inngest'
+import { onScriptFailure } from '@/inngest/onScriptFaillure'
 
-const scriptPayload = object({
-  userId: string(),
-  cryptoAddressId: string(),
-  persist: boolean(),
-})
-
-async function onFailureSetPrimaryCryptoAddressOfUser(failureEventArgs: FailureEventArgs) {
-  Sentry.captureException(failureEventArgs.error, {
-    level: 'error',
-    tags: {
-      functionId: failureEventArgs.event.data.function_id,
-    },
-  })
+export interface ScriptPayload {
+  userId: string
+  cryptoAddressId: string
+  persist: boolean
 }
 
 const SET_CRYPTO_ADDRESS_OF_USER_INNGEST_EVENT_NAME = 'script/set-primary-crypto-address-of-user'
@@ -26,17 +14,17 @@ export const setPrimaryCryptoAddressOfUserWithInngest = inngest.createFunction(
   {
     id: SET_CRYPTO_ADDRESS_OF_USER_INNGEST_FUNCTION_ID,
     retries: 0,
-    onFailure: onFailureSetPrimaryCryptoAddressOfUser,
+    onFailure: onScriptFailure,
   },
   { event: SET_CRYPTO_ADDRESS_OF_USER_INNGEST_EVENT_NAME },
   async ({ event, step }) => {
-    const payload = scriptPayload.parse(event.data)
+    const payload = event.data as ScriptPayload
     await step.run('execute-script', async () => {
-      return await setPrimaryCryptoAddressOfUser(
-        payload.userId,
-        payload.cryptoAddressId,
-        payload.persist,
-      )
+      return await setPrimaryCryptoAddressOfUser({
+        userId: payload.userId,
+        cryptoAddressId: payload.cryptoAddressId,
+        persist: payload.persist,
+      })
     })
 
     return {

--- a/src/inngest/functions/setPrimaryCryptoAddressOfUser.ts
+++ b/src/inngest/functions/setPrimaryCryptoAddressOfUser.ts
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/nextjs'
 import { FailureEventArgs } from 'inngest'
 
-import { inngest } from '@/inngest/inngest'
 import { setPrimaryCryptoAddressOfUser } from '@/bin/oneTimeScripts/setPrimaryCryptoAddressOfUser'
+import { inngest } from '@/inngest/inngest'
 
 export interface ScriptPayload {
   userId: string

--- a/src/inngest/onScriptFaillure.ts
+++ b/src/inngest/onScriptFaillure.ts
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/nextjs'
+import { FailureEventArgs } from 'inngest'
+
+export async function onScriptFailure(failureEventArgs: FailureEventArgs) {
+  Sentry.captureException(failureEventArgs.error, {
+    level: 'error',
+    tags: {
+      functionId: failureEventArgs.event.data.function_id,
+    },
+  })
+}


### PR DESCRIPTION
**What changed? Why?**
Added a new inngest function to update user primary crypto address in case of users having multiple crypto addresses but have the wrong one as primary.

**UI changes**

**PlanetScale Deploy Request**

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

**Notes to reviewers**

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

**How has it been tested?**

- [x] Locally
- [x] Vercel Preview Branch

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
