### PR TITLE
[feature] reenable conditional live airdrop and return proper response for NFT backfill cron job

### DIFF
--- a/src/app/api/internal/commerce-webhook/route.ts
+++ b/src/app/api/internal/commerce-webhook/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: NextRequest) {
     const pricingValues = extractPricingValues(body)
 
     // Tracking the payment event regardless of type - the donation action is not created here.
-    analytics.track('Coinbase Commerce webhook event received', {
+    analytics.track('Coinbase Commerce Webhook Event Received', {
       creationMethod: 'On Site',
       paymentExpire: body.event.data.expires_at,
       paymentId: body.id,

--- a/src/app/api/internal/commerce-webhook/route.ts
+++ b/src/app/api/internal/commerce-webhook/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: NextRequest) {
     const pricingValues = extractPricingValues(body)
 
     // Tracking the payment event regardless of type - the donation action is not created here.
-    analytics.track('Coinbase Commerce Webhook Event Received', {
+    analytics.track('Coinbase Commerce webhook event received', {
       creationMethod: 'On Site',
       paymentExpire: body.event.data.expires_at,
       paymentId: body.id,

--- a/src/bin/smokeTests/nft/airdropNFT.ts
+++ b/src/bin/smokeTests/nft/airdropNFT.ts
@@ -51,6 +51,7 @@ async function smokeTestAirdropNFTWithInngest() {
     nftMintId: action.nftMintId!,
     nftSlug: NFTSlug.SWC_SHIELD,
     recipientWalletAddress: LOCAL_USER_CRYPTO_ADDRESS,
+    userId: user.id,
   }
 
   await inngest.send({

--- a/src/inngest/functions/airdropNFT.ts
+++ b/src/inngest/functions/airdropNFT.ts
@@ -28,6 +28,8 @@ const AIRDROP_NFT_RETRY = 2
 
 const logger = getLogger('airdropNFTWithInngest')
 
+const WEI_TO_ETH_UNIT = 1e-18
+
 export const airdropNFTWithInngest = inngest.createFunction(
   {
     id: AIRDROP_NFT_INNGEST_FUNCTION_ID,
@@ -61,7 +63,7 @@ export const airdropNFTWithInngest = inngest.createFunction(
       mintStatus = transactionStatus.status
       transactionHash = transactionStatus.transactionHash
       transactionFee = new Decimal(
-        Number(transactionStatus.gasLimit) * Number(transactionStatus.gasPrice),
+        Number(transactionStatus.gasLimit) * +Number(transactionStatus.gasPrice) * WEI_TO_ETH_UNIT, // Gas price is in wei, so we need to convert it to ETH.
       )
       attempt += 1
     }

--- a/src/inngest/functions/backfillNFT/logic.ts
+++ b/src/inngest/functions/backfillNFT/logic.ts
@@ -52,7 +52,7 @@ export async function backfillNFT(parameters: z.infer<typeof zodBackfillNFParame
   await batchAsyncAndLog(userActions, actions =>
     Promise.all(
       actions.map(action =>
-        claimNFT(action, action.user.primaryUserCryptoAddress!, { ignoreTurnOffNFTMintFlag: true }),
+        claimNFT(action, action.user.primaryUserCryptoAddress!, { skipTransactionFeeCheck: true }),
       ),
     ),
   )

--- a/src/inngest/functions/backfillNFTCronJob/index.ts
+++ b/src/inngest/functions/backfillNFTCronJob/index.ts
@@ -157,21 +157,14 @@ export const backfillNFTInngestCronJob = inngest.createFunction(
 
     // Fetch the remaining user actions that are in the backlog.
     const userActionsRemaining = await step.run('script.get-user-actions-remaining', async () => {
-      const actions = await prismaClient.userAction.findMany({
+      return await prismaClient.userAction.count({
         where: {
           datetimeCreated: { gte: GO_LIVE_DATE },
           nftMint: null,
           actionType: { in: actionsWithNFT },
           user: { primaryUserCryptoAddress: { isNot: null } },
         },
-        include: {
-          user: {
-            include: { primaryUserCryptoAddress: true },
-          },
-        },
       })
-
-      return actions.length
     })
 
     return {

--- a/src/inngest/functions/backfillNFTCronJob/index.ts
+++ b/src/inngest/functions/backfillNFTCronJob/index.ts
@@ -77,6 +77,7 @@ export const backfillNFTInngestCronJob = inngest.createFunction(
             include: { primaryUserCryptoAddress: true },
           },
         },
+        orderBy: { datetimeCreated: 'asc' }, // Fetch the oldest user actions first.
       })
       logger.info(`Fetched ${userActions.length} user actions to backfill`)
       return chunk(userActions, BACKFILL_NFT_INNGEST_CRON_JOB_AIRDROP_BATCH_SIZE)

--- a/src/inngest/functions/backfillNFTCronJob/index.ts
+++ b/src/inngest/functions/backfillNFTCronJob/index.ts
@@ -8,6 +8,7 @@ import { claimNFT } from '@/utils/server/nft/claimNFT'
 import { LEGACY_NFT_DEPLOYER_WALLET, SWC_DOT_ETH_WALLET } from '@/utils/server/nft/constants'
 import { prismaClient } from '@/utils/server/prismaClient'
 import { fetchAirdropTransactionFee } from '@/utils/server/thirdweb/fetchCurrentClaimTransactionFee'
+import { AIRDROP_NFT_ETH_TRANSACTION_FEE_THRESHOLD } from '@/utils/shared/airdropNFTETHTransactionFeeThreshold'
 import { getLogger } from '@/utils/shared/logger'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
 
@@ -20,10 +21,6 @@ const BACKFILL_NFT_INNGEST_CRON_JOB_AIRDROP_SLEEP_INTERVAL =
 // This is the number of user actions to process in a single batch.
 const BACKFILL_NFT_INNGEST_CRON_JOB_AIRDROP_BATCH_SIZE =
   Number(process.env.BACKFILL_NFT_INNGEST_CRON_JOB_AIRDROP_BATCH_SIZE) || 20
-
-// This is the ETH threshold in which we will stop the cron job if the current transaction fee exceeds the threshold.
-const AIRDROP_NFT_ETH_TRANSACTION_FEE_THRESHOLD =
-  Number(process.env.AIRDROP_NFT_ETH_TRANSACTION_FEE_THRESHOLD) || 0.00006
 
 // This is the date when SWC went live. We do not care about user actions before this date.
 const GO_LIVE_DATE = new Date('2024-02-25 00:00:00.000')
@@ -63,6 +60,7 @@ export const backfillNFTInngestCronJob = inngest.createFunction(
         BACKFILL_NFT_INNGEST_CRON_JOB_AIRDROP_SLEEP_INTERVAL) *
       BACKFILL_NFT_INNGEST_CRON_JOB_AIRDROP_BATCH_SIZE
     let batchNum = 1
+    let stopMessage = ''
 
     // Fetch the user action batches that need to be backfilled.
     const userActionBatches = await step.run('script.get-user-actions', async () => {
@@ -88,13 +86,15 @@ export const backfillNFTInngestCronJob = inngest.createFunction(
     for (const userActionBatch of userActionBatches) {
       // If there are no more user actions to backfill, stop the cron job.
       if (userActionBatch.length === 0) {
-        logger.info(`No more user actions to backfill - stopping the cron job`)
+        stopMessage = 'No more user actions to backfill'
+        logger.info(`${stopMessage} - stopping the cron job`)
         break
       }
 
       // Check if the current timestamp has passed the timeframe.
       if (new Date().getTime() > currentTime + BACKFILL_NFT_INNGEST_CRON_JOB_AIRDROP_TIMEFRAME) {
-        logger.info(`Current timestamp has passed the timeframe - stopping the cron job`)
+        stopMessage = 'Current timestamp has passed the timeframe'
+        logger.info(`${stopMessage} - stopping the cron job`)
         break
       }
 
@@ -113,11 +113,10 @@ export const backfillNFTInngestCronJob = inngest.createFunction(
         },
       )
       if (walletsWithLowBalances && walletsWithLowBalances.length > 0) {
-        logger.warn(
-          `Low Base ETH balance detected for ${walletsWithLowBalances
-            .map(wallet => wallet.account)
-            .join(', ')} - please fund as soon as possible - stopping the cron job`,
-        )
+        stopMessage = `Critically low Base ETH balance detected for ${walletsWithLowBalances
+          .map(wallet => wallet.account)
+          .join(', ')}`
+        logger.warn(`${stopMessage} - please fund as soon as possible - stopping the cron job`)
         break
       }
 
@@ -131,9 +130,8 @@ export const backfillNFTInngestCronJob = inngest.createFunction(
         },
       )
       if (currentAirdropTransactionFee > AIRDROP_NFT_ETH_TRANSACTION_FEE_THRESHOLD) {
-        logger.info(
-          `Current airdrop transaction fee (${currentAirdropTransactionFee}) exceeds the threshold (${AIRDROP_NFT_ETH_TRANSACTION_FEE_THRESHOLD}) - stopping the cron job`,
-        )
+        stopMessage = `Current airdrop transaction fee (${currentAirdropTransactionFee}) exceeds the threshold (${AIRDROP_NFT_ETH_TRANSACTION_FEE_THRESHOLD})`
+        logger.info(`${stopMessage} - stopping the cron job`)
         break
       }
 
@@ -142,7 +140,7 @@ export const backfillNFTInngestCronJob = inngest.createFunction(
         await Promise.all(
           userActionBatch.map(userAction =>
             claimNFT(userAction, userAction.user.primaryUserCryptoAddress!, {
-              ignoreTurnOffNFTMintFlag: true,
+              skipTransactionFeeCheck: true,
             }),
           ),
         )
@@ -154,6 +152,30 @@ export const backfillNFTInngestCronJob = inngest.createFunction(
         `script.sleep-${batchNum}`,
         BACKFILL_NFT_INNGEST_CRON_JOB_AIRDROP_SLEEP_INTERVAL,
       )
+    }
+
+    // Fetch the remaining user actions that are in the backlog.
+    const userActionsRemaining = await step.run('script.get-user-actions-remaining', async () => {
+      const actions = await prismaClient.userAction.findMany({
+        where: {
+          datetimeCreated: { gte: GO_LIVE_DATE },
+          nftMint: null,
+          actionType: { in: actionsWithNFT },
+          user: { primaryUserCryptoAddress: { isNot: null } },
+        },
+        include: {
+          user: {
+            include: { primaryUserCryptoAddress: true },
+          },
+        },
+      })
+
+      return actions.length
+    })
+
+    return {
+      stopMessage,
+      userActionsRemaining: userActionsRemaining,
     }
   },
 )

--- a/src/utils/server/nft/claimNFT.ts
+++ b/src/utils/server/nft/claimNFT.ts
@@ -115,8 +115,9 @@ export async function claimNFT(
 
   const payload: AirdropPayload = {
     nftMintId: action.nftMintId!,
-    recipientWalletAddress: userCryptoAddress.cryptoAddress,
     nftSlug,
+    recipientWalletAddress: userCryptoAddress.cryptoAddress,
+    userId: action.userId,
   }
 
   return inngest.send({

--- a/src/utils/server/nft/payload.ts
+++ b/src/utils/server/nft/payload.ts
@@ -4,4 +4,5 @@ export interface AirdropPayload {
   nftMintId: string
   nftSlug: NFTSlug
   recipientWalletAddress: string
+  userId: string
 }

--- a/src/utils/shared/airdropNFTETHTransactionFeeThreshold.ts
+++ b/src/utils/shared/airdropNFTETHTransactionFeeThreshold.ts
@@ -1,0 +1,3 @@
+// This is the ETH threshold in which we will stop the cron job if the current transaction fee exceeds the threshold.
+export const AIRDROP_NFT_ETH_TRANSACTION_FEE_THRESHOLD =
+  Number(process.env.AIRDROP_NFT_ETH_TRANSACTION_FEE_THRESHOLD) || 0.00001

--- a/src/utils/shared/airdropNFTETHTransactionFeeThreshold.ts
+++ b/src/utils/shared/airdropNFTETHTransactionFeeThreshold.ts
@@ -1,3 +1,3 @@
-// This is the ETH threshold in which we will stop the cron job if the current transaction fee exceeds the threshold.
+// This is the ETH threshold in which prevent an airdrop if the current transaction fee exceeds the threshold.
 export const AIRDROP_NFT_ETH_TRANSACTION_FEE_THRESHOLD =
   Number(process.env.AIRDROP_NFT_ETH_TRANSACTION_FEE_THRESHOLD) || 0.00001


### PR DESCRIPTION
Closes #600 
Closes #704 

**What changed? Why?**

This PR reenables the conditional live airdrop (where the condition is that the current estimated transaction fee is under a defined threshold). Why? Because ideally we want the user to receive their NFT as soon as possible, but we also do not want to spend too much ETH on airdrop transaction fees. Thus, we perform the live airdrop if transaction fees are low - otherwise, we will skip the live airdrop and let the NFT backfill cron job airdrop the NFT at a later point.

This PR also returns a proper response from the NFT backfill cron job that includes the stop reason and the remaining number of NFT user actions in the backfill backlog. Why? So we can easily audit the result of any run and to see the trend of backlogged user actions.

**UI changes**

No UI changes.

**PlanetScale Deploy Request**

No PlanetScale schema changes.

**Notes to reviewers**

- `ignoreTurnOffNFTMintFlag` has been renamed to `skipTransactionFeeCheck`
- The `AIRDROP_NFT_ETH_TRANSACTION_FEE_THRESHOLD` constant has been moved to a shared folder
- A Mixpanel analytic event is sent when a NFT has been successfully airdropped - the event includes the NFT slug and the transaction fee in USD
- Changed another analytic event name to match conventions

**How has it been tested?**

- [X] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

![image](https://github.com/Stand-With-Crypto/swc-web/assets/135282747/a7b31347-3320-43b7-9b0b-6e81010d666b)

<img width="1473" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/135282747/8da84c17-b62d-4b00-9640-1ca3f3716ce3">

**Change management**
type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
