### PR TITLE
[feature] add alert when there is an old (eligible) user action that is still missing their NFT

### DIFF
--- a/src/inngest/functions/backfillNFTCronJob/index.ts
+++ b/src/inngest/functions/backfillNFTCronJob/index.ts
@@ -196,6 +196,7 @@ export const backfillNFTInngestCronJob = inngest.createFunction(
           {
             level: 'error',
             extra: {
+              currentAirdropTransactionFee: await fetchAirdropTransactionFee(),
               missingNFTDaysAlertThreshold: MISSING_NFT_DAYS_ALERT_THRESHOLD,
               userActionDatetimeCreated: userAction.datetimeCreated,
               userActionId: userAction.id,

--- a/src/inngest/functions/backfillNFTCronJob/index.ts
+++ b/src/inngest/functions/backfillNFTCronJob/index.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs'
 import { chunk } from 'lodash-es'
 
 import { inngest } from '@/inngest/inngest'
@@ -21,6 +22,9 @@ const BACKFILL_NFT_INNGEST_CRON_JOB_AIRDROP_SLEEP_INTERVAL =
 // This is the number of user actions to process in a single batch.
 const BACKFILL_NFT_INNGEST_CRON_JOB_AIRDROP_BATCH_SIZE =
   Number(process.env.BACKFILL_NFT_INNGEST_CRON_JOB_AIRDROP_BATCH_SIZE) || 20
+
+// This is the threshold to trigger an alert if there are user actions missing NFTs in which the action's created time is greater than the threshold.
+const MISSING_NFT_DAYS_ALERT_THRESHOLD = 3 * 24 * 60 * 60 * 1000 // 3 days.
 
 // This is the date when SWC went live. We do not care about user actions before this date.
 const GO_LIVE_DATE = new Date('2024-02-25 00:00:00.000')
@@ -165,6 +169,40 @@ export const backfillNFTInngestCronJob = inngest.createFunction(
           user: { primaryUserCryptoAddress: { isNot: null } },
         },
       })
+    })
+
+    // Trigger alert if we have user actions missing NFTs whose creation time is greater than `MISSING_NFT_DAYS_ALERT_THRESHOLD`.
+    await step.run('script.trigger-alert', async () => {
+      const userAction = await prismaClient.userAction.findFirst({
+        where: {
+          datetimeCreated: { gte: GO_LIVE_DATE },
+          nftMint: null,
+          actionType: { in: actionsWithNFT },
+          user: { primaryUserCryptoAddress: { isNot: null } },
+        },
+        orderBy: { datetimeCreated: 'asc' }, // Fetch the oldest user action.
+      })
+      if (!userAction) {
+        return
+      }
+
+      if (
+        currentTime - new Date(userAction.datetimeCreated).getTime() >
+        MISSING_NFT_DAYS_ALERT_THRESHOLD
+      ) {
+        // Trigger Sentry alert.
+        Sentry.captureMessage(
+          `Detected old user action that is missing NFT. Please check for Base network congestion and incidents, and adjust variables if needed.`,
+          {
+            level: 'error',
+            extra: {
+              missingNFTDaysAlertThreshold: MISSING_NFT_DAYS_ALERT_THRESHOLD,
+              userActionDatetimeCreated: userAction.datetimeCreated,
+              userActionId: userAction.id,
+            },
+          },
+        )
+      }
     })
 
     return {


### PR DESCRIPTION
Relates to #600 
Closes #703 

## What changed? Why?

This PR adds a Sentry alert when there is an old (eligible) user action that is still missing their NFT. Why? Because we want to be able to audit if our NFT backfill cron job is having issues and make any environment variable adjustments (_e.g._ during an extended bull market when fees may stay high for a long period of time).

## UI changes

No UI changes.

## PlanetScale Deploy Request

No PlanetScale schema changes.

## Notes to reviewers

- We only fetch for the first oldest action because that's all we need
  - The threshold for being old is set to 3 days in the past
- If there is no user action, then we just `return` because we are all caught up

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

<img width="1487" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/135282747/41ec5680-0fb4-4a43-85a2-0afe06a997d1">

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
