### PR TITLE
[bug] change NFT mint flow's NFT slug from `'swc-shield'` to `'stand-with-crypto-supporter'`

### DIFF
--- a/src/actions/actionCreateUserActionNFTMint.ts
+++ b/src/actions/actionCreateUserActionNFTMint.ts
@@ -145,7 +145,7 @@ async function createAction<U extends User>({
       userCryptoAddress: { connect: { id: user.primaryUserCryptoAddressId! } },
       nftMint: {
         create: {
-          nftSlug: NFTSlug.SWC_SHIELD,
+          nftSlug: NFTSlug.STAND_WITH_CRYPTO_SUPPORTER,
           status: NFTMintStatus.CLAIMED,
           costAtMint: decimalEthTransactionValue,
           contractAddress: contractMetadata.contractAddress,


### PR DESCRIPTION
## What changed? Why?

This is a super simple PR that changes the NFT slug within the NFT mint flow from `'swc-shield'` to `'stand-with-crypto-supporter'`. Why? Because the `'swc-shield'` slug is the NFT that is _airdropped_ to all users who log-in, which is not the same as the _manually purchased_ NFT from the mint flow.

## UI changes

No UI changes.

## PlanetScale Deploy Request

No PlanetScale schema changes.

## Notes to reviewers

N/A

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
