### PR TITLE
[feature] implement one-time Inngest script to clean up "non-user-funded" NFT mints 

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -3,6 +3,7 @@ import { serve } from 'inngest/next'
 import { airdropNFTWithInngest } from '@/inngest/functions/airdropNFT'
 import { backfillNFTWithInngest } from '@/inngest/functions/backfillNFT'
 import { backfillNFTInngestCronJob } from '@/inngest/functions/backfillNFTCronJob'
+import { cleanupNFTMintsWithInngest } from '@/inngest/functions/cleanupNFTMints'
 import { cleanupPostalCodesWithInngest } from '@/inngest/functions/cleanupPostalCodes'
 import { emailRepViaCapitolCanaryWithInngest } from '@/inngest/functions/emailRepViaCapitolCanary'
 import { monitorBaseETHBalances } from '@/inngest/functions/monitorBaseETHBalances'
@@ -21,5 +22,6 @@ export const { GET, POST, PUT } = serve({
     setPrimaryCryptoAddressOfUserWithInngest,
     backfillNFTWithInngest,
     backfillNFTInngestCronJob,
+    cleanupNFTMintsWithInngest,
   ],
 })

--- a/src/inngest/functions/cleanupNFTMints/index.ts
+++ b/src/inngest/functions/cleanupNFTMints/index.ts
@@ -20,6 +20,41 @@ export const cleanupNFTMintsWithInngest = inngest.createFunction(
     const payload = event.data as ScriptPayload
 
     // Get `nft_mint` rows where:
+    // - `nft_slug` = 'swc-shield'
+    // - `contract_address` = '0x741B334b0690de44Bce6c926a1F74Ca69C95c80c'
+    const invalidShieldRows = await step.run('script.get-invalid-shield-nft-mints', async () => {
+      return prismaClient.nFTMint.findMany({
+        select: {
+          id: true,
+        },
+        where: {
+          nftSlug: NFTSlug.SWC_SHIELD,
+          contractAddress: '0x741B334b0690de44Bce6c926a1F74Ca69C95c80c',
+        },
+      })
+    })
+
+    let updatedInvalidShieldRows = { count: 0 }
+    if (payload.persist) {
+      // Update the `nft_slug` to `'stand-with-crypto-supporter'` for the selected rows.
+      updatedInvalidShieldRows = await step.run(
+        'script.update-invalid-shield-nft-mints',
+        async () => {
+          return prismaClient.nFTMint.updateMany({
+            where: {
+              id: {
+                in: invalidShieldRows.map(row => row.id),
+              },
+            },
+            data: {
+              nftSlug: NFTSlug.STAND_WITH_CRYPTO_SUPPORTER,
+            },
+          })
+        },
+      )
+    }
+
+    // Get `nft_mint` rows where:
     // - `nft_slug` is in `('swc-shield', 'i-am-a-voter', 'call-representative-sept-11', 'la-crypto-event-2024-03-04')`
     // - `cost_at_mint` is greater than 0
     const mintRows = await step.run('script.get-relevant-nft-mints', async () => {
@@ -43,33 +78,30 @@ export const cleanupNFTMintsWithInngest = inngest.createFunction(
       })
     })
 
-    if (!payload.persist) {
-      return {
-        dryRun: !payload.persist,
-        mintRowsCount: mintRows.length,
-        updatedMintRowsCount: 0,
-      }
-    }
-
-    // Update the `cost_at_mint` and `cost_at_mint_usd` to 0 for the selected rows.
-    const updatedMintRows = await step.run('script.update-nft-mints', async () => {
-      return prismaClient.nFTMint.updateMany({
-        where: {
-          id: {
-            in: mintRows.map(row => row.id),
+    let updatedMintRows = { count: 0 }
+    if (payload.persist) {
+      // Update the `cost_at_mint` and `cost_at_mint_usd` to 0 for the selected rows.
+      updatedMintRows = await step.run('script.update-nft-mints', async () => {
+        return prismaClient.nFTMint.updateMany({
+          where: {
+            id: {
+              in: mintRows.map(row => row.id),
+            },
           },
-        },
-        data: {
-          costAtMint: 0,
-          costAtMintUsd: 0,
-        },
+          data: {
+            costAtMint: 0,
+            costAtMintUsd: 0,
+          },
+        })
       })
-    })
+    }
 
     return {
       dryRun: payload.persist,
       mintRowsCount: mintRows.length,
       updatedMintRowsCount: updatedMintRows.count,
+      invalidShieldRowsCount: invalidShieldRows.length,
+      updatedInvalidShieldRowsCount: updatedInvalidShieldRows.count,
     }
   },
 )

--- a/src/inngest/functions/cleanupNFTMints/index.ts
+++ b/src/inngest/functions/cleanupNFTMints/index.ts
@@ -1,0 +1,75 @@
+import { inngest } from '@/inngest/inngest'
+import { onScriptFailure } from '@/inngest/onScriptFailure'
+import { prismaClient } from '@/utils/server/prismaClient'
+import { NFTSlug } from '@/utils/shared/nft'
+
+export interface ScriptPayload {
+  persist: boolean
+}
+
+const CLEANUP_NFT_MINTS_FUNCTION_ID = 'script.cleanup-nft-mints'
+const CLEANUP_NFT_MINTS_EVENT_NAME = 'script/cleanup.nft.mints'
+export const cleanupNFTMintsWithInngest = inngest.createFunction(
+  {
+    id: CLEANUP_NFT_MINTS_FUNCTION_ID,
+    retries: 0,
+    onFailure: onScriptFailure,
+  },
+  { event: CLEANUP_NFT_MINTS_EVENT_NAME },
+  async ({ event, step }) => {
+    const payload = event.data as ScriptPayload
+
+    // Get `nft_mint` rows where:
+    // - `nft_slug` is in `('swc-shield', 'i-am-a-voter', 'call-representative-sept-11', 'la-crypto-event-2024-03-04')`
+    // - `cost_at_mint` is greater than 0
+    const mintRows = await step.run('script.get-relevant-nft-mints', async () => {
+      return prismaClient.nFTMint.findMany({
+        select: {
+          id: true,
+        },
+        where: {
+          nftSlug: {
+            in: [
+              NFTSlug.SWC_SHIELD,
+              NFTSlug.I_AM_A_VOTER,
+              NFTSlug.CALL_REPRESENTATIVE_SEPT_11,
+              NFTSlug.LA_CRYPTO_EVENT_2024_03_04,
+            ],
+          },
+          costAtMint: {
+            gt: 0,
+          },
+        },
+      })
+    })
+
+    if (!payload.persist) {
+      return {
+        dryRun: !payload.persist,
+        mintRowsCount: mintRows.length,
+        updatedMintRowsCount: 0,
+      }
+    }
+
+    // Update the `cost_at_mint` and `cost_at_mint_usd` to 0 for the selected rows.
+    const updatedMintRows = await step.run('script.update-nft-mints', async () => {
+      return prismaClient.nFTMint.updateMany({
+        where: {
+          id: {
+            in: mintRows.map(row => row.id),
+          },
+        },
+        data: {
+          costAtMint: 0,
+          costAtMintUsd: 0,
+        },
+      })
+    })
+
+    return {
+      dryRun: payload.persist,
+      mintRowsCount: mintRows.length,
+      updatedMintRowsCount: updatedMintRows.count,
+    }
+  },
+)

--- a/src/mocks/models/mockNFTMint.ts
+++ b/src/mocks/models/mockNFTMint.ts
@@ -12,7 +12,12 @@ export function mockCreateNFTMintInput() {
   const status = faker.helpers.arrayElement(Object.values(NFTMintStatus))
   const transactionHash = status === NFTMintStatus.CLAIMED ? faker.git.commitSha() : ''
   const nftSlug = faker.helpers.arrayElement(Object.values(NFTSlug))
-  const costAtMint = new Decimal(faker.number.float({ min: 0.01, max: 0.2, multipleOf: 0.01 }))
+  const costAtMint =
+    (nftSlug === NFTSlug.STAND_WITH_CRYPTO_LEGACY ||
+      nftSlug === NFTSlug.STAND_WITH_CRYPTO_SUPPORTER) &&
+    status === NFTMintStatus.CLAIMED
+      ? new Decimal(faker.number.float({ min: 0.01, max: 0.2, multipleOf: 0.01 }))
+      : new Decimal(0)
   return {
     nftSlug,
     transactionHash,


### PR DESCRIPTION
closes internal ticket 14
unblocks #660 

## What changed? Why?

This PR implements a one-time Inngest script to clean up "non-user-funded" NFT mints by resetting the `cost_at_mint` and `cost_at_mint_usd` back to 0 for NFT mints that are not funded by the users. Why? Because the currently stored information is not correct and should be reset appropriately, and #660 is soft-blocked by this.

## UI changes

No UI changes.

## PlanetScale Deploy Request

No PlanetScale schema changes.

## Notes to reviewers

This PR also updates the mock NFT mint to only include "cost at mint" for user-funded mints.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

Video demo (only accessible by Coinbase employees): https://drive.google.com/file/d/1ezFDfyVomdfIjzp6iFNWx-AfcTPODPCQ/view?usp=sharing

https://github.com/Stand-With-Crypto/swc-web/assets/135282747/b233f8f0-279e-4f02-b221-db62e3dbb4ee

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
