### PR TITLE
[fix] fallback to matching DTSI to google civic API by just last name

### DIFF
--- a/src/utils/shared/googleCivicInfo.ts
+++ b/src/utils/shared/googleCivicInfo.ts
@@ -162,7 +162,7 @@ export function getGoogleCivicOfficialByDTSIName(
 
   // This is necessary since the Google Civic API return the middle initial (e.g. "John F. Kennedy")
   // While the DTSI data does not (e.g. "John Kennedy")
-  const matchOfficial = officials.find(official => {
+  let matchOfficial = officials.find(official => {
     const normalizedOfficialName = normalizeName(official.name)
     return (
       (normalizedOfficialName.startsWith(normalizedDTSIFirstName) ||
@@ -170,6 +170,13 @@ export function getGoogleCivicOfficialByDTSIName(
       normalizedOfficialName.includes(normalizedDTSILastName)
     )
   })
+
+  if (!matchOfficial) {
+    matchOfficial = officials.find(official => {
+      const normalizedOfficialName = normalizeName(official.name)
+      return normalizedOfficialName.includes(normalizedDTSILastName)
+    })
+  }
 
   if (!matchOfficial) {
     const extra = {


### PR DESCRIPTION
fixes PROD-SWC-WEB-K9

**What changed? Why?**
In [this issue](https://stand-with-crypto.sentry.io/issues/4947101303/?environment=production&project=4506490717470720&query=is%3Aunresolved+timesSeen%3A%3E%3D10&referrer=issue-stream&statsPeriod=30d&stream_index=0) the results return a rep whos firstname differs from DTSI (its an abbreviation) ![image](https://github.com/Stand-With-Crypto/swc-web/assets/153657370/30ecfca4-9323-48d4-83c0-e82b39cb8533)

This fallback logic ensures we match in this case.

**How has it been tested?**

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
