### PR TITLE
tests: change tests to adapt to dtsi mocks

### DIFF
--- a/cypress/e2e/3-page-politicians.cy.ts
+++ b/cypress/e2e/3-page-politicians.cy.ts
@@ -26,7 +26,7 @@ it('page - politicians interactions', () => {
     trigger: cy.get('input[placeholder="Enter your address"]'),
     searchText: '350 Fifth Avenue New York, NY 10118',
   })
-  cy.contains('Jerry Nadler', { timeout: 10000 })
+  cy.contains('Zola Feil Sr', { timeout: 10000 })
 
   // clear your address
   cy.contains('350 Fifth Avenue, New York, NY 10118, USA').click()

--- a/cypress/e2e/4-action-email-your-congressperson.cy.ts
+++ b/cypress/e2e/4-action-email-your-congressperson.cy.ts
@@ -31,7 +31,7 @@ it('action - email your congressperson', () => {
     trigger: cy.get('input[placeholder="Your full address"]'),
     searchText: '350 Fifth Avenue New York, NY 10118',
   })
-  cy.contains('Your representative is Jerry Nadler')
+  cy.contains('Your representative is Zola Feil Sr')
   cy.get('textarea').type('test message')
   cy.get('button[type="submit"]').click()
 

--- a/src/data/dtsi/fetchDTSI.ts
+++ b/src/data/dtsi/fetchDTSI.ts
@@ -17,6 +17,7 @@ const logger = getLogger('fetchDTSI')
 const DO_THEY_SUPPORT_IT_API_KEY = process.env.DO_THEY_SUPPORT_IT_API_KEY!
 
 export const fetchDTSI = async <R, V = object>(query: string, variables?: V) => {
+  // console.log(query)
   if (
     IS_DEVELOPING_OFFLINE ||
     (!DO_THEY_SUPPORT_IT_API_KEY && NEXT_PUBLIC_ENVIRONMENT === 'local')

--- a/src/mocks/dtsi/mockResolvers/dtsiPersonRoleResolver.ts
+++ b/src/mocks/dtsi/mockResolvers/dtsiPersonRoleResolver.ts
@@ -7,7 +7,9 @@ import {
 } from '@/data/dtsi/generated'
 import { US_STATE_CODE_TO_DISPLAY_NAME_MAP } from '@/utils/shared/usStateUtils'
 
-export const dtsiPersonRoleMockResolver = (): Partial<DTSI_PersonRoleResolvers> => {
+export const dtsiPersonRoleMockResolver = (
+  overrides: Partial<DTSI_PersonRoleResolvers> = {},
+): Partial<DTSI_PersonRoleResolvers> => {
   return {
     primaryCountryCode: () => 'US',
     primaryState: () =>
@@ -22,5 +24,6 @@ export const dtsiPersonRoleMockResolver = (): Partial<DTSI_PersonRoleResolvers> 
         DTSI_PersonRoleCategory.PRESIDENT,
         DTSI_PersonRoleCategory.SENATE,
       ]),
+    ...overrides,
   }
 }

--- a/src/mocks/dtsi/queryDTSIMockSchema.ts
+++ b/src/mocks/dtsi/queryDTSIMockSchema.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker'
 import { addMocksToSchema } from '@graphql-tools/mock'
 import { buildClientSchema, graphql } from 'graphql'
 
+import { DTSI_PersonRoleCategory } from '@/data/dtsi/generated'
 import introspectionResult from '@/data/dtsi/introspection.json'
 import { dtsiBillMockResolver } from '@/mocks/dtsi/mockResolvers/dtsiBillMockResolver'
 import { dtsiPersonMockResolver } from '@/mocks/dtsi/mockResolvers/dtsiPersonMockResolver'
@@ -39,6 +40,18 @@ const schemaWithMocks = addMocksToSchema({
     Bill: dtsiBillMockResolver,
     Query: dtsiQueryResolver,
   },
+  resolvers: () => ({
+    Query: {
+      peopleByUSCongressionalDistrict: () => {
+        return Object.values(DTSI_PersonRoleCategory).map(category => ({
+          ...dtsiPersonMockResolver(),
+          primaryRole: dtsiPersonRoleMockResolver({
+            roleCategory: () => category,
+          }),
+        }))
+      },
+    },
+  }),
 })
 
 export const queryDTSIMockSchema = <R>(query: string, variables?: any) => {


### PR DESCRIPTION
**What changed? Why?**

Since we did a new mocking structure to dtsi running locally, some changes had to be made to cypress to adapt to it instead of the real api

**How has it been tested?**

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [x] Functional test

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
