### PR TITLE
docs: updates knowledge pre-requisites links in contributing guideline

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -18,9 +18,9 @@ If you are here to suggest a feature, first [create an issue](https://github.com
 
 Below is a list of suggested documentation to read through if you aren't already familiar with the technologies used in this repository:
 
-- Read [Leveraging Modern NextJS Features](<docs/Leveraging Modern NextJS Features.md>) for an overview on the new Next.js features and React Server Components + Server Actions being leveraged in this repo
+- Read [Leveraging Modern NextJS Features](<Leveraging Modern NextJS Features.md>) for an overview on the new Next.js features and React Server Components + Server Actions being leveraged in this repo
   - If this is your first time working with these technologies, please take the time to read the linked-to blog posts
-- Read [Coding Conventions](<docs/Coding Conventions.md>) for an overview of coding conventions encouraged for this project
+- Read [Coding Conventions](<Coding Conventions.md>) for an overview of coding conventions encouraged for this project
 - Read ["What is Prisma"](https://www.prisma.io/docs/orm/overview/introduction/what-is-prisma) and ["Why Prisma"](https://www.prisma.io/docs/orm/overview/introduction/why-prisma) to learn about the ORM we use to query our database
 - Watch [this YouTube video](https://www.youtube.com/watch?v=CQuTF-bkOgc) for a great overview of the tradeoffs between the UI library/framework options that exist for frontend development, and why we decided to use TailwindCSS + Radix UI as our template
 - Read Vercel's guide on ["Connection Pooling with Serverless Functions"](https://vercel.com/guides/connection-pooling-with-serverless-functions#modern-databases-with-high-connection-limits) to learn about the architecture tradeoffs of connecting to SQL database in serverless environments, and why we decided to leverage the robust scalability architecture inherent in [PlanetScale](https://planetscale.com/features)


### PR DESCRIPTION
## Description

This PR fixes two incorrect links in contributing documentation inside the "knowledge pre-requisites" section by removing unnecessary `/docs` from each link.

closes #719 

@travisbloom-cb could you please review this PR? Thank you!
