### PR TITLE
[feature] include MySQL index for `datetime_created` field

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,6 +136,7 @@ model User {
   @@index([internalStatus])
   @@index([capitolCanaryAdvocateId])
   @@index([totalDonationAmountUsd(sort: Desc)])
+  @@index([datetimeCreated])
   @@map("user")
 }
 


### PR DESCRIPTION
relates to #660 

## What changed? Why?

This is a small PR that includes a MySQL index for the `datetime_created` field. Why? Because for the auditing cron job, I am planning to audit in batches of users in order of `datetime_created`.

Why `datetime_created`? In my opinion, that is the ideal field to use in order to _not_ skip any user rows when iterating through batches of users.

## UI changes

N/A

## PlanetScale Deploy Request

From my local branch to `testing`: https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/12

## Notes to reviewers

N/A

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
