### PR TITLE
Questionnaire Splashpage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+closes <!-- GITHUB issue (e.g.: #123) -->
+fixes <!-- SENTRY issue (e.g.: PROD-SWC-WEB-1JE) -->
+
 **What changed? Why?**
 
 **UI changes**

--- a/public/logo/shield-black-bg.svg
+++ b/public/logo/shield-black-bg.svg
@@ -1,0 +1,43 @@
+<svg width="562" height="300" viewBox="0 0 562 300" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="562" height="300" rx="32" fill="black"/>
+<path d="M243.498 75H206V142.238C208.482 177.612 231.704 208.043 264.928 219.47L281 225V75H243.498Z" fill="url(#paint0_linear_386_17583)"/>
+<path d="M318.502 75H281V225L297.072 219.462C330.305 208.034 353.518 177.599 356 142.225V75H318.502Z" fill="url(#paint1_linear_386_17583)"/>
+<g clip-path="url(#clip0_386_17583)">
+<path d="M243.498 75H206V142.238C208.482 177.612 231.705 208.043 264.929 219.47L281.001 225V75H243.498Z" fill="url(#paint2_linear_386_17583)"/>
+<path d="M318.502 75H280.999V225L297.071 219.462C330.304 208.034 353.518 177.599 356 142.225V75H318.497H318.502Z" fill="url(#paint3_linear_386_17583)"/>
+<path d="M243.498 75H206V142.238C208.482 177.612 231.704 208.043 264.928 219.47L281 225V75H243.498Z" fill="url(#paint4_linear_386_17583)"/>
+<path d="M318.502 75H281V225L297.072 219.462C330.305 208.034 353.518 177.599 356 142.225V75H318.502Z" fill="url(#paint5_linear_386_17583)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_386_17583" x1="243.498" y1="75" x2="243.498" y2="225" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6100FF"/>
+<stop offset="1" stop-color="#C09AFF"/>
+</linearGradient>
+<linearGradient id="paint1_linear_386_17583" x1="318.502" y1="75" x2="318.502" y2="225" gradientUnits="userSpaceOnUse">
+<stop stop-color="#C09AFF"/>
+<stop offset="1" stop-color="#6100FF"/>
+<stop offset="1" stop-color="#6100FF"/>
+</linearGradient>
+<linearGradient id="paint2_linear_386_17583" x1="243.498" y1="75" x2="243.498" y2="225" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6100FF"/>
+<stop offset="1" stop-color="#ECE0FF"/>
+</linearGradient>
+<linearGradient id="paint3_linear_386_17583" x1="318.502" y1="75" x2="318.502" y2="225" gradientUnits="userSpaceOnUse">
+<stop stop-color="#ECE0FF"/>
+<stop offset="1" stop-color="#6100FF"/>
+<stop offset="1" stop-color="#6100FF"/>
+</linearGradient>
+<linearGradient id="paint4_linear_386_17583" x1="243.498" y1="75" x2="243.498" y2="225" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6100FF"/>
+<stop offset="1" stop-color="#E5D6FF"/>
+</linearGradient>
+<linearGradient id="paint5_linear_386_17583" x1="318.502" y1="75" x2="318.502" y2="225" gradientUnits="userSpaceOnUse">
+<stop stop-color="#E5D6FF"/>
+<stop offset="1" stop-color="#6100FF"/>
+<stop offset="1" stop-color="#6100FF"/>
+</linearGradient>
+<clipPath id="clip0_386_17583">
+<rect width="150" height="150" fill="white" transform="translate(206 75)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/app/[locale]/questionnaire/page.tsx
+++ b/src/app/[locale]/questionnaire/page.tsx
@@ -1,0 +1,61 @@
+import { Clock } from 'lucide-react'
+import { Metadata } from 'next'
+
+import { Button } from '@/components/ui/button'
+import { NextImage } from '@/components/ui/image'
+import { ExternalLink } from '@/components/ui/link'
+import { PageSubTitle } from '@/components/ui/pageSubTitle'
+import { PageTitle } from '@/components/ui/pageTitleText'
+import { generateMetadataDetails } from '@/utils/server/metadataUtils'
+import { externalUrls } from '@/utils/shared/urls'
+
+export const dynamic = 'error'
+
+export const metadata: Metadata = {
+  ...generateMetadataDetails({
+    title: 'Questionnaire',
+  }),
+}
+
+export default async function QuestionnairePage() {
+  return (
+    <div className="container flex flex-col items-center space-y-20">
+      <div className="relative h-[180px] w-full md:h-[300px]">
+        <NextImage
+          alt="Stand With Crypto shield with black background"
+          fill
+          priority
+          sizes="(max-width: 768px) 562px, 300px"
+          src="/logo/shield-black-bg.svg"
+        />
+      </div>
+
+      <div className="space-y-6">
+        <PageTitle>Stand With Crypto Questionnaire</PageTitle>
+        <PageSubTitle>
+          Stand With Crypto advocates for clear, common-sense regulation, prioritizing consumer
+          protection in the crypto industry. We’re mobilizing the 52 million crypto owners in the US
+          – a demographic that is younger (60% Gen-Z and Millennials) and more diverse (41% identify
+          as racial minorities) than the general US population – to unlock crypto’s innovation
+          potential and foster greater economic freedom. Crypto is pivotal for America as an
+          innovation driver ushering in web3; it's crucial for job creation, talent retention, and
+          ensuring global leadership. Recognizing crypto as a national priority, akin to
+          semiconductor manufacturing, we strive to ensure the United States maintains its global
+          leadership as the financial system adapts.
+        </PageSubTitle>
+      </div>
+
+      <div className="space-y-6">
+        <Button asChild size="lg">
+          <ExternalLink href={externalUrls.swcQuestionnaire()}>
+            Proceed to questionnaire
+          </ExternalLink>
+        </Button>
+        <div className="flex items-center justify-center gap-[7px] text-muted-foreground">
+          <Clock size={16} />
+          <p>2-3 minutes</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/utils/shared/urls.tsx
+++ b/src/utils/shared/urls.tsx
@@ -82,6 +82,7 @@ export const externalUrls = {
   swcOnChainSummer: () => 'https://onchainsummer.xyz/standwithcrypto',
   swcReferralUrl: ({ referralId }: { referralId: string }) =>
     `https://www.standwithcrypto.org/join/${referralId}`,
+  swcQuestionnaire: () => 'https://standwithcrypto.typeform.com/questionnaire',
 }
 
 export const apiUrls = {


### PR DESCRIPTION
closes #656 <!-- GITHUB issue (e.g.: #123) -->

**What changed? Why?**

This creates the questionnaire CTA page
This also changes the PR template to have closing keywords for sentry and github issues

**UI changes**

_Web_

![image](https://github.com/Stand-With-Crypto/swc-web/assets/155585835/2cbeaa62-4d4f-40f0-911a-3c65dea09856)

_Mobile Web_

![image](https://github.com/Stand-With-Crypto/swc-web/assets/155585835/d363dc3b-9755-459f-9c35-3a000f3e4adb)

**How has it been tested?**

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
