### PR TITLE
fix: add validation for not null crypto address

### DIFF
--- a/src/actions/actionCreateUserActionCallCongressperson/index.ts
+++ b/src/actions/actionCreateUserActionCallCongressperson/index.ts
@@ -197,7 +197,7 @@ async function createActionAndUpdateUser<U extends User>({
       user: { connect: { id: user.id } },
       actionType: UserActionType.CALL,
       campaignName: validatedInput.campaignName,
-      ...('userCryptoAddress' in userMatch
+      ...('userCryptoAddress' in userMatch && userMatch.userCryptoAddress
         ? {
             userCryptoAddress: { connect: { id: userMatch.userCryptoAddress.id } },
           }

--- a/src/actions/actionCreateUserActionEmailCongressperson.ts
+++ b/src/actions/actionCreateUserActionEmailCongressperson.ts
@@ -126,7 +126,7 @@ async function _actionCreateUserActionEmailCongressperson(input: Input) {
       user: { connect: { id: user.id } },
       actionType,
       campaignName: validatedFields.data.campaignName,
-      ...('userCryptoAddress' in userMatch
+      ...('userCryptoAddress' in userMatch && userMatch.userCryptoAddress
         ? {
             userCryptoAddress: { connect: { id: userMatch.userCryptoAddress.id } },
           }

--- a/src/actions/actionCreateUserActionLiveEvent.ts
+++ b/src/actions/actionCreateUserActionLiveEvent.ts
@@ -213,7 +213,7 @@ async function createAction<U extends User>({
       user: { connect: { id: user.id } },
       actionType: UserActionType.LIVE_EVENT,
       campaignName: validatedInput.campaignName,
-      ...('userCryptoAddress' in userMatch
+      ...('userCryptoAddress' in userMatch && userMatch.userCryptoAddress
         ? {
             userCryptoAddress: { connect: { id: userMatch.userCryptoAddress.id } },
           }

--- a/src/actions/actionCreateUserActionTweet.ts
+++ b/src/actions/actionCreateUserActionTweet.ts
@@ -102,7 +102,7 @@ async function _actionCreateUserActionTweet() {
       user: { connect: { id: user.id } },
       actionType,
       campaignName,
-      ...('userCryptoAddress' in userMatch
+      ...('userCryptoAddress' in userMatch && userMatch.userCryptoAddress
         ? {
             userCryptoAddress: { connect: { id: userMatch.userCryptoAddress.id } },
           }

--- a/src/actions/actionCreateUserActionVoterRegistration.ts
+++ b/src/actions/actionCreateUserActionVoterRegistration.ts
@@ -195,7 +195,7 @@ async function createAction<U extends User>({
       user: { connect: { id: user.id } },
       actionType: UserActionType.VOTER_REGISTRATION,
       campaignName: validatedInput.campaignName,
-      ...('userCryptoAddress' in userMatch
+      ...('userCryptoAddress' in userMatch && userMatch.userCryptoAddress
         ? {
             userCryptoAddress: { connect: { id: userMatch.userCryptoAddress.id } },
           }

--- a/src/utils/server/getMaybeUserAndMethodOfMatch.ts
+++ b/src/utils/server/getMaybeUserAndMethodOfMatch.ts
@@ -16,7 +16,7 @@ type PrismaBase = Omit<Prisma.UserFindFirstArgs, 'where'>
 type BaseUserAndMethodOfMatch<S extends string | undefined, I extends PrismaBase = PrismaBase> =
   | {
       user: GetFindResult<Prisma.$UserPayload, I>
-      userCryptoAddress: UserCryptoAddress
+      userCryptoAddress: UserCryptoAddress | null
     }
   | {
       user: GetFindResult<Prisma.$UserPayload, I> | null
@@ -102,10 +102,10 @@ async function baseGetMaybeUserAndMethodOfMatch<
     }
     const authedCryptoAddress = userWithoutReturnTypes!.userCryptoAddresses.find(
       x => x.cryptoAddress === authUser.address,
-    )!
+    )
     return {
       user,
-      userCryptoAddress: authedCryptoAddress,
+      userCryptoAddress: authedCryptoAddress ?? null,
     }
   }
   return {


### PR DESCRIPTION
**What changed? Why?**

fixes #662 

This was a typescript issue. Since now we have sessions with only validated emails, those users won't have a `userCryptoAddress`, that said previously we were forcing the user match type so the crypto address were not nullable.
This changes that type and also changes how we check if it exists from `'userCryptoAddress' in userMatch` to `'userCryptoAddress' in userMatch && userMatch.userCryptoAddress`. Both are necessary bc TS uses the first check to infer the type of `userMatch` (it is an union of two types) and the second one to actually check if we have the property set. (noting that `'a' in { a: null }` is true)

**How has it been tested?**

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
