### PR TITLE
[bug] implement an Inngest script to merge duplicate backfilled users that have not logged-in

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -175,6 +175,7 @@ const V1_ACTION_REDIRECTS = ACTION_REDIRECTS.map(({ destination, queryKey, query
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  staticPageGenerationTimeout: 1000, // 1000 seconds, 16 minutes - REMOVE THIS WHEN DONE
   images: {
     unoptimized: false,
     remotePatterns: [

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -11,6 +11,8 @@ import { setPrimaryCryptoAddressOfUserWithInngest } from '@/inngest/functions/se
 import { upsertAdvocateInCapitolCanaryWithInngest } from '@/inngest/functions/upsertAdvocateInCapitolCanary'
 import { inngest } from '@/inngest/inngest'
 
+export const maxDuration = 300 // 5 minutes - maximum duration for a Vercel serverless function to run
+
 export const { GET, POST, PUT } = serve({
   client: inngest,
   functions: [

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -5,6 +5,7 @@ import { backfillNFTInngestCronJob } from '@/inngest/functions/airdropNFTCronJob
 import { backfillNFTWithInngest } from '@/inngest/functions/backfillNFT'
 import { cleanupPostalCodesWithInngest } from '@/inngest/functions/cleanupPostalCodes'
 import { emailRepViaCapitolCanaryWithInngest } from '@/inngest/functions/emailRepViaCapitolCanary'
+import { mergeBackfilledUsersWithInngest } from '@/inngest/functions/mergeBackfilledUsers'
 import { monitorBaseETHBalances } from '@/inngest/functions/monitorBaseETHBalances'
 import { setPrimaryCryptoAddressOfUserWithInngest } from '@/inngest/functions/setPrimaryCryptoAddressOfUser'
 import { upsertAdvocateInCapitolCanaryWithInngest } from '@/inngest/functions/upsertAdvocateInCapitolCanary'
@@ -21,5 +22,6 @@ export const { GET, POST, PUT } = serve({
     setPrimaryCryptoAddressOfUserWithInngest,
     backfillNFTWithInngest,
     backfillNFTInngestCronJob,
+    mergeBackfilledUsersWithInngest,
   ],
 })

--- a/src/data/aggregations/getCountPolicymakerContacts.ts
+++ b/src/data/aggregations/getCountPolicymakerContacts.ts
@@ -30,7 +30,7 @@ export const getCountPolicymakerContacts = async () => {
   const hardcodedCountSum =
     hardcodedCountCapitolCanaryEmails + hardcodedCountCalls + hardcodedCountIrsContacts
 
-  if (NEXT_PUBLIC_ENVIRONMENT === 'production') {
+  if (NEXT_PUBLIC_ENVIRONMENT === 'production' || NEXT_PUBLIC_ENVIRONMENT === 'local') {
     return { countUserActionEmails, countUserActionCalls, hardcodedCountSum }
   }
   /*

--- a/src/data/aggregations/getCountUsers.ts
+++ b/src/data/aggregations/getCountUsers.ts
@@ -5,7 +5,7 @@ import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
 
 export const getCountUsers = async () => {
   const count = await prismaClient.user.count()
-  if (NEXT_PUBLIC_ENVIRONMENT === 'production') {
+  if (NEXT_PUBLIC_ENVIRONMENT === 'production' || NEXT_PUBLIC_ENVIRONMENT === 'local') {
     return { count }
   }
   /*

--- a/src/inngest/functions/mergeBackfilledUsers/index.ts
+++ b/src/inngest/functions/mergeBackfilledUsers/index.ts
@@ -1,14 +1,23 @@
-import { mergeBackfilledUsers } from '@/inngest/functions/mergeBackfilledUsers/logic'
+import {
+  calculateAndLogDuplicateUserCounts,
+  mergeBackfilledUsers,
+} from '@/inngest/functions/mergeBackfilledUsers/logic'
 import { inngest } from '@/inngest/inngest'
 import { onScriptFailure } from '@/inngest/onScriptFailure'
+import { getLogger } from '@/utils/shared/logger'
 
 export interface ScriptPayload {
   limit: number
   persist: boolean
 }
 
+const logger = getLogger('mergeBackfilledUsers')
+
 const MERGE_BACKFILLED_USERS_INNGEST_FUNCTION_ID = 'script.merge-backfilled-users'
 const MERGE_BACKFILLED_USERS_INNGEST_EVENT_NAME = 'script/merge.backfilled.users'
+
+const MERGE_BACKFILLED_USERS_BATCH_SIZE = 20
+
 export const mergeBackfilledUsersWithInngest = inngest.createFunction(
   {
     id: MERGE_BACKFILLED_USERS_INNGEST_FUNCTION_ID,
@@ -16,18 +25,33 @@ export const mergeBackfilledUsersWithInngest = inngest.createFunction(
     onFailure: onScriptFailure,
   },
   { event: MERGE_BACKFILLED_USERS_INNGEST_EVENT_NAME },
-  async ({ event, step }) => {
+  async ({ event }) => {
     const payload = event.data as ScriptPayload
 
-    await step.run('script/execute.merge', async () => {
-      return await mergeBackfilledUsers({
-        limit: payload.limit,
+    await calculateAndLogDuplicateUserCounts()
+
+    let currentMergedUserCount = 0
+    let userIdsToSkip: string[] = []
+    while (currentMergedUserCount < payload.limit) {
+      const { mergedUsersCount, newUserIdsToSkip } = await mergeBackfilledUsers({
+        limit: Math.min(payload.limit - currentMergedUserCount, MERGE_BACKFILLED_USERS_BATCH_SIZE),
         persist: payload.persist,
+        userIdsToSkip,
       })
-    })
+      if (mergedUsersCount === 0) {
+        logger.info('No more users to merge')
+        break
+      }
+      currentMergedUserCount += mergedUsersCount
+      userIdsToSkip = userIdsToSkip.concat(newUserIdsToSkip)
+      logger.info(`Merged ${currentMergedUserCount} users so far`)
+    }
+
+    logger.info('Finished merging backfilled users', { currentMergedUserCount })
 
     return {
       dryRun: !payload.persist,
+      mergedUserCount: currentMergedUserCount,
     }
   },
 )

--- a/src/inngest/functions/mergeBackfilledUsers/index.ts
+++ b/src/inngest/functions/mergeBackfilledUsers/index.ts
@@ -1,0 +1,33 @@
+import { mergeBackfilledUsers } from '@/inngest/functions/mergeBackfilledUsers/logic'
+import { inngest } from '@/inngest/inngest'
+import { onScriptFailure } from '@/inngest/onScriptFailure'
+
+export interface ScriptPayload {
+  limit: number
+  persist: boolean
+}
+
+const MERGE_BACKFILLED_USERS_INNGEST_FUNCTION_ID = 'script.merge-backfilled-users'
+const MERGE_BACKFILLED_USERS_INNGEST_EVENT_NAME = 'script/merge.backfilled.users'
+export const mergeBackfilledUsersWithInngest = inngest.createFunction(
+  {
+    id: MERGE_BACKFILLED_USERS_INNGEST_FUNCTION_ID,
+    retries: 0,
+    onFailure: onScriptFailure,
+  },
+  { event: MERGE_BACKFILLED_USERS_INNGEST_EVENT_NAME },
+  async ({ event, step }) => {
+    const payload = event.data as ScriptPayload
+
+    await step.run('script/execute.merge', async () => {
+      return await mergeBackfilledUsers({
+        limit: payload.limit,
+        persist: payload.persist,
+      })
+    })
+
+    return {
+      dryRun: !payload.persist,
+    }
+  },
+)

--- a/src/inngest/functions/mergeBackfilledUsers/index.ts
+++ b/src/inngest/functions/mergeBackfilledUsers/index.ts
@@ -9,14 +9,13 @@ import { getLogger } from '@/utils/shared/logger'
 export interface ScriptPayload {
   limit: number
   persist: boolean
+  includeTotalCountCalculation: boolean
 }
 
 const logger = getLogger('mergeBackfilledUsers')
 
 const MERGE_BACKFILLED_USERS_INNGEST_FUNCTION_ID = 'script.merge-backfilled-users'
 const MERGE_BACKFILLED_USERS_INNGEST_EVENT_NAME = 'script/merge.backfilled.users'
-
-const MERGE_BACKFILLED_USERS_BATCH_SIZE = 20
 
 export const mergeBackfilledUsersWithInngest = inngest.createFunction(
   {
@@ -27,31 +26,25 @@ export const mergeBackfilledUsersWithInngest = inngest.createFunction(
   { event: MERGE_BACKFILLED_USERS_INNGEST_EVENT_NAME },
   async ({ event }) => {
     const payload = event.data as ScriptPayload
-
-    await calculateAndLogDuplicateUserCounts()
-
-    let currentMergedUserCount = 0
-    let userIdsToSkip: string[] = []
-    while (currentMergedUserCount < payload.limit) {
-      const { mergedUsersCount, newUserIdsToSkip } = await mergeBackfilledUsers({
-        limit: Math.min(payload.limit - currentMergedUserCount, MERGE_BACKFILLED_USERS_BATCH_SIZE),
-        persist: payload.persist,
-        userIdsToSkip,
-      })
-      if (mergedUsersCount === 0) {
-        logger.info('No more users to merge')
-        break
-      }
-      currentMergedUserCount += mergedUsersCount
-      userIdsToSkip = userIdsToSkip.concat(newUserIdsToSkip)
-      logger.info(`Merged ${currentMergedUserCount} users so far`)
+    if (!payload.limit || payload.limit <= 0) {
+      logger.info('`limit` not provided - defaulting to 100')
+      payload.limit = 100
     }
 
-    logger.info('Finished merging backfilled users', { currentMergedUserCount })
+    if (payload.includeTotalCountCalculation) {
+      await calculateAndLogDuplicateUserCounts()
+    }
+
+    const mergedUserCount = await mergeBackfilledUsers({
+      limit: payload.limit,
+      persist: payload.persist,
+    })
+
+    logger.info('Finished merging backfilled users', { mergedUserCount })
 
     return {
       dryRun: !payload.persist,
-      mergedUserCount: currentMergedUserCount,
+      mergedUserCount,
     }
   },
 )

--- a/src/inngest/functions/mergeBackfilledUsers/index.ts
+++ b/src/inngest/functions/mergeBackfilledUsers/index.ts
@@ -1,9 +1,10 @@
-import {
-  calculateAndLogDuplicateUserCounts,
-  mergeBackfilledUsers,
-} from '@/inngest/functions/mergeBackfilledUsers/logic'
+import { DataCreationMethod, UserInformationVisibility } from '@prisma/client'
+import * as Sentry from '@sentry/nextjs'
+
 import { inngest } from '@/inngest/inngest'
 import { onScriptFailure } from '@/inngest/onScriptFailure'
+import { mergeUsers } from '@/utils/server/mergeUsers/mergeUsers'
+import { prismaClient } from '@/utils/server/prismaClient'
 import { getLogger } from '@/utils/shared/logger'
 
 export interface ScriptPayload {
@@ -24,27 +25,171 @@ export const mergeBackfilledUsersWithInngest = inngest.createFunction(
     onFailure: onScriptFailure,
   },
   { event: MERGE_BACKFILLED_USERS_INNGEST_EVENT_NAME },
-  async ({ event }) => {
-    const payload = event.data as ScriptPayload
-    if (!payload.limit || payload.limit <= 0) {
-      logger.info('`limit` not provided - defaulting to 100')
-      payload.limit = 100
-    }
-
-    if (payload.includeTotalCountCalculation) {
-      await calculateAndLogDuplicateUserCounts()
-    }
-
-    const mergedUserCount = await mergeBackfilledUsers({
-      limit: payload.limit,
-      persist: payload.persist,
+  async ({ event, step }) => {
+    const payload = await step.run('script.initialize-payload', async () => {
+      const params = event.data as ScriptPayload
+      if (!params.limit || params.limit <= 0) {
+        logger.info('`limit` not provided - defaulting to 100')
+        params.limit = 100
+      }
+      return params
     })
 
-    logger.info('Finished merging backfilled users', { mergedUserCount })
-
-    return {
-      dryRun: !payload.persist,
-      mergedUserCount,
+    if (payload.includeTotalCountCalculation) {
+      await step.run('script.calculate-total-all-duplicate-user-counts', async () => {
+        logger.info('Calculating total duplicate user counts...')
+        const groupings = await findDuplicateUserEmailAddressGroupings(0)
+        logger.info(`Found total ${groupings.length} duplicate user email address groupings`)
+      })
     }
+
+    const userEmailAddressGroupings = await step.run(
+      'script.find-duplicate-user-email-address-groupings',
+      async () => {
+        logger.info('Finding duplicate user email address groupings...')
+        const groupings = await findDuplicateUserEmailAddressGroupings(payload.limit)
+        logger.info(`Found ${groupings.length} duplicate user email address groupings`)
+        return groupings
+      },
+    )
+
+    let groupingIndex = 0
+    for (const emailAddressGrouping of userEmailAddressGroupings) {
+      await step.run(`script.merge-users-by-email-address-${groupingIndex}`, async () => {
+        await mergeUsersByEmailAddress(emailAddressGrouping.emailAddress, payload.persist)
+      })
+      groupingIndex += 1
+    }
+
+    logger.info('Finished merging users')
   },
 )
+
+/**
+ * This function finds duplicate user email address groupings.
+ * Due to the grouping query, this function can take a long while to run (more than the default Vercel serverless function of 15 seconds).
+ *
+ * @param limit
+ * @returns
+ */
+async function findDuplicateUserEmailAddressGroupings(limit: number) {
+  return await prismaClient.userEmailAddress.groupBy({
+    by: ['emailAddress'],
+    where: {
+      dataCreationMethod: {
+        notIn: ['BY_USER'],
+      },
+      user: {
+        informationVisibility: UserInformationVisibility.ANONYMOUS,
+        dataCreationMethod: DataCreationMethod.INITIAL_BACKFILL,
+        acquisitionSource: 'capital-canary-initial-backfill',
+        userActions: {
+          every: {
+            dataCreationMethod: DataCreationMethod.INITIAL_BACKFILL,
+          },
+        },
+        userCryptoAddresses: {
+          every: {
+            dataCreationMethod: DataCreationMethod.INITIAL_BACKFILL,
+          },
+        },
+      },
+    },
+    having: {
+      emailAddress: {
+        _count: {
+          gt: 1,
+        },
+      },
+    },
+    orderBy: {
+      emailAddress: 'asc',
+    },
+    ...(limit && { take: limit }),
+  })
+}
+
+/**
+ * This function merges users by email address.
+ *
+ * @param emailAddress
+ * @param persist
+ * @returns
+ */
+async function mergeUsersByEmailAddress(emailAddress: string, persist: boolean) {
+  const userEmailAddresses = await prismaClient.userEmailAddress.findMany({
+    where: {
+      emailAddress: emailAddress,
+      user: {
+        informationVisibility: UserInformationVisibility.ANONYMOUS,
+        dataCreationMethod: DataCreationMethod.INITIAL_BACKFILL,
+        acquisitionSource: 'capital-canary-initial-backfill',
+        userActions: {
+          every: {
+            dataCreationMethod: DataCreationMethod.INITIAL_BACKFILL,
+          },
+        },
+        userCryptoAddresses: {
+          every: {
+            dataCreationMethod: DataCreationMethod.INITIAL_BACKFILL,
+          },
+        },
+      },
+    },
+    orderBy: {
+      userId: 'asc',
+    },
+  })
+  // If the user has been already merged by the user before being caught by this portion of the script, then we can expect
+  //   the length of `userEmailAddresses` to be 1.
+  // As such, we should skip the user.
+  if (userEmailAddresses.length <= 1) {
+    return
+  }
+  logger.info(`Found next' ${userEmailAddresses.length} email address rows`)
+
+  // Choose a user to keep - the rest will be deleted.
+  const userIdToKeep = userEmailAddresses[0].userId
+  const userIdsToDelete = userEmailAddresses.slice(1).map(({ userId }) => userId)
+
+  for (const userIdToDelete of userIdsToDelete) {
+    // Double-check that we have not already merged these users.
+    const userToKeep = await prismaClient.user.findUnique({
+      where: {
+        id: userIdToKeep,
+      },
+    })
+    const userToDelete = await prismaClient.user.findUnique({
+      where: {
+        id: userIdToDelete,
+      },
+    })
+    if (!userToKeep || !userToDelete) {
+      continue
+    }
+
+    // Also double-check that we are not merging the same user.
+    if (userToKeep.id === userToDelete.id) {
+      continue
+    }
+
+    // Merge the users if persist is true.
+    try {
+      await mergeUsers({
+        userToDeleteId: userIdToDelete,
+        userToKeepId: userIdToKeep,
+        persist,
+      })
+    } catch (error) {
+      Sentry.captureException(error, {
+        extra: {
+          userIdToDelete,
+          userIdToKeep,
+        },
+        tags: {
+          domain: 'mergeUsers',
+        },
+      })
+    }
+  }
+}

--- a/src/inngest/functions/mergeBackfilledUsers/logic.ts
+++ b/src/inngest/functions/mergeBackfilledUsers/logic.ts
@@ -1,0 +1,102 @@
+import { boolean, number, object, z } from 'zod'
+
+import { mergeUsers } from '@/utils/server/mergeUsers/mergeUsers'
+import { prismaClient } from '@/utils/server/prismaClient'
+import { getLogger } from '@/utils/shared/logger'
+
+const logger = getLogger('mergeBackfilledUsers')
+
+export const zodMergeBackfilledUsers = object({
+  limit: number().optional(),
+  persist: boolean().optional(),
+})
+
+export async function mergeBackfilledUsers(parameters: z.infer<typeof zodMergeBackfilledUsers>) {
+  zodMergeBackfilledUsers.parse(parameters)
+  const limit = parameters.limit
+  let persist = parameters.persist
+  if (!persist) {
+    persist = false
+  }
+
+  /**
+   * Find all duplicate email groups where none of the emails were inputted by a user.
+   * This implies that the emails were all from the V1 --> V2 backfill and that there has been no log-in attempt from that user.
+   * (The data creation would be `BY_USER` if the user had inputted the email in V2. In those cases, we ignore those duplicate emails).
+   * Because there has been no log-in attempt, those users have not been merged.
+   *
+   * "Why are you using the email addresses to determine duplicate users instead of user rows themselves?"
+   * - There is no good way to determine duplicate users from the backfill from the users table:
+   *   - Email addresses can be the same, but have different row IDs - the users table will show different IDs for different users.
+   * - Email addresses can tell us if a user has attempted to log in or not.
+   *   - If they have not logged in at all, then the email addresses are left unmerged.
+   *   - If they have logged in with email, then the email addresses should have already been merged (and hence no duplicate users).
+   *   - If they have logged in with a crypto address, then there might still be duplicate email addresses.
+   *     - However, we should not touch those users because it is intentional that email users are different than crypto users.
+   *       - There are only about a few hundred of these cases as far as I can tell.
+   *
+   * "What about crypto addresses?"
+   * By my investigation, if there are any duplicate crypto addresses, then that actually means that there are 2+ users
+   *   that use the same crypto address but use different email addresses. A common case for this is for couples who
+   *   share the same crypto address in SWC V1. I believe that this is not a problem and that we should not merge these users.
+   */
+  const userEmailAddressGroupings = await prismaClient.userEmailAddress.groupBy({
+    by: ['emailAddress'],
+    where: {
+      dataCreationMethod: {
+        notIn: ['BY_USER'],
+      },
+    },
+    having: {
+      emailAddress: {
+        _count: {
+          gt: 1,
+        },
+      },
+    },
+    orderBy: {
+      emailAddress: 'asc',
+    },
+    take: limit,
+  })
+  logger.info(`Found ${userEmailAddressGroupings.length} duplicate email addresses`)
+
+  // Get the full rows for the email addresses and for the users.
+  const userEmailAddresses = await prismaClient.userEmailAddress.findMany({
+    where: {
+      emailAddress: {
+        in: userEmailAddressGroupings.map(({ emailAddress }) => emailAddress),
+      },
+    },
+  })
+  logger.info(`Found ${userEmailAddresses.length} email address rows`)
+
+  let mergedUsersCount = 0
+  // Iterate through the email address groupings and merge the users.
+  for (const emailAddress of userEmailAddressGroupings) {
+    // Get all users for this email address.
+    const usersForEmailAddress = userEmailAddresses.filter(
+      emailAddressRow => emailAddressRow.emailAddress === emailAddress.emailAddress,
+    )
+    // This should not happen, but let's be safe.
+    if (usersForEmailAddress.length <= 1) {
+      continue
+    }
+
+    // Choose a user to keep - the rest will be deleted.
+    const userIdToKeep = usersForEmailAddress[0].userId
+    const userIdsToDelete = usersForEmailAddress.slice(1).map(({ userId }) => userId)
+
+    // Merge the users if persist is true.
+    for (const userIdToDelete of userIdsToDelete) {
+      await mergeUsers({
+        userToDeleteId: userIdToDelete,
+        userToKeepId: userIdToKeep,
+        persist,
+      })
+      mergedUsersCount++
+    }
+  }
+
+  logger.info(`Merged ${mergedUsersCount} users`)
+}

--- a/src/inngest/functions/mergeBackfilledUsers/logic.ts
+++ b/src/inngest/functions/mergeBackfilledUsers/logic.ts
@@ -24,6 +24,8 @@ export async function mergeBackfilledUsers(parameters: z.infer<typeof zodMergeBa
    * This implies that the emails were all from the V1 --> V2 backfill and that there has been no log-in attempt from that user.
    * (The data creation would be `BY_USER` if the user had inputted the email in V2. In those cases, we ignore those duplicate emails).
    *
+   * Simply put, we want to find users where they share the same email address, and the email address is not an V2 input.
+   *
    * "Why are you using the email addresses to determine duplicate users instead of user rows themselves?"
    * - There is no good way to determine duplicate users from the backfill from the users table:
    *   - Email addresses can be the same, but have different IDs - the users table will show the different IDs for different users, so that does not help.
@@ -33,14 +35,15 @@ export async function mergeBackfilledUsers(parameters: z.infer<typeof zodMergeBa
    *   - If they have logged in with email, then the email addresses should have already been merged (and hence no duplicate users).
    *   - If they have logged in with a crypto address, then there might still be duplicate email addresses.
    *     - However, we should not touch those users because it is intentional that email users are different than crypto users.
-   *       - There are only about a few hundred of these cases as far as I can tell.
+   *       - There are only about a few hundred of these cases as far as I can tell. We should still consider them as separate users.
    *
    * "What about crypto addresses?"
-   * By my investigation, if there are any duplicate crypto addresses, then that actually means that there are 2+ users
-   *   that use the same crypto address but use different email addresses. A common case for this is for couples who
-   *   share the same crypto address in SWC V1. I believe that this is not a problem and that we should not merge these users.
-   *   Also, if there is a case there are duplicate users that have the same email address and the same crypto address, the query
-   *   below will still catch those duplicate users anyways.
+   * - By my investigation, I determine that if there are any duplicate crypto addresses, then that usually means that there are 2+ users
+   *   that use the same crypto address but use different email addresses.
+   *   - A common case for this is for couples who share the same crypto address in SWC V1.
+   *   - I believe that this is not a problem and that we should not merge these users.
+   * - Also, if there is a case there are duplicate users that have the same email address and the same crypto address, the script
+   *   below will still catch those duplicate users anyways based on email address and merge properly.
    */
   const userEmailAddressGroupings = await prismaClient.userEmailAddress.groupBy({
     by: ['emailAddress'],

--- a/src/inngest/functions/mergeBackfilledUsers/logic.ts
+++ b/src/inngest/functions/mergeBackfilledUsers/logic.ts
@@ -26,7 +26,9 @@ export async function mergeBackfilledUsers(parameters: z.infer<typeof zodMergeBa
    *
    * "Why are you using the email addresses to determine duplicate users instead of user rows themselves?"
    * - There is no good way to determine duplicate users from the backfill from the users table:
-   *   - Email addresses can be the same, but have different row IDs - the users table will show different IDs for different users.
+   *   - Email addresses can be the same, but have different IDs - the users table will show different IDs for different users, so that does not help.
+   *   - Folks can have the same name and address, but not necessarily be duplicates of each other.
+   *   - Somehow, because of Capitol Canary's inconsistencies, the same user can have different Capitol Canary IDs, making that field unreliable.
    * - By my investigation, the email addresses can easily tell us if a user has attempted to log in or not.
    *   - If they have not logged in at all, then the email addresses are left unmerged.
    *   - If they have logged in with email, then the email addresses should have already been merged (and hence no duplicate users).

--- a/src/inngest/functions/mergeBackfilledUsers/logic.ts
+++ b/src/inngest/functions/mergeBackfilledUsers/logic.ts
@@ -23,12 +23,11 @@ export async function mergeBackfilledUsers(parameters: z.infer<typeof zodMergeBa
    * Find all duplicate email groups where none of the emails were inputted by a user.
    * This implies that the emails were all from the V1 --> V2 backfill and that there has been no log-in attempt from that user.
    * (The data creation would be `BY_USER` if the user had inputted the email in V2. In those cases, we ignore those duplicate emails).
-   * Because there has been no log-in attempt, those users have not been merged.
    *
    * "Why are you using the email addresses to determine duplicate users instead of user rows themselves?"
    * - There is no good way to determine duplicate users from the backfill from the users table:
    *   - Email addresses can be the same, but have different row IDs - the users table will show different IDs for different users.
-   * - Email addresses can tell us if a user has attempted to log in or not.
+   * - By my investigation, the email addresses can easily tell us if a user has attempted to log in or not.
    *   - If they have not logged in at all, then the email addresses are left unmerged.
    *   - If they have logged in with email, then the email addresses should have already been merged (and hence no duplicate users).
    *   - If they have logged in with a crypto address, then there might still be duplicate email addresses.
@@ -87,8 +86,23 @@ export async function mergeBackfilledUsers(parameters: z.infer<typeof zodMergeBa
     const userIdToKeep = usersForEmailAddress[0].userId
     const userIdsToDelete = usersForEmailAddress.slice(1).map(({ userId }) => userId)
 
-    // Merge the users if persist is true.
     for (const userIdToDelete of userIdsToDelete) {
+      // Double-check that we have not already merged these users.
+      const userToKeep = await prismaClient.user.findUnique({
+        where: {
+          id: userIdToKeep,
+        },
+      })
+      const userToDelete = await prismaClient.user.findUnique({
+        where: {
+          id: userIdToDelete,
+        },
+      })
+      if (!userToKeep || !userToDelete) {
+        continue
+      }
+
+      // Merge the users if persist is true.
       await mergeUsers({
         userToDeleteId: userIdToDelete,
         userToKeepId: userIdToKeep,

--- a/src/inngest/functions/mergeBackfilledUsers/logic.ts
+++ b/src/inngest/functions/mergeBackfilledUsers/logic.ts
@@ -108,7 +108,7 @@ export async function mergeBackfilledUsers(
   }
 
   logger.info(
-    `Found ${parameters.calculateMode ? 'next' : ''} ${userEmailAddressGroupings.length} duplicate email addresses`,
+    `Found ${parameters.calculateMode ? 'next' : 'total'} ${userEmailAddressGroupings.length} duplicate email addresses`,
   )
 
   // Get the full rows for the email addresses and for the users.
@@ -121,7 +121,7 @@ export async function mergeBackfilledUsers(
     },
   })
   logger.info(
-    `Found ${parameters.calculateMode ? 'next' : ''} ${userEmailAddresses.length} email address rows`,
+    `Found ${parameters.calculateMode ? 'next' : 'total'} ${userEmailAddresses.length} email address rows`,
   )
 
   if (parameters.calculateMode) {

--- a/src/inngest/functions/mergeBackfilledUsers/logic.ts
+++ b/src/inngest/functions/mergeBackfilledUsers/logic.ts
@@ -100,7 +100,7 @@ export async function mergeBackfilledUsers(parameters: z.infer<typeof zodMergeBa
     return 0
   }
   logger.info(
-    `${parameters.calculateMode ? 'Counted' : 'Found next'} ${userEmailAddressGroupings.length}${parameters.calculateMode ? ' total' : ''} duplicate email addresses`,
+    `${parameters.calculateMode ? 'Counted' : 'Found next'}${userEmailAddressGroupings.length}${parameters.calculateMode ? ' total' : ''} duplicate email addresses`,
   )
   if (parameters.calculateMode) {
     return 0
@@ -110,7 +110,7 @@ export async function mergeBackfilledUsers(parameters: z.infer<typeof zodMergeBa
   const newUserIdsToSkip: string[] = []
   for (const emailAddress of userEmailAddressGroupings) {
     // For each email address, find all email address rows that match the email address.
-    // We will use the rows to get the user ID.
+    // We will use the rows to get the user ID, then we will use the user ID to merge users.
     // Also filter out the specific attributes again here just to make sure.
     const userEmailAddresses = await prismaClient.userEmailAddress.findMany({
       where: {
@@ -137,8 +137,9 @@ export async function mergeBackfilledUsers(parameters: z.infer<typeof zodMergeBa
     })
     logger.info(`Found next' ${userEmailAddresses.length} email address rows`)
 
-    // This may happen if the user has been already merged by the user before being caught by this portion of the script,
-    // so we should skip this user if the length is less than or equal to 1.
+    // If the user has been already merged by the user before being caught by this portion of the script, then we can expect
+    //   the length of `userEmailAddresses` to be 1.
+    // As such, we should skip the user.
     if (userEmailAddresses.length <= 1) {
       continue
     }

--- a/src/inngest/functions/mergeBackfilledUsers/logic.ts
+++ b/src/inngest/functions/mergeBackfilledUsers/logic.ts
@@ -26,8 +26,7 @@ export async function mergeBackfilledUsers(parameters: z.infer<typeof zodMergeBa
    *
    * "Why are you using the email addresses to determine duplicate users instead of user rows themselves?"
    * - There is no good way to determine duplicate users from the backfill from the users table:
-   *   - Email addresses can be the same, but have different IDs - the users table will show different IDs for different users, so that does not help.
-   *   - Folks can have the same name and address, but not necessarily be duplicates of each other.
+   *   - Email addresses can be the same, but have different IDs - the users table will show the different IDs for different users, so that does not help.
    *   - Somehow, because of Capitol Canary's inconsistencies, the same user can have different Capitol Canary IDs, making that field unreliable.
    * - By my investigation, the email addresses can easily tell us if a user has attempted to log in or not.
    *   - If they have not logged in at all, then the email addresses are left unmerged.

--- a/src/inngest/functions/mergeBackfilledUsers/logic.ts
+++ b/src/inngest/functions/mergeBackfilledUsers/logic.ts
@@ -38,6 +38,8 @@ export async function mergeBackfilledUsers(parameters: z.infer<typeof zodMergeBa
    * By my investigation, if there are any duplicate crypto addresses, then that actually means that there are 2+ users
    *   that use the same crypto address but use different email addresses. A common case for this is for couples who
    *   share the same crypto address in SWC V1. I believe that this is not a problem and that we should not merge these users.
+   *   Also, if there is a case there are duplicate users that have the same email address and the same crypto address, the query
+   *   below will still catch those duplicate users anyways.
    */
   const userEmailAddressGroupings = await prismaClient.userEmailAddress.groupBy({
     by: ['emailAddress'],


### PR DESCRIPTION
relates to #160 

**What changed? Why?**

This PR implements an Inngest script that will merge duplicate backfilled users that have not logged-in.

"Why?" Because as a result of the V1 --> V2 migration script, there were duplicate users created. Normally, these duplicate users would be merged if the user logs into the SWC V2 website. However, given the push for correct data metrics, we should proactively merge these duplicate backfilled users.

**UI changes**

No UI changes.

**PlanetScale Deploy Request**

No database schema changes.

**Notes to reviewers**

See [this comment](https://github.com/Stand-With-Crypto/swc-web/pull/674/files#diff-f0022d2acc7132c003f3bde09711b73707ebe11763828306cc160e54465c1e8fR22-R42) for a full explanation of how we know which backfilled users to merge.
 
**How has it been tested?**

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
