### PR TITLE
[bug] remove storing gas price in MySQL database for NFT airdrops 

### DIFF
--- a/src/utils/server/nft/updateMintNFTStatus.ts
+++ b/src/utils/server/nft/updateMintNFTStatus.ts
@@ -1,12 +1,7 @@
-import { NFTCurrency, NFTMintStatus } from '@prisma/client'
-import { Decimal } from '@prisma/client/runtime/library'
+import { NFTMintStatus } from '@prisma/client'
 
 import { prismaClient } from '@/utils/server/prismaClient'
 import { ThirdwebTransactionStatus } from '@/utils/server/thirdweb/engineGetMintStatus'
-import { getCryptoToFiatConversion } from '@/utils/shared/getCryptoToFiatConversion'
-import { getLogger } from '@/utils/shared/logger'
-
-const logger = getLogger('updateMintNFTStatus')
 
 export const THIRDWEB_TRANSACTION_STATUS_TO_NFT_MINT_STATUS: Record<
   ThirdwebTransactionStatus,
@@ -24,27 +19,7 @@ export async function updateMintNFTStatus(
   mintNftId: string,
   nftMintStatus: NFTMintStatus,
   transactionHash: string | null,
-  gasPrice: string | null,
 ) {
-  logger.info('Triggered')
-
-  logger.info(gasPrice)
-  const costAtMint = gasPrice ? new Decimal(+gasPrice * 1e-9) : new Decimal(0.0)
-  let costAtMintUsd = new Decimal(0)
-  let ratio = new Decimal(0)
-  if (costAtMint.greaterThan(0.0)) {
-    ratio = await getCryptoToFiatConversion(NFTCurrency.ETH)
-      .then(res => {
-        return res?.data.amount ? res?.data.amount : new Decimal(0)
-      })
-      .catch(e => {
-        logger.error(e)
-        return new Decimal(0)
-      })
-
-    costAtMintUsd = costAtMint.mul(ratio)
-  }
-
   return prismaClient.nFTMint.update({
     where: {
       id: mintNftId,
@@ -52,8 +27,8 @@ export async function updateMintNFTStatus(
     data: {
       status: nftMintStatus,
       transactionHash: transactionHash,
-      costAtMint: costAtMint,
-      costAtMintUsd: costAtMintUsd,
+      costAtMint: 0,
+      costAtMintUsd: 0,
     },
   })
 }


### PR DESCRIPTION
**What changed? Why?**

This PR removes storing the transaction's gas price in our MySQL database for NFT airdrops. Why? Because the `cost_at_mint` column should record the cost when a user spends their own funds to mint an NFT (at the moment, that is only the supporter NFT) - airdrops do not involve user funds, so technically the cost at mint is 0.
 
**UI changes**

No UI changes.

**PlanetScale Deploy Request**

No PlanetScale schema changes.

**Notes to reviewers**

We need to write a script to set the `cost_at_mint` and `cost_at_mint_usd` fields to be 0 for `nft_mint` rows where `nft_slug NOT IN ('stand-with-crypto', 'stand-with-crypto-supporter')`

**How has it been tested?**

![image](https://github.com/Stand-With-Crypto/swc-web/assets/135282747/8675e965-d3cf-45e2-88a0-3892de525a7c)

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
