### PR TITLE
feature: migrate v1 inAppDonations to swc v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,20 +55,20 @@ DISABLE_ERD="true"
 NEXT_PUBLIC_THIRDWEB_AUTH_DOMAIN="localhost:3000"
 NEXT_PUBLIC_ENVIRONMENT="local"
 
-# ETH address for your local web3 wallet of choice that you will be connecting to the app. 
+# ETH address for your local web3 wallet of choice that you will be connecting to the app.
 # Fill it with your crypto address or leave it as a dummy value
 LOCAL_USER_CRYPTO_ADDRESS="0x0000000000000000000000000000000000000000"
 
 # Logger maximum verbosity level to display
 # All levels to the right of the one selected will show
-NEXT_PUBLIC_LOG_LEVEL="info" # debug | info | warn | error | custom 
+NEXT_PUBLIC_LOG_LEVEL="info" # debug | info | warn | error | custom
 
 SUPPRESS_SENTRY_ERRORS_ON_LOCAL="true"
 
 # Whether or not to log the sql queries coming from Prisma
 LOG_DATABASE="false"
 
-# Reduces the number of pre-generated pages to speed up local development/preview deploys. 
+# Reduces the number of pre-generated pages to speed up local development/preview deploys.
 # Set to false if you need to test logic specific to build pregeneration
 MINIMIZE_PAGE_PRE_GENERATION="true"
 
@@ -78,11 +78,16 @@ NEXT_PUBLIC_DEBUG_COOKIE_CONSENT="false"
 # Verified partner secret keys
 VERIFIED_SWC_PARTNER_SECRET_COINBASE="super_secret_coinbase_partner_key"
 
+# Coinbase Commerce API key
+# You can get this by creating a new API key in your Coinbase Commerce account
+# https://docs.cloud.coinbase.com/commerce-onchain/docs/creating-api-key
+COINBASE_COMMERCE_API_KEY="coinbase_commerce_secret_key"
+
 # Allows to create a live event action without checking the event date
 NEXT_PUBLIC_BYPASS_LIVE_EVENT_DURATION_CHECK="false"
 
-# These are contract addresses for minting and db registration 
-# These values are here as dummys for database seed 
+# These are contract addresses for minting and db registration
+# These values are here as dummys for database seed
 LEGACY_NFT_DEPLOYER_WALLET="0x0000000000000000000000000000000000000000"
 SWC_DOT_ETH_WALLET="0x0000000000000000000000000000000000000000"
 SWC_SHIELD_NFT_CONTRACT_ADDRESS="0x0000000000000000000000000000000000000000"

--- a/src/app/api/internal/commerce-webhook/route.ts
+++ b/src/app/api/internal/commerce-webhook/route.ts
@@ -87,6 +87,7 @@ export async function POST(request: NextRequest) {
       paymentType: body.event.type,
       sessionId: body.event.data.metadata.sessionId,
       userId: body.event.data.metadata.userId,
+      email: body.event.data.metadata.email,
     })
 
     // Only store the payment request if the charge has been confirmed.

--- a/src/app/api/internal/commerce-webhook/route.ts
+++ b/src/app/api/internal/commerce-webhook/route.ts
@@ -54,6 +54,23 @@ export async function POST(request: NextRequest) {
       localUser = getLocalUserFromUser(user)
     }
   }
+
+  // mini-dapp in app donation flow - we store user email address
+  if (body.event.data.metadata.email) {
+    const user = await prismaClient.user.findFirst({
+      where: {
+        userEmailAddresses: {
+          some: {
+            emailAddress: body.event.data.metadata.email,
+          },
+        },
+      },
+    })
+    if (user) {
+      localUser = getLocalUserFromUser(user)
+    }
+  }
+
   const analytics = getServerAnalytics({
     localUser,
     userId: body.event.data.metadata.userId,

--- a/src/app/api/internal/in-app-donations/route.ts
+++ b/src/app/api/internal/in-app-donations/route.ts
@@ -1,10 +1,11 @@
 import * as Sentry from '@sentry/nextjs'
 import { NextRequest, NextResponse } from 'next/server'
+
 import {
-  createInAppCharge,
-  CreateChargeParams,
   CoinbaseCommerceDonation,
-  zodCoinbaseCommerceDonation
+  createInAppCharge,
+  CreateInAppChargeParams,
+  zodCoinbaseCommerceDonation,
 } from '@/utils/server/coinbaseCommerce/createCharge'
 
 export async function POST(request: NextRequest) {
@@ -21,7 +22,7 @@ export async function POST(request: NextRequest) {
       },
     })
   }
-  const params: CreateChargeParams = {
+  const params: CreateInAppChargeParams = {
     address: body.address,
     email: body.email,
     employer: body.employer,
@@ -29,11 +30,7 @@ export async function POST(request: NextRequest) {
     is_citizen: body.is_citizen,
     occupation: body.occupation,
   }
-  const hostedUrl = (
-    await createInAppCharge({
-      createChargeParams: params,
-    })
-  ).data.hosted_url
+  const hostedUrl = (await createInAppCharge(params)).data.hosted_url
 
   return new NextResponse(JSON.stringify({ charge_url: hostedUrl }), { status: 200 })
 }

--- a/src/app/api/internal/in-app-donations/route.ts
+++ b/src/app/api/internal/in-app-donations/route.ts
@@ -1,0 +1,39 @@
+import * as Sentry from '@sentry/nextjs'
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  createInAppCharge,
+  CreateChargeParams,
+  CoinbaseCommerceDonation,
+  zodCoinbaseCommerceDonation
+} from '@/utils/server/coinbaseCommerce/createCharge'
+
+export async function POST(request: NextRequest) {
+  const rawRequestBody = await request.json()
+
+  const body = rawRequestBody as CoinbaseCommerceDonation
+  const zodResult = zodCoinbaseCommerceDonation.safeParse(body)
+  if (!zodResult.success) {
+    // Only capture message, but still attempt to proceed with the request.
+    Sentry.captureMessage('unexpected Coinbase Commerce donation request format', {
+      extra: {
+        body,
+        errors: zodResult.error.flatten(),
+      },
+    })
+  }
+  const params: CreateChargeParams = {
+    address: body.address,
+    email: body.email,
+    employer: body.employer,
+    full_name: body.full_name,
+    is_citizen: body.is_citizen,
+    occupation: body.occupation,
+  }
+  const hostedUrl = (
+    await createInAppCharge({
+      createChargeParams: params,
+    })
+  ).data.hosted_url
+
+  return new NextResponse(JSON.stringify({ charge_url: hostedUrl }), { status: 200 })
+}

--- a/src/app/api/internal/in-app-donations/route.ts
+++ b/src/app/api/internal/in-app-donations/route.ts
@@ -1,3 +1,14 @@
+import {
+  Address,
+  Prisma,
+  User,
+  UserActionOptInType,
+  UserActionType,
+  UserEmailAddress,
+  UserEmailAddressSource,
+  UserInformationVisibility,
+  UserSession,
+} from '@prisma/client'
 import * as Sentry from '@sentry/nextjs'
 import { NextRequest, NextResponse } from 'next/server'
 
@@ -7,6 +18,19 @@ import {
   CreateInAppChargeParams,
   zodCoinbaseCommerceDonation,
 } from '@/utils/server/coinbaseCommerce/createCharge'
+import { prismaClient } from '@/utils/server/prismaClient'
+import { AnalyticsUserActionUserState } from '@/utils/server/serverAnalytics'
+import { VerifiedSWCPartner } from '@/utils/server/verifiedSWCPartner/constants'
+import { getLogger } from '@/utils/shared/logger'
+import { generateReferralId } from '@/utils/shared/referralId'
+
+type UserWithRelations = User & {
+  userEmailAddresses: UserEmailAddress[]
+  userSessions: Array<UserSession>
+  address?: Address | null
+}
+
+const logger = getLogger('inAppDonation')
 
 export async function POST(request: NextRequest) {
   const rawRequestBody = await request.json()
@@ -32,5 +56,137 @@ export async function POST(request: NextRequest) {
   }
   const hostedUrl = (await createInAppCharge(params)).data.hosted_url
 
+  const actionType = UserActionType.DONATION
+  const existingAction = await prismaClient.userAction.findFirst({
+    include: {
+      user: {
+        include: {
+          userEmailAddresses: true,
+          userSessions: true,
+        },
+      },
+    },
+    where: {
+      actionType,
+      userActionOptIn: {
+        optInType: UserActionOptInType.SWC_SIGN_UP_AS_SUBSCRIBER,
+      },
+      user: {
+        userEmailAddresses: {
+          some: { emailAddress: body.email },
+        },
+      },
+    },
+  })
+
+  await maybeUpsertUser({ existingUser: existingAction?.user, input: params })
+
   return new NextResponse(JSON.stringify({ charge_url: hostedUrl }), { status: 200 })
+}
+
+async function maybeUpsertUser({
+  existingUser,
+  input,
+}: {
+  existingUser: UserWithRelations | undefined
+  input: CreateInAppChargeParams
+}): Promise<{ user: UserWithRelations; userState: AnalyticsUserActionUserState }> {
+  const { email, full_name } = input
+
+  const nameParts = full_name.split(' ')
+  const firstName = nameParts[0]
+  const lastName = nameParts.slice(1, nameParts.length).join(' ')
+
+  if (existingUser) {
+    const updatePayload: Prisma.UserUpdateInput = {
+      // TODO typesafe against invalid fields
+      ...(firstName && !existingUser.firstName && { firstName: firstName }),
+      ...(lastName && !existingUser.lastName && { lastName: lastName }),
+      ...(email &&
+        existingUser.userEmailAddresses.every(addr => addr.emailAddress !== email) && {
+          userEmailAddresses: {
+            create: {
+              emailAddress: email,
+              isVerified: true,
+              source: UserEmailAddressSource.VERIFIED_THIRD_PARTY,
+            },
+          },
+        }),
+    }
+    const keysToUpdate = Object.keys(updatePayload)
+    if (!keysToUpdate.length) {
+      return { user: existingUser, userState: 'Existing' }
+    }
+    logger.info(`updating the following user fields ${keysToUpdate.join(', ')}`)
+    const user = await prismaClient.user.update({
+      where: { id: existingUser.id },
+      data: updatePayload,
+      include: {
+        userEmailAddresses: true,
+        userSessions: true,
+        address: true,
+      },
+    })
+    const existingEmail = user.userEmailAddresses.find(e => e.emailAddress === email)
+    if (existingEmail && !existingEmail.isVerified) {
+      logger.info(`verifying previously unverified email`)
+      await prismaClient.userEmailAddress.update({
+        where: { id: existingEmail.id },
+        data: { isVerified: true },
+      })
+    }
+
+    if (!user.primaryUserEmailAddressId && email) {
+      const newEmail = user.userEmailAddresses.find(addr => addr.emailAddress === email)!
+      logger.info(`updating primary email`)
+      await prismaClient.user.update({
+        where: { id: user.id },
+        data: { primaryUserEmailAddressId: newEmail.id },
+      })
+      user.primaryUserEmailAddressId = newEmail.id
+    }
+    return { user, userState: 'Existing With Updates' }
+  }
+  let user = await prismaClient.user.create({
+    include: {
+      userEmailAddresses: true,
+      userSessions: true,
+    },
+    data: {
+      acquisitionReferer: '',
+      acquisitionSource: VerifiedSWCPartner.COINBASE,
+      acquisitionMedium: 'verified-swc-partner-api',
+      acquisitionCampaign: '',
+      referralId: generateReferralId(),
+      userSessions: {
+        create: {},
+      },
+      informationVisibility: UserInformationVisibility.ANONYMOUS,
+      firstName: firstName,
+      lastName: lastName,
+      phoneNumber: '',
+      hasOptedInToEmails: true,
+      hasOptedInToMembership: false,
+      hasOptedInToSms: false,
+      userEmailAddresses: {
+        create: {
+          emailAddress: email,
+          isVerified: true,
+          source: UserEmailAddressSource.VERIFIED_THIRD_PARTY,
+        },
+      },
+    },
+  })
+  user = await prismaClient.user.update({
+    include: {
+      userEmailAddresses: true,
+      userSessions: true,
+      address: true,
+    },
+    where: { id: user.id },
+    data: {
+      primaryUserEmailAddressId: user.userEmailAddresses[0].id,
+    },
+  })
+  return { user, userState: 'New' }
 }

--- a/src/utils/server/coinbaseCommerce/createCharge.ts
+++ b/src/utils/server/coinbaseCommerce/createCharge.ts
@@ -103,16 +103,6 @@ interface CreateChargeRequest {
   redirect_url?: string
 }
 
-// mini-dApps donation flow
-export interface CoinbaseCommerceDonation {
-  address: string
-  email: string
-  employer: string
-  full_name: string
-  is_citizen: boolean
-  occupation: string
-}
-
 export const zodCoinbaseCommerceDonation = z.object({
   address: z.string(),
   email: z.string(),
@@ -122,14 +112,8 @@ export const zodCoinbaseCommerceDonation = z.object({
   occupation: z.string(),
 })
 
-export interface CreateInAppChargeParams {
-  address: string
-  email: string
-  employer: string
-  full_name: string
-  is_citizen: boolean
-  occupation: string
-}
+// mini-dApps donation flow
+export type CoinbaseCommerceDonation = z.infer<typeof zodCoinbaseCommerceDonation>
 
 export async function createCharge({ sessionId, userId }: { sessionId: string; userId: string }) {
   const payload: CreateChargeRequest = {
@@ -159,7 +143,7 @@ export async function createCharge({ sessionId, userId }: { sessionId: string; u
   }
 }
 
-export async function createInAppCharge(createInAppChargeParams: CreateInAppChargeParams) {
+export async function createInAppCharge(createInAppChargeParams: CoinbaseCommerceDonation) {
   const payload: CreateChargeRequest = {
     cancel_url: 'https://www.standwithcrypto.org',
     description: 'Donate to Crypto',


### PR DESCRIPTION
closes #222 

## What changed? Why?
This PR introduces `createInAppCharge` function copying functionality of backend endpoint for in app donations  from SwC V1.

@travisbloom-cb @lucasrmp-cb should this function also accept `userId` and `sessionId` like `createCharge`? I exposed `api/internal/in-app-donations`, not sure though if this is right approach if we're planning to add frontend to this feature.

It was tested via running local server and curling endpoint to hit commerce v2 api (I was only able to migrate my account to prod on commerce beta/api - commerce dev env still responds with v1 api):

`data_swc.json` file
```json
{
  "address": "My test address, 11-111",
  "email": "my-test-email@coinbase.com",
  "employer": "Coinbase",
  "full_name": "John Doe",
  "is_citizen": false,
  "occupation": "occupation test"
}
```
api responded with

```json
{"charge_url":"https://commerce.coinbase.com/pay/test_pay_id"
```
upon inspecting created commerce charge I was able to confirm that api stored fields correctly

```json
{
  "data": {
    "brand_color": "#122332",
    "brand_logo_url": "",
    "charge_kind": "WEB3",
    "code": "test code",
    "collected_email": true,
    "created_at": "2024-03-22T19:04:31Z",
    "description": "Donate to Crypto",
    "expires_at": "2024-03-24T19:04:31Z",
    "hosted_url": "https://commerce.coinbase.com/pay/test_id",
    "id": "test_id",
    "metadata": {
      "is_citizen": "false",
      "employer": "Coinbase",
      "full_name": "John Doe",
      "address": "My test address, 11-111",
      "occupation": "occupation test",
      "email": "my-test-email@coinbase.com"
    },
    "name": "John Doe",
    "organization_name": "",
    "payments": [],
    "pricing": {
      "local": {
        "amount": "0",
        "currency": "USD"
      },
      "settlement": {
        "amount": "0",
        "currency": "USDC"
      }
    },
    "pricing_type": "no_price",
    "redirects": {
      "cancel_url": "https://www.standwithcrypto.org",
      "success_url": "",
      "will_redirect_after_success": false
    },
    "support_email": "my-test-email@coinbase.com",
    "timeline": [
      {
        "status": "NEW",
        "time": "2024-03-22T19:04:31Z"
      }
    ],
    "web3_data": {
      "transfer_intent": null,
      "success_events": [],
      "failure_events": [],
      "contract_addresses": {
        "137": "address_1",
        "1": "address_2",
        "8453": "address_3"
      },
      "settlement_currency_addresses": {
        "137": "address_4",
        "1": "address_5",
        "8453": "address_6"
      },
      "subsidized_payments_chain_to_tokens": {},
      "contract_caller_request_id": ""
    },
    "web3_retail_payments_enabled": true
  }
}
```

Let me know if this requires more exhaustive testing / some additional changes

## UI changes

### Web

| Old 👴         | New 👶         |
| -------------- | -------------- |
| old screenshot | new screenshot |

### Mobile Web

| Old 👴         | New 👶         |
| -------------- | -------------- |
| old screenshot | new screenshot |

## PlanetScale Deploy Request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
