### PR TITLE
475 update default ordering for table when filters are selected

### DIFF
--- a/src/components/app/dtsiClientPersonDataTable/sortPeople.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/sortPeople.tsx
@@ -13,14 +13,17 @@ export function sortDTSIPersonDataTable(data: DTSIPersonDataTablePeople) {
         : 1
     }
     if (personB.promotedPositioning) {
-      return 1
+      return -1
     }
 
     // At this point you already verified that neither personA or personB have `promotedPositioning`
     const aScore = personA.manuallyOverriddenStanceScore || personA.computedStanceScore
     const bScore = personB.manuallyOverriddenStanceScore || personB.computedStanceScore
     if (aScore === bScore || (isNil(aScore) && isNil(bScore))) {
-      return 0
+      if (personA.lastName < personB.lastName) {
+        return -1
+      }
+      return 1
     }
     if (isNil(aScore)) {
       return 1

--- a/src/components/app/dtsiClientPersonDataTable/sortPeople.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/sortPeople.tsx
@@ -20,10 +20,7 @@ export function sortDTSIPersonDataTable(data: DTSIPersonDataTablePeople) {
     const aScore = personA.manuallyOverriddenStanceScore || personA.computedStanceScore
     const bScore = personB.manuallyOverriddenStanceScore || personB.computedStanceScore
     if (aScore === bScore || (isNil(aScore) && isNil(bScore))) {
-      if (personA.lastName < personB.lastName) {
-        return -1
-      }
-      return 1
+      return personA.lastName < personB.lastName ? -1 : 1
     }
     if (isNil(aScore)) {
       return 1


### PR DESCRIPTION
closes https://github.com/Stand-With-Crypto/swc-web/issues/475

**What changed? Why?**
Updated the sorting function to sort by last name 
**UI changes**

_Web_
None

_Mobile Web_
None

**PlanetScale Deploy Request**

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

**Notes to reviewers**

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

**How has it been tested?**

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
