### PR TITLE
[feature] reduce gas limit for transaction fee estimation in NFT backfill cron job

### DIFF
--- a/src/utils/server/thirdweb/fetchCurrentClaimTransactionFee.ts
+++ b/src/utils/server/thirdweb/fetchCurrentClaimTransactionFee.ts
@@ -19,7 +19,7 @@ declare module globalThis {
 // This is our SWC testing NFT contract address, but because its claim conditions are public, we can use this contract address to check the current transaction fees of the Base network.
 const AIRDROP_FEE_ESTIMATION_CONTRACT_ADDRESS = '0xd9C77be238F858b3d08eF87202c624D520663920'
 
-const CLAIM_GAS_LIMIT_OE721_CONTRACT = 231086
+const AIRDROP_GAS_LIMIT_OE721_CONTRACT = 190000 // This is based on the used gas limit of existing transactions from our airdropping wallets.
 
 export async function fetchAirdropTransactionFee(): Promise<number> {
   globalThis.TW_SKIP_FETCH_SETUP = true
@@ -28,7 +28,7 @@ export async function fetchAirdropTransactionFee(): Promise<number> {
   })
   const contract = await sdk.getContract(AIRDROP_FEE_ESTIMATION_CONTRACT_ADDRESS)
   const transaction = await contract.erc721.claim.prepare(1)
-  transaction.updateOverrides({ gasLimit: CLAIM_GAS_LIMIT_OE721_CONTRACT })
+  transaction.updateOverrides({ gasLimit: AIRDROP_GAS_LIMIT_OE721_CONTRACT })
   const gasCost = await transaction.estimateGasCost()
   return Number(gasCost.ether)
 }


### PR DESCRIPTION
Relates to #600 

**What changed? Why?**

This is a small PR that reduces the gas limit override for transaction fee estimations. Why? Because looking at the used gas limit for the past transactions, they are lower than the current override.

**UI changes**

No UI changes.

**PlanetScale Deploy Request**

No PlanetScale schema changes.

**Notes to reviewers**

N/A

**How has it been tested?**

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
