### PR TITLE
[bug] prevent automatic scrolling when focusing on modal

### DIFF
--- a/src/components/app/userActionFormCallCongressperson/sections/intro.tsx
+++ b/src/components/app/userActionFormCallCongressperson/sections/intro.tsx
@@ -10,7 +10,7 @@ import { UseSectionsReturn } from '@/hooks/useSections'
 export function Intro({ goToSection }: UseSectionsReturn<SectionNames>) {
   const ref = React.useRef<HTMLButtonElement>(null)
   useEffect(() => {
-    ref.current?.focus()
+    ref.current?.focus({ preventScroll: true })
   }, [ref])
   return (
     <IntroStaticContent>

--- a/src/components/app/userActionFormCallCongressperson/sections/suggestedScript.tsx
+++ b/src/components/app/userActionFormCallCongressperson/sections/suggestedScript.tsx
@@ -35,7 +35,7 @@ export function SuggestedScript({
   const router = useRouter()
   const ref = React.useRef<HTMLAnchorElement>(null)
   useEffect(() => {
-    ref.current?.focus()
+    ref.current?.focus({ preventScroll: true })
   }, [ref])
   const phoneNumber = React.useMemo(() => {
     const official = getGoogleCivicOfficialByDTSIName(dtsiPerson, googleCivicData)


### PR DESCRIPTION
closes #693 

## What changed? Why?

This PR is a simple changes that prevents automatic scrolling to the bottom of the modal when the `useEffect` hook focus on the modal. Why? Because it's annoying that the scroll state goes to the very bottom.

This issues seems to only impact the "call rep" flow.

## UI changes

### Web

_Web before_:

https://github.com/Stand-With-Crypto/swc-web/assets/135282747/580d2a05-921f-4425-9bab-6b1a7beb6777

_Web after_:

https://github.com/Stand-With-Crypto/swc-web/assets/135282747/8258cb56-06ec-402c-8df4-c8eb461ac5a0

### Mobile Web

_Mobile before_:

https://github.com/Stand-With-Crypto/swc-web/assets/135282747/65fa472c-1130-47d4-bd8b-43b9727bed10

_Mobile after_:

https://github.com/Stand-With-Crypto/swc-web/assets/135282747/4ab21b74-3063-4f62-9ab3-539a3dc2b09e

## PlanetScale Deploy Request

No PlanetScale schema changes.

## Notes to reviewers

N/A

## How has it been tested?

- [X] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
