### PR TITLE
Handle undefined result from action

### DIFF
--- a/src/components/app/pageDonate/donateButton.tsx
+++ b/src/components/app/pageDonate/donateButton.tsx
@@ -20,9 +20,11 @@ export function DonateButton() {
       },
       () =>
         actionCreateCoinbaseCommerceCharge().then(res => {
-          const windowReference = openWindow(res.hostedUrl, '_blank', '')
-          if (!windowReference) {
-            openWindow(res.hostedUrl, '_self')
+          if (res) {
+            const windowReference = openWindow(res.hostedUrl, '_blank', '')
+            if (!windowReference) {
+              openWindow(res.hostedUrl, '_self')
+            }
           }
           return res
         }),

--- a/src/components/app/pageUserProfile/mergeAlertCTA.tsx
+++ b/src/components/app/pageUserProfile/mergeAlertCTA.tsx
@@ -48,8 +48,8 @@ export function MergeAlertCTA({
       userMergeAlertId: mergeAlert.id,
       userToDeleteId,
     })
-      .then(({ status }) => {
-        if (status === 'complete') {
+      .then(result => {
+        if (result?.status === 'complete') {
           toast.success('Your accounts have been successfully merged!')
           router.refresh()
         } else {

--- a/src/components/app/userActionFormCallCongressperson/sections/suggestedScript.tsx
+++ b/src/components/app/userActionFormCallCongressperson/sections/suggestedScript.tsx
@@ -76,7 +76,7 @@ export function SuggestedScript({
         },
         payload =>
           actionCreateUserActionCallCongressperson(payload).then(actionResult => {
-            if (actionResult.user) {
+            if (actionResult?.user) {
               identifyUserOnClient(actionResult.user)
             }
             return actionResult
@@ -89,6 +89,7 @@ export function SuggestedScript({
         goToSection(SectionNames.SUCCESS_MESSAGE)
       } else {
         setCallingState('error')
+        toastGenericError()
       }
     },
     [addressSchema, dtsiPerson.slug, goToSection, router],

--- a/src/components/app/userActionFormEmailCongressperson/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/index.tsx
@@ -42,7 +42,10 @@ import {
 } from '@/utils/web/formUtils'
 import { convertGooglePlaceAutoPredictionToAddressSchema } from '@/utils/web/googlePlaceUtils'
 import { identifyUserOnClient } from '@/utils/web/identifyUser'
-import { catchUnexpectedServerErrorAndTriggerToast } from '@/utils/web/toastUtils'
+import {
+  catchUnexpectedServerErrorAndTriggerToast,
+  toastGenericError,
+} from '@/utils/web/toastUtils'
 import { zodUserActionFormEmailCongresspersonFields } from '@/validation/forms/zodUserActionFormEmailCongressperson'
 
 type FormValues = z.infer<typeof zodUserActionFormEmailCongresspersonFields> &
@@ -139,7 +142,7 @@ export function UserActionFormEmailCongressperson({
             },
             payload =>
               actionCreateUserActionEmailCongressperson(payload).then(actionResult => {
-                if (actionResult.user) {
+                if (actionResult?.user) {
                   identifyUserOnClient(actionResult.user)
                 }
                 return actionResult
@@ -148,6 +151,8 @@ export function UserActionFormEmailCongressperson({
           if (result.status === 'success') {
             router.refresh()
             onSuccess()
+          } else {
+            toastGenericError()
           }
         }, trackFormSubmissionSyncErrors(ANALYTICS_NAME_USER_ACTION_FORM_EMAIL_CONGRESSPERSON))}
       >

--- a/src/components/app/userActionFormLiveEvent/claimNft.tsx
+++ b/src/components/app/userActionFormLiveEvent/claimNft.tsx
@@ -20,6 +20,7 @@ import { UserActionLiveEventCampaignName } from '@/utils/shared/userActionCampai
 import { triggerServerActionForForm } from '@/utils/web/formUtils'
 import { identifyUserOnClient } from '@/utils/web/identifyUser'
 import { NFT_CLIENT_METADATA } from '@/utils/web/nft'
+import { toastGenericError } from '@/utils/web/toastUtils'
 
 interface Props extends UseSectionsReturn<SectionNames> {
   isLoggedIn: boolean
@@ -53,7 +54,7 @@ export function ClaimNft({ isLoggedIn, slug, goToSection }: Props) {
       },
       payload =>
         actionCreateUserActionLiveEvent(payload).then(actionResult => {
-          if (actionResult.user) {
+          if (actionResult?.user) {
             identifyUserOnClient(actionResult.user)
           }
           return actionResult
@@ -63,6 +64,8 @@ export function ClaimNft({ isLoggedIn, slug, goToSection }: Props) {
     if (result.status === 'success') {
       router.refresh()
       goToSection(SectionNames.SUCCESS)
+    } else {
+      toastGenericError()
     }
     setLoading(false)
   }, [goToSection, router, slug])

--- a/src/components/app/userActionFormNFTMint/sections/transactionWatch.tsx
+++ b/src/components/app/userActionFormNFTMint/sections/transactionWatch.tsx
@@ -68,7 +68,7 @@ export function UserActionFormNFTMintTransactionWatch({
       },
       payload =>
         actionCreateUserActionMintNFT(payload).then(actionResult => {
-          if (actionResult.user) {
+          if (actionResult?.user) {
             identifyUserOnClient(actionResult.user)
           }
           return actionResult

--- a/src/components/app/userActionFormVoterRegistration/sections/claimNft.tsx
+++ b/src/components/app/userActionFormVoterRegistration/sections/claimNft.tsx
@@ -55,7 +55,7 @@ export function ClaimNft({ goToSection, stateCode }: ClaimNftProps) {
       },
       payload =>
         actionCreateUserActionVoterRegistration(payload).then(actionResult => {
-          if (actionResult.user) {
+          if (actionResult?.user) {
             identifyUserOnClient(actionResult.user)
           }
           return actionResult
@@ -65,6 +65,8 @@ export function ClaimNft({ goToSection, stateCode }: ClaimNftProps) {
     if (result.status === 'success') {
       router.refresh()
       goToSection(SectionNames.SUCCESS)
+    } else {
+      toastGenericError()
     }
     setLoading(false)
   }, [goToSection, router, stateCode])

--- a/src/utils/server/withServerActionMiddleware.ts
+++ b/src/utils/server/withServerActionMiddleware.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/nextjs'
 import { headers } from 'next/headers'
+
 import { getLogger } from '@/utils/shared/logger'
 
 // sentry only allows form data to be passed but we want to support json objects as well so we need to make it form data

--- a/src/utils/web/formUtils.ts
+++ b/src/utils/web/formUtils.ts
@@ -23,7 +23,7 @@ export type FormValues<T extends z.ZodType<any, any, any>> = z.infer<T> & Generi
 export async function triggerServerActionForForm<
   F extends UseFormReturn<any, any, any>,
   P,
-  Fn extends (args: P) => Promise<{ errors: Record<string, string[]> } | object>,
+  Fn extends (args: P) => Promise<{ errors: Record<string, string[]> } | object | undefined>,
 >(
   {
     form,


### PR DESCRIPTION
closes https://github.com/Stand-With-Crypto/swc-web/issues/670
fixes [PROD-SWC-WEB-18Q](https://stand-with-crypto.sentry.io/issues/5029315222/?referrer=github_integration)

**What changed? Why?**
I added a check of the result of an action in withServerActionMiddleware function and throw an error if the result is undefined. This is to avoid reading a field of an undefined result on the client side.

**Notes to reviewers**
I don't think I fully understand the promises in javascript. So I an not fully confident of my solution here. 
I was able to test it on local, but not sure how I can test this on Preview

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

**How has it been tested?**

- [x] Locally
- [ ] Vercel Preview Branch


**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
