### PR TITLE
[feature] add default value for `hasRepliedToOptInSms` field

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,7 +104,7 @@ model User {
   primaryUserCryptoAddressId String?                   @unique @map("primary_user_crypto_address_id")
   hasOptedInToEmails         Boolean                   @map("has_opted_in_to_emails")
   hasOptedInToSms            Boolean                   @map("has_opted_in_to_sms")
-  hasRepliedToOptInSms       Boolean                   @map("has_replied_to_opt_in_sms")
+  hasRepliedToOptInSms       Boolean                   @default(false) @map("has_replied_to_opt_in_sms")
   hasOptedInToMembership     Boolean                   @map("has_opted_in_to_membership")
   internalStatus             UserInternalStatus        @default(VISIBLE) @map("internal_status")
   dataCreationMethod         DataCreationMethod        @default(BY_USER) @map("data_creation_method")


### PR DESCRIPTION
relates to internal issue 16
## What changed? Why?

This is a small PR that adds the default value for the new boolean field. Why? Because PlanetScale requires a default value for newly added fields - otherwise, a deploy request will fail (see [failed request](https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/14)).

## UI changes

No UI changes.

## PlanetScale Deploy Request

From my DB branch to `testing`: https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/16

## Notes to reviewers

Nothing to note.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
