### PR TITLE
Trim char for Acquisition referer

### DIFF
--- a/src/bin/smokeTests/onNewLogin/9testCaseWithLongAcquisitionReferrer.ts
+++ b/src/bin/smokeTests/onNewLogin/9testCaseWithLongAcquisitionReferrer.ts
@@ -1,8 +1,32 @@
-import { getParametersWithLocalUser, TestCase, verify } from './utils'
+import { faker } from '@faker-js/faker'
+
+import { parseThirdwebAddress } from '@/hooks/useThirdwebAddress/parseThirdwebAddress'
+import { fakerFields } from '@/mocks/fakerUtils'
+
+import { TestCase, verify } from './utils'
 
 export const testCaseWithLongAcquisitionReferer: TestCase = {
   name: 'Test Case with long Acquisition referer',
-  parameters: async () => getParametersWithLocalUser({ initialRefererOption: { length: 192 } }),
+  parameters: async () => {
+    return {
+      cryptoAddress: parseThirdwebAddress(faker.finance.ethereumAddress()),
+      localUser: {
+        persisted: {
+          initialSearchParams: { utm_source: faker.string.alphanumeric({ length: 200 }) },
+          initialReferer: faker.string.alphanumeric({ length: 200 }),
+          datetimeFirstSeen: new Date().toISOString(),
+        },
+        currentSession: {
+          datetimeOnLoad: new Date().toISOString(),
+          refererOnLoad: '',
+          searchParamsOnLoad: { utm_source: faker.string.alphanumeric({ length: 200 }) },
+        },
+      },
+      getUserSessionId: () => fakerFields.id(),
+      // dependency injecting this in to the function so we can mock it in tests
+      injectedFetchEmbeddedWalletMetadataFromThirdweb: () => Promise.resolve(null),
+    }
+  },
   validateResults: (
     {
       existingUsersWithSource,

--- a/src/bin/smokeTests/onNewLogin/9testCaseWithLongAcquisitionReferrer.ts
+++ b/src/bin/smokeTests/onNewLogin/9testCaseWithLongAcquisitionReferrer.ts
@@ -1,0 +1,65 @@
+import { getParametersWithLocalUser, TestCase, verify } from './utils'
+
+export const testCaseWithLongAcquisitionReferer: TestCase = {
+  name: 'Test Case with long Acquisition referer',
+  parameters: async () => getParametersWithLocalUser({ initialRefererOption: { length: 192 } }),
+  validateResults: (
+    {
+      existingUsersWithSource,
+      embeddedWalletEmailAddress,
+      merge,
+      wasUserCreated,
+      maybeUpsertCryptoAddressResult,
+      maybeUpsertEmbeddedWalletEmailAddressResult,
+      didCapitalCanaryUpsert,
+      postLoginUserActionSteps,
+    },
+    issues,
+  ) => {
+    verify(existingUsersWithSource.length, false, 'existingUsersWithSource.length', issues)
+    verify(embeddedWalletEmailAddress, false, 'embeddedWalletEmailAddress', issues)
+    verify(merge?.usersToDelete.length, false, 'merge?.usersToDelete.length', issues)
+    verify(merge?.userToKeep, false, 'merge?.userToKeep', issues)
+    verify(wasUserCreated, true, 'wasUserCreated', issues)
+    verify(
+      maybeUpsertCryptoAddressResult.newCryptoAddress,
+      true,
+      'maybeUpsertCryptoAddressResult.newCryptoAddress',
+      issues,
+    )
+    verify(
+      maybeUpsertCryptoAddressResult.updatedCryptoAddress,
+      false,
+      'maybeUpsertCryptoAddressResult.updatedCryptoAddress',
+      issues,
+    )
+    verify(
+      maybeUpsertEmbeddedWalletEmailAddressResult?.wasCreated,
+      false,
+      'maybeUpsertEmbeddedWalletEmailAddressResult?.wasCreated',
+      issues,
+    )
+    verify(
+      maybeUpsertEmbeddedWalletEmailAddressResult?.updatedFields,
+      false,
+      'maybeUpsertEmbeddedWalletEmailAddressResult?.updatedFields',
+      issues,
+    )
+    verify(didCapitalCanaryUpsert, false, 'didCapitalCanaryUpsert', issues)
+    verify(
+      postLoginUserActionSteps.hadOptInUserAction,
+      false,
+      'postLoginUserActionSteps.hadOptInUserAction',
+      issues,
+    )
+    verify(
+      postLoginUserActionSteps.pastActionsMinted.length,
+      false,
+      'postLoginUserActionSteps.pastActionsMinted.length',
+      issues,
+    )
+    return {
+      issues,
+    }
+  },
+}

--- a/src/bin/smokeTests/onNewLogin/9testCaseWithLongAcquisitionReferrer.ts
+++ b/src/bin/smokeTests/onNewLogin/9testCaseWithLongAcquisitionReferrer.ts
@@ -12,14 +12,22 @@ export const testCaseWithLongAcquisitionReferer: TestCase = {
       cryptoAddress: parseThirdwebAddress(faker.finance.ethereumAddress()),
       localUser: {
         persisted: {
-          initialSearchParams: { utm_source: faker.string.alphanumeric({ length: 200 }) },
+          initialSearchParams: {
+            utm_source: faker.string.alphanumeric({ length: 200 }),
+            utm_medium: faker.string.alphanumeric({ length: 200 }),
+            utm_campaign: faker.string.alphanumeric({ length: 200 }),
+          },
           initialReferer: faker.string.alphanumeric({ length: 200 }),
           datetimeFirstSeen: new Date().toISOString(),
         },
         currentSession: {
           datetimeOnLoad: new Date().toISOString(),
           refererOnLoad: '',
-          searchParamsOnLoad: { utm_source: faker.string.alphanumeric({ length: 200 }) },
+          searchParamsOnLoad: {
+            utm_source: faker.string.alphanumeric({ length: 200 }),
+            utm_medium: faker.string.alphanumeric({ length: 200 }),
+            utm_campaign: faker.string.alphanumeric({ length: 200 }),
+          },
         },
       },
       getUserSessionId: () => fakerFields.id(),

--- a/src/bin/smokeTests/onNewLogin/index.ts
+++ b/src/bin/smokeTests/onNewLogin/index.ts
@@ -5,6 +5,7 @@ import { testCaseUserHasLegacyMigrationCryptoAndEmailAddressAndLogsOnViaSameCryp
 import { testCaseUserHasSameEmailAddressButOtherUserHasAlreadyCreatedAccount } from '@/bin/smokeTests/onNewLogin/6testCaseUserHasSameEmailAddressButOtherUserHasAlreadyCreatedAccount'
 import { testCaseMultipleUsersWithSameLegacyCryptoAddress } from '@/bin/smokeTests/onNewLogin/7testCaseMultipleUsersWithSameLegacyCryptoAddress'
 import { testCaseMultipleUsersWithSameLegacyEmail } from '@/bin/smokeTests/onNewLogin/8testCaseMultipleUsersWithSameLegacyEmail'
+import { testCaseWithLongAcquisitionReferer } from '@/bin/smokeTests/onNewLogin/9testCaseWithLongAcquisitionReferrer'
 import { onNewLogin } from '@/utils/server/thirdweb/onLogin'
 import { logger } from '@/utils/shared/logger'
 
@@ -34,6 +35,7 @@ async function smokeTestOnLogin() {
     testCaseUserHasSameEmailAddressButOtherUserHasAlreadyCreatedAccount,
     testCaseMultipleUsersWithSameLegacyCryptoAddress,
     testCaseMultipleUsersWithSameLegacyEmail,
+    testCaseWithLongAcquisitionReferer,
   ]
   for (const test of tests) {
     await runTestCase(test)

--- a/src/bin/smokeTests/onNewLogin/utils.ts
+++ b/src/bin/smokeTests/onNewLogin/utils.ts
@@ -16,6 +16,7 @@ export type TestCase = {
   parameters: () => Promise<Params>
   validateResults: (data: Awaited<ReturnType<typeof onNewLogin>>, issues: Issue[]) => void
 }
+
 export function getDefaultParameters(): Params {
   return {
     cryptoAddress: parseThirdwebAddress(faker.finance.ethereumAddress()),
@@ -25,6 +26,30 @@ export function getDefaultParameters(): Params {
     injectedFetchEmbeddedWalletMetadataFromThirdweb: () => Promise.resolve(null),
   }
 }
+
+export function getParametersWithLocalUser(option?: {
+  initialRefererOption?: { length: number }
+}): Params {
+  return {
+    cryptoAddress: parseThirdwebAddress(faker.finance.ethereumAddress()),
+    localUser: {
+      persisted: {
+        initialSearchParams: {},
+        initialReferer: faker.string.alphanumeric({ length: option?.initialRefererOption?.length }),
+        datetimeFirstSeen: new Date().toISOString(),
+      },
+      currentSession: {
+        datetimeOnLoad: new Date().toISOString(),
+        refererOnLoad: '',
+        searchParamsOnLoad: {},
+      },
+    },
+    getUserSessionId: () => fakerFields.id(),
+    // dependency injecting this in to the function so we can mock it in tests
+    injectedFetchEmbeddedWalletMetadataFromThirdweb: () => Promise.resolve(null),
+  }
+}
+
 export async function mockEmbeddedWalletMetadata(
   email: string,
 ): Promise<ThirdwebEmbeddedWalletMetadata> {
@@ -35,6 +60,7 @@ export async function mockEmbeddedWalletMetadata(
     createdAt: new Date().toISOString(),
   }
 }
+
 export function verify(
   condition: any | (() => any),
   expectedCondition: boolean,

--- a/src/bin/smokeTests/onNewLogin/utils.ts
+++ b/src/bin/smokeTests/onNewLogin/utils.ts
@@ -27,29 +27,6 @@ export function getDefaultParameters(): Params {
   }
 }
 
-export function getParametersWithLocalUser(option?: {
-  initialRefererOption?: { length: number }
-}): Params {
-  return {
-    cryptoAddress: parseThirdwebAddress(faker.finance.ethereumAddress()),
-    localUser: {
-      persisted: {
-        initialSearchParams: {},
-        initialReferer: faker.string.alphanumeric({ length: option?.initialRefererOption?.length }),
-        datetimeFirstSeen: new Date().toISOString(),
-      },
-      currentSession: {
-        datetimeOnLoad: new Date().toISOString(),
-        refererOnLoad: '',
-        searchParamsOnLoad: {},
-      },
-    },
-    getUserSessionId: () => fakerFields.id(),
-    // dependency injecting this in to the function so we can mock it in tests
-    injectedFetchEmbeddedWalletMetadataFromThirdweb: () => Promise.resolve(null),
-  }
-}
-
 export async function mockEmbeddedWalletMetadata(
   email: string,
 ): Promise<ThirdwebEmbeddedWalletMetadata> {

--- a/src/utils/server/serverLocalUser.ts
+++ b/src/utils/server/serverLocalUser.ts
@@ -57,7 +57,7 @@ export function mapLocalUserToUserDatabaseFields(
   'acquisitionReferer' | 'acquisitionSource' | 'acquisitionMedium' | 'acquisitionCampaign'
 > {
   return {
-    acquisitionReferer: localUser?.persisted?.initialReferer || '',
+    acquisitionReferer: localUser?.persisted?.initialReferer?.slice(0, 191) || '',
     acquisitionSource:
       localUser?.persisted?.initialSearchParams.utm_source ||
       localUser?.currentSession.searchParamsOnLoad.utm_source ||

--- a/src/utils/server/serverLocalUser.ts
+++ b/src/utils/server/serverLocalUser.ts
@@ -57,6 +57,7 @@ export function mapLocalUserToUserDatabaseFields(
   'acquisitionReferer' | 'acquisitionSource' | 'acquisitionMedium' | 'acquisitionCampaign'
 > {
   return {
+    // We are trimming the char input in case it is greater that the DB limit (191 characters)
     acquisitionReferer: localUser?.persisted?.initialReferer?.slice(0, 191) || '',
     acquisitionSource:
       localUser?.persisted?.initialSearchParams.utm_source?.slice(0, 191) ||

--- a/src/utils/server/serverLocalUser.ts
+++ b/src/utils/server/serverLocalUser.ts
@@ -63,12 +63,12 @@ export function mapLocalUserToUserDatabaseFields(
       localUser?.currentSession.searchParamsOnLoad.utm_source?.slice(0, 191) ||
       '',
     acquisitionMedium:
-      localUser?.persisted?.initialSearchParams.utm_medium ||
-      localUser?.currentSession.searchParamsOnLoad.utm_medium ||
+      localUser?.persisted?.initialSearchParams.utm_medium?.slice(0, 191) ||
+      localUser?.currentSession.searchParamsOnLoad.utm_medium?.slice(0, 191) ||
       '',
     acquisitionCampaign:
-      localUser?.persisted?.initialSearchParams.utm_campaign ||
-      localUser?.currentSession.searchParamsOnLoad.utm_campaign ||
+      localUser?.persisted?.initialSearchParams.utm_campaign?.slice(0, 191) ||
+      localUser?.currentSession.searchParamsOnLoad.utm_campaign?.slice(0, 191) ||
       '',
   }
 }

--- a/src/utils/server/serverLocalUser.ts
+++ b/src/utils/server/serverLocalUser.ts
@@ -57,7 +57,7 @@ export function mapLocalUserToUserDatabaseFields(
   'acquisitionReferer' | 'acquisitionSource' | 'acquisitionMedium' | 'acquisitionCampaign'
 > {
   return {
-    // We are trimming the char input in case it is greater that the DB limit (191 characters)
+    // We are trimming the char input in case it is greater than the DB limit (191 characters)
     acquisitionReferer: localUser?.persisted?.initialReferer?.slice(0, 191) || '',
     acquisitionSource:
       localUser?.persisted?.initialSearchParams.utm_source?.slice(0, 191) ||

--- a/src/utils/server/serverLocalUser.ts
+++ b/src/utils/server/serverLocalUser.ts
@@ -59,8 +59,8 @@ export function mapLocalUserToUserDatabaseFields(
   return {
     acquisitionReferer: localUser?.persisted?.initialReferer?.slice(0, 191) || '',
     acquisitionSource:
-      localUser?.persisted?.initialSearchParams.utm_source ||
-      localUser?.currentSession.searchParamsOnLoad.utm_source ||
+      localUser?.persisted?.initialSearchParams.utm_source?.slice(0, 191) ||
+      localUser?.currentSession.searchParamsOnLoad.utm_source?.slice(0, 191) ||
       '',
     acquisitionMedium:
       localUser?.persisted?.initialSearchParams.utm_medium ||


### PR DESCRIPTION
closes https://github.com/Stand-With-Crypto/swc-web/issues/676
fixes https://stand-with-crypto.sentry.io/issues/5067506303/?referrer=github_integration

**What changed? Why?**
Trim the acquisition referer when greater than 191 characters. 

**Notes to reviewers**

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

**How has it been tested?**

- [x] Locally
- [x] Vercel Preview Branch
- [x] Unit test

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
