### PR TITLE
[feature + bug] add new `hasRepliedToOptInSms` field for users table, and fix Capitol Canary SMS opt-in bug

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,7 @@ model User {
   primaryUserCryptoAddressId String?                   @unique @map("primary_user_crypto_address_id")
   hasOptedInToEmails         Boolean                   @map("has_opted_in_to_emails")
   hasOptedInToSms            Boolean                   @map("has_opted_in_to_sms")
+  hasRepliedToOptInSms       Boolean                   @map("has_replied_to_opt_in_sms")
   hasOptedInToMembership     Boolean                   @map("has_opted_in_to_membership")
   internalStatus             UserInternalStatus        @default(VISIBLE) @map("internal_status")
   dataCreationMethod         DataCreationMethod        @default(BY_USER) @map("data_creation_method")

--- a/src/actions/actionCreateUserActionCallCongressperson/index.ts
+++ b/src/actions/actionCreateUserActionCallCongressperson/index.ts
@@ -132,6 +132,7 @@ async function createUser(sharedDependencies: Pick<SharedDependencies, 'localUse
       hasOptedInToEmails: false,
       hasOptedInToMembership: false,
       hasOptedInToSms: false,
+      hasRepliedToOptInSms: false,
       ...mapLocalUserToUserDatabaseFields(localUser),
     },
     include: {

--- a/src/actions/actionCreateUserActionEmailCongressperson.ts
+++ b/src/actions/actionCreateUserActionEmailCongressperson.ts
@@ -284,6 +284,7 @@ async function maybeUpsertUser({
       hasOptedInToEmails: true,
       hasOptedInToMembership: false,
       hasOptedInToSms: false,
+      hasRepliedToOptInSms: false,
       firstName,
       lastName,
       userEmailAddresses: {

--- a/src/actions/actionCreateUserActionLiveEvent.ts
+++ b/src/actions/actionCreateUserActionLiveEvent.ts
@@ -148,6 +148,7 @@ async function createUser(sharedDependencies: Pick<SharedDependencies, 'localUse
       hasOptedInToEmails: false,
       hasOptedInToMembership: false,
       hasOptedInToSms: false,
+      hasRepliedToOptInSms: false,
       referralId: generateReferralId(),
       ...mapLocalUserToUserDatabaseFields(localUser),
     },

--- a/src/actions/actionCreateUserActionTweet.ts
+++ b/src/actions/actionCreateUserActionTweet.ts
@@ -146,6 +146,7 @@ async function maybeUpsertUser({
       hasOptedInToEmails: false,
       hasOptedInToMembership: false,
       hasOptedInToSms: false,
+      hasRepliedToOptInSms: false,
     },
   })
   return { user, userState: 'New' }

--- a/src/actions/actionCreateUserActionVoterRegistration.ts
+++ b/src/actions/actionCreateUserActionVoterRegistration.ts
@@ -127,6 +127,7 @@ async function createUser(sharedDependencies: Pick<SharedDependencies, 'localUse
       hasOptedInToEmails: false,
       hasOptedInToMembership: false,
       hasOptedInToSms: false,
+      hasRepliedToOptInSms: false,
       referralId: generateReferralId(),
       ...mapLocalUserToUserDatabaseFields(localUser),
     },

--- a/src/actions/actionUpdateUserProfile.ts
+++ b/src/actions/actionUpdateUserProfile.ts
@@ -162,10 +162,12 @@ async function handleCapitolCanaryAdvocateUpsert(
   } & { userEmailAddresses: UserEmailAddress[] },
 ) {
   // Send unsubscribe payload if the old email address or phone number has changed, or if the user removed their old email or phone number.
+  // `hasChangedEmail` is true if an old email address exists and the new email address is different from the old email address.
   const hasChangedEmail =
     !!oldUser.primaryUserEmailAddress &&
     (!primaryUserEmailAddress ||
       oldUser.primaryUserEmailAddress.emailAddress !== primaryUserEmailAddress.emailAddress)
+  // `hasChangedPhone` is true if an old phone number exists and the new phone number is different from the old phone number.
   const hasChangedPhone =
     !!oldUser.phoneNumber &&
     (!updatedUser.phoneNumber || oldUser.phoneNumber !== updatedUser.phoneNumber)

--- a/src/actions/actionUpdateUserProfile.ts
+++ b/src/actions/actionUpdateUserProfile.ts
@@ -163,28 +163,29 @@ async function handleCapitolCanaryAdvocateUpsert(
 ) {
   // Send unsubscribe payload if the old email address or phone number has changed, or if the user removed their old email or phone number.
   if (
-    (oldUser.primaryUserEmailAddress !== null &&
-      oldUser.primaryUserEmailAddress.emailAddress !== primaryUserEmailAddress?.emailAddress) ||
-    oldUser.phoneNumber !== updatedUser.phoneNumber ||
-    (primaryUserEmailAddress === null && oldUser.primaryUserEmailAddress !== null) ||
-    (oldUser.phoneNumber && !updatedUser.phoneNumber)
+    (oldUser.primaryUserEmailAddress &&
+      (oldUser.primaryUserEmailAddress.emailAddress !== primaryUserEmailAddress?.emailAddress ||
+        !primaryUserEmailAddress)) ||
+    (oldUser.phoneNumber &&
+      (oldUser.phoneNumber !== updatedUser.phoneNumber || !updatedUser.phoneNumber))
   ) {
     const unsubscribePayload: UpsertAdvocateInCapitolCanaryPayloadRequirements = {
       campaignId: getCapitolCanaryCampaignID(CapitolCanaryCampaignName.DEFAULT_SUBSCRIBER),
       user: {
-        ...updatedUser, // Always use new user information.
-        address: updatedUser.address, // Always use new user information.
+        ...updatedUser, // Use new user information EXCEPT for the phone number.
+        phoneNumber: oldUser.phoneNumber, // Using old phone number here.
+        address: updatedUser.address,
       },
       userEmailAddress: oldUser.primaryUserEmailAddress, // Using old email here.
       opts: {
-        isEmailOptout:
-          (oldUser.primaryUserEmailAddress?.emailAddress !== undefined &&
-            oldUser.primaryUserEmailAddress.emailAddress !==
-              primaryUserEmailAddress?.emailAddress) ||
-          primaryUserEmailAddress === null,
+        isEmailOptout: !!(
+          oldUser.primaryUserEmailAddress &&
+          (oldUser.primaryUserEmailAddress.emailAddress !== primaryUserEmailAddress?.emailAddress ||
+            !primaryUserEmailAddress)
+        ),
         isSmsOptout: !!(
-          oldUser.phoneNumber !== updatedUser.phoneNumber ||
-          (oldUser.phoneNumber && !updatedUser.phoneNumber)
+          oldUser.phoneNumber &&
+          (oldUser.phoneNumber !== updatedUser.phoneNumber || !updatedUser.phoneNumber)
         ),
       },
     }
@@ -213,10 +214,10 @@ async function handleCapitolCanaryAdvocateUpsert(
     const payload: UpsertAdvocateInCapitolCanaryPayloadRequirements = {
       campaignId: getCapitolCanaryCampaignID(CapitolCanaryCampaignName.DEFAULT_SUBSCRIBER),
       user: {
-        ...updatedUser,
+        ...updatedUser, // Using new user information (including new phone number).
         address: updatedUser.address,
       },
-      userEmailAddress: primaryUserEmailAddress,
+      userEmailAddress: primaryUserEmailAddress, // Using new email here.
       opts: {
         isEmailOptin: true,
         isSmsOptin: hasOptedInToSms,

--- a/src/actions/actionUpdateUserProfile.ts
+++ b/src/actions/actionUpdateUserProfile.ts
@@ -178,15 +178,15 @@ async function handleCapitolCanaryAdvocateUpsert(
       },
       userEmailAddress: oldUser.primaryUserEmailAddress, // Using old email here.
       opts: {
-        isEmailOptout: !!(
-          oldUser.primaryUserEmailAddress &&
-          (oldUser.primaryUserEmailAddress.emailAddress !== primaryUserEmailAddress?.emailAddress ||
-            !primaryUserEmailAddress)
-        ),
-        isSmsOptout: !!(
-          oldUser.phoneNumber &&
-          (oldUser.phoneNumber !== updatedUser.phoneNumber || !updatedUser.phoneNumber)
-        ),
+        // Opt out if there is an old email address and either there is no new email address or the new email address is different.
+        isEmailOptout:
+          oldUser.primaryUserEmailAddress !== null &&
+          (!primaryUserEmailAddress ||
+            oldUser.primaryUserEmailAddress.emailAddress !== primaryUserEmailAddress.emailAddress),
+        // Opt out if there is an old phone number and either there is no new phone number or the new phone number is different.
+        isSmsOptout:
+          oldUser.phoneNumber !== '' &&
+          (!updatedUser.phoneNumber || oldUser.phoneNumber !== updatedUser.phoneNumber),
       },
     }
     await inngest.send({

--- a/src/data/verifiedSWCPartners/userActionOptIn.ts
+++ b/src/data/verifiedSWCPartners/userActionOptIn.ts
@@ -317,6 +317,7 @@ async function maybeUpsertUser({
       hasOptedInToEmails: true,
       hasOptedInToMembership: hasOptedInToMembership || false,
       hasOptedInToSms: hasOptedInToReceiveSMSFromSWC || false,
+      hasRepliedToOptInSms: false,
       userEmailAddresses: {
         create: {
           emailAddress,

--- a/src/mocks/models/mockUser.ts
+++ b/src/mocks/models/mockUser.ts
@@ -37,6 +37,7 @@ export function mockCreateUserInput({
     hasOptedInToEmails: true,
     hasOptedInToMembership: false,
     hasOptedInToSms: false,
+    hasRepliedToOptInSms: false,
     internalStatus: UserInternalStatus.VISIBLE,
     capitolCanaryAdvocateId: null,
     capitolCanaryInstance: null,

--- a/src/utils/server/coinbaseCommerce/storePaymentRequest.ts
+++ b/src/utils/server/coinbaseCommerce/storePaymentRequest.ts
@@ -194,6 +194,7 @@ async function createNewUser(payment: CoinbaseCommercePayment) {
       referralId: generateReferralId(),
       hasOptedInToEmails: false,
       hasOptedInToSms: false,
+      hasRepliedToOptInSms: false,
       hasOptedInToMembership: false,
       informationVisibility: UserInformationVisibility.ANONYMOUS,
       acquisitionReferer: '',

--- a/src/utils/server/thirdweb/onLogin.ts
+++ b/src/utils/server/thirdweb/onLogin.ts
@@ -446,6 +446,7 @@ async function createUser({ localUser }: { localUser: ServerLocalUser | null }) 
       hasOptedInToEmails: true,
       hasOptedInToMembership: false,
       hasOptedInToSms: false,
+      hasRepliedToOptInSms: false,
       referralId: generateReferralId(),
       ...mapLocalUserToUserDatabaseFields(localUser),
     },


### PR DESCRIPTION
relates to internal issue 16

## What changed? Why?

This PR adds a new `hasRepliedToOptInSms` field for the users table. Why? Because even though a user has opted-in via the SWC website, they may not respond to the SMS message from Capitol Canary. Responding to the SMS message is how an advocate can _fully_ opt into SMS messaging, thus we need to keep track of that.

This PR also fixes two Capitol Canary SMS opt-in bugs:
- We were accidentally marking the Capitol Canary advocate as an explicitly SMS opt-out if the respective SWC user supplied their phone number without checking the opt-in checkbox
- We were also accidentally opting out the _new_ phone number if the SWC user changed their phone number

This is important because Capitol Canary does not allow advocates to opt back into SMS (we should really talk to Capitol Canary about this).

![image](https://github.com/Stand-With-Crypto/swc-web/assets/135282747/ba86c4df-e127-468f-8e16-1232580516d7) 

## UI changes

No UI changes.

## PlanetScale Deploy Request

From my personal DB branch to `testing`: https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/14

## Notes to reviewers

No specific notes.

## How has it been tested?

Verified information in Sandbox Capitol Canary account.

- [X] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
