### PR TITLE
[bug] wrap Local Storage functons with a try-catch block to prevent the app from crashing on certain browsers

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -71,44 +71,6 @@ export default function Layout({ children, params }: PageProps & { children: Rea
       <body className={fontClassName}>
         {/* LATER-TASK add back once https://github.com/TheSGJ/nextjs-toploader/issues/66 is resolved */}
         {/* <NextTopLoader /> */}
-        <script>
-          {`
-            const originalLocalStorage = window.localStorage
-            const wrappedLocalStorage = {
-              getItem: function (key: string) {
-                try {
-                  return originalLocalStorage.getItem(key)
-                } catch (error) {
-                  return null
-                }
-              },
-              setItem: function (key: string, value: string) {
-                try {
-                  originalLocalStorage.setItem(key, value)
-                } catch (error) {}
-              },
-              removeItem: function (key: string) {
-                try {
-                  originalLocalStorage.removeItem(key)
-                } catch (error) {}
-              },
-              clear: function () {
-                try {
-                  originalLocalStorage.clear()
-                } catch (error) {}
-              },
-              length: originalLocalStorage.length,
-              key: function (index: number) {
-                try {
-                  return originalLocalStorage.key(index)
-                } catch (error) {
-                  return null
-                }
-              },
-            }
-            window.localStorage = wrappedLocalStorage
-          `}
-        </script>
         <TopLevelClientLogic locale={locale}>
           <FullHeight.Container>
             <Navbar locale={locale} />

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -65,7 +65,6 @@ export default function Layout({ children, params }: PageProps & { children: Rea
   if (!ORDERED_SUPPORTED_LOCALES.includes(locale)) {
     notFound()
   }
-
   return (
     <html lang={locale}>
       <body className={fontClassName}>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 import { capitalize } from 'lodash-es'
 import type { Metadata, Viewport } from 'next'
 import { notFound } from 'next/navigation'
+import Script from 'next/script'
 
 import { TopLevelClientLogic } from '@/app/[locale]/topLevelClientLogic'
 import { CookieConsent } from '@/components/app/cookieConsent'
@@ -70,6 +71,70 @@ export default function Layout({ children, params }: PageProps & { children: Rea
       <body className={fontClassName}>
         {/* LATER-TASK add back once https://github.com/TheSGJ/nextjs-toploader/issues/66 is resolved */}
         {/* <NextTopLoader /> */}
+        <Script id="foobar" strategy="beforeInteractive">
+          {`
+            console.log('overriding localStorage methods')
+
+            const originalClear = Storage.prototype.clear
+            const originalGetItem = Storage.prototype.getItem
+            const originalKey = Storage.prototype.key
+            const originalSetItem = Storage.prototype.setItem
+            const originalRemoveItem = Storage.prototype.removeItem
+
+            Storage.prototype.clear = function () {
+              try {
+                console.log('Clearing localStorage')
+                originalClear.call(localStorage)
+              } catch (e) {
+                console.error('Failed to clear localStorage:', e)
+              }
+            }
+
+            Storage.prototype.getItem = function (key) {
+              try {
+                console.log('Getting item from localStorage:', key)
+                return originalGetItem.call(localStorage, key)
+              } catch (e) {
+                console.error('Failed to retrieve item from localStorage:', e)
+                return null
+              }
+            }
+
+            Storage.prototype.key = function (index) {
+              try {
+                console.log('Getting key from localStorage:', index)
+                return originalKey.call(localStorage, index)
+              } catch (e) {
+                console.error('Failed to retrieve key from localStorage:', e)
+                return null
+              }
+            }
+
+            Storage.prototype.removeItem = function (key) {
+              try {
+                console.log('Removing item from localStorage:', key)
+                originalRemoveItem.call(localStorage, key)
+              } catch (e) {
+                console.error('Failed to remove item from localStorage:', e)
+              }
+            }
+
+            Storage.prototype.setItem = function (key, value) {
+              try {
+                console.log('Storing item in localStorage:', key, value)
+                originalSetItem.call(localStorage, key, value)
+              } catch (e) {
+                console.error('Failed to store item in localStorage:', e)
+              }
+            }
+
+            localStorage.clear = Storage.prototype.clear
+            localStorage.getItem = Storage.prototype.getItem
+            localStorage.key = Storage.prototype.key
+            localStorage.removeItem = Storage.prototype.removeItem
+            localStorage.setItem = Storage.prototype.setItem
+          `}
+        </Script>
         <TopLevelClientLogic locale={locale}>
           <FullHeight.Container>
             <Navbar locale={locale} />

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -75,64 +75,57 @@ export default function Layout({ children, params }: PageProps & { children: Rea
           {`
             console.log('overriding localStorage methods')
 
-            const originalClear = Storage.prototype.clear
-            const originalGetItem = Storage.prototype.getItem
-            const originalKey = Storage.prototype.key
-            const originalSetItem = Storage.prototype.setItem
-            const originalRemoveItem = Storage.prototype.removeItem
-
-            Storage.prototype.clear = function () {
+            const clear = localStorage.clear
+            const getItem = localStorage.getItem
+            const key = localStorage.key
+            const removeItem = localStorage.removeItem
+            const setItem = localStorage.setItem
+          
+            localStorage.clear = function () {
               try {
-                console.log('Clearing localStorage')
-                originalClear.call(localStorage)
+                clear.call(this)
               } catch (e) {
                 console.error('Failed to clear localStorage:', e)
               }
             }
-
-            Storage.prototype.getItem = function (key) {
+          
+            localStorage.getItem = function (keyString) {
               try {
-                console.log('Getting item from localStorage:', key)
-                return originalGetItem.call(localStorage, key)
+                console.log('Getting item from localStorage:', keyString)
+                return getItem.call(this, keyString)
               } catch (e) {
                 console.error('Failed to retrieve item from localStorage:', e)
                 return null
               }
             }
-
-            Storage.prototype.key = function (index) {
+          
+            localStorage.key = function (index) {
               try {
                 console.log('Getting key from localStorage:', index)
-                return originalKey.call(localStorage, index)
+                return key.call(this, index)
               } catch (e) {
                 console.error('Failed to retrieve key from localStorage:', e)
                 return null
               }
             }
-
-            Storage.prototype.removeItem = function (key) {
+          
+            localStorage.removeItem = function (keyString) {
               try {
-                console.log('Removing item from localStorage:', key)
-                originalRemoveItem.call(localStorage, key)
+                console.log('Removing item from localStorage:', keyString)
+                removeItem.call(this, keyString)
               } catch (e) {
                 console.error('Failed to remove item from localStorage:', e)
               }
             }
-
-            Storage.prototype.setItem = function (key, value) {
+          
+            localStorage.setItem = function (keyString, value) {
               try {
-                console.log('Storing item in localStorage:', key, value)
-                originalSetItem.call(localStorage, key, value)
+                console.log('Storing item in localStorage:', keyString, value)
+                setItem.call(this, keyString, value)
               } catch (e) {
                 console.error('Failed to store item in localStorage:', e)
               }
             }
-
-            localStorage.clear = Storage.prototype.clear
-            localStorage.getItem = Storage.prototype.getItem
-            localStorage.key = Storage.prototype.key
-            localStorage.removeItem = Storage.prototype.removeItem
-            localStorage.setItem = Storage.prototype.setItem
           `}
         </Script>
         <TopLevelClientLogic locale={locale}>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -65,11 +65,50 @@ export default function Layout({ children, params }: PageProps & { children: Rea
   if (!ORDERED_SUPPORTED_LOCALES.includes(locale)) {
     notFound()
   }
+
   return (
     <html lang={locale}>
       <body className={fontClassName}>
         {/* LATER-TASK add back once https://github.com/TheSGJ/nextjs-toploader/issues/66 is resolved */}
         {/* <NextTopLoader /> */}
+        <script>
+          {`
+            const originalLocalStorage = window.localStorage
+            const wrappedLocalStorage = {
+              getItem: function (key: string) {
+                try {
+                  return originalLocalStorage.getItem(key)
+                } catch (error) {
+                  return null
+                }
+              },
+              setItem: function (key: string, value: string) {
+                try {
+                  originalLocalStorage.setItem(key, value)
+                } catch (error) {}
+              },
+              removeItem: function (key: string) {
+                try {
+                  originalLocalStorage.removeItem(key)
+                } catch (error) {}
+              },
+              clear: function () {
+                try {
+                  originalLocalStorage.clear()
+                } catch (error) {}
+              },
+              length: originalLocalStorage.length,
+              key: function (index: number) {
+                try {
+                  return originalLocalStorage.key(index)
+                } catch (error) {
+                  return null
+                }
+              },
+            }
+            window.localStorage = wrappedLocalStorage
+          `}
+        </script>
         <TopLevelClientLogic locale={locale}>
           <FullHeight.Container>
             <Navbar locale={locale} />

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -73,15 +73,14 @@ export default function Layout({ children, params }: PageProps & { children: Rea
         {/* <NextTopLoader /> */}
         <Script id="localStorageOverride" strategy="beforeInteractive">
           {`
-            console.log('overriding localStorage methods')
-            console.log('localStorage:', localStorage)
+            console.log('Overriding localStorage methods')
             try {
               const clear = localStorage.clear
               const getItem = localStorage.getItem
               const key = localStorage.key
               const removeItem = localStorage.removeItem
               const setItem = localStorage.setItem
-          
+
               localStorage.clear = function () {
                 try {
                   clear.call(this)
@@ -89,7 +88,7 @@ export default function Layout({ children, params }: PageProps & { children: Rea
                   console.error('Failed to clear localStorage:', e)
                 }
               }
-          
+
               localStorage.getItem = function (keyString) {
                 try {
                   console.log('Getting item from localStorage:', keyString)
@@ -99,7 +98,7 @@ export default function Layout({ children, params }: PageProps & { children: Rea
                   return null
                 }
               }
-          
+
               localStorage.key = function (index) {
                 try {
                   console.log('Getting key from localStorage:', index)
@@ -109,7 +108,7 @@ export default function Layout({ children, params }: PageProps & { children: Rea
                   return null
                 }
               }
-          
+
               localStorage.removeItem = function (keyString) {
                 try {
                   console.log('Removing item from localStorage:', keyString)
@@ -118,7 +117,7 @@ export default function Layout({ children, params }: PageProps & { children: Rea
                   console.error('Failed to remove item from localStorage:', e)
                 }
               }
-          
+
               localStorage.setItem = function (keyString, value) {
                 try {
                   console.log('Storing item in localStorage:', keyString, value)
@@ -129,6 +128,15 @@ export default function Layout({ children, params }: PageProps & { children: Rea
               }
             } catch (e) {
               console.error('Failed to override localStorage methods:', e)
+              window.localStorage = {
+                getItem: () => null,
+                setItem: () => {},
+                removeItem: () => {},
+                clear: () => {},
+                key: () => null,
+                length: 0,
+              }
+              console.log('Initialized no-op localStorage')
             }
           `}
         </Script>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -74,6 +74,7 @@ export default function Layout({ children, params }: PageProps & { children: Rea
         <Script id="localStorageOverride" strategy="beforeInteractive">
           {`
             console.log('overriding localStorage methods')
+            console.log('localStorage:', localStorage)
             try {
               const clear = localStorage.clear
               const getItem = localStorage.getItem

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -71,60 +71,63 @@ export default function Layout({ children, params }: PageProps & { children: Rea
       <body className={fontClassName}>
         {/* LATER-TASK add back once https://github.com/TheSGJ/nextjs-toploader/issues/66 is resolved */}
         {/* <NextTopLoader /> */}
-        <Script id="foobar" strategy="beforeInteractive">
+        <Script id="localStorageOverride" strategy="beforeInteractive">
           {`
             console.log('overriding localStorage methods')
-
-            const clear = localStorage.clear
-            const getItem = localStorage.getItem
-            const key = localStorage.key
-            const removeItem = localStorage.removeItem
-            const setItem = localStorage.setItem
+            try {
+              const clear = localStorage.clear
+              const getItem = localStorage.getItem
+              const key = localStorage.key
+              const removeItem = localStorage.removeItem
+              const setItem = localStorage.setItem
           
-            localStorage.clear = function () {
-              try {
-                clear.call(this)
-              } catch (e) {
-                console.error('Failed to clear localStorage:', e)
+              localStorage.clear = function () {
+                try {
+                  clear.call(this)
+                } catch (e) {
+                  console.error('Failed to clear localStorage:', e)
+                }
               }
-            }
           
-            localStorage.getItem = function (keyString) {
-              try {
-                console.log('Getting item from localStorage:', keyString)
-                return getItem.call(this, keyString)
-              } catch (e) {
-                console.error('Failed to retrieve item from localStorage:', e)
-                return null
+              localStorage.getItem = function (keyString) {
+                try {
+                  console.log('Getting item from localStorage:', keyString)
+                  return getItem.call(this, keyString)
+                } catch (e) {
+                  console.error('Failed to retrieve item from localStorage:', e)
+                  return null
+                }
               }
-            }
           
-            localStorage.key = function (index) {
-              try {
-                console.log('Getting key from localStorage:', index)
-                return key.call(this, index)
-              } catch (e) {
-                console.error('Failed to retrieve key from localStorage:', e)
-                return null
+              localStorage.key = function (index) {
+                try {
+                  console.log('Getting key from localStorage:', index)
+                  return key.call(this, index)
+                } catch (e) {
+                  console.error('Failed to retrieve key from localStorage:', e)
+                  return null
+                }
               }
-            }
           
-            localStorage.removeItem = function (keyString) {
-              try {
-                console.log('Removing item from localStorage:', keyString)
-                removeItem.call(this, keyString)
-              } catch (e) {
-                console.error('Failed to remove item from localStorage:', e)
+              localStorage.removeItem = function (keyString) {
+                try {
+                  console.log('Removing item from localStorage:', keyString)
+                  removeItem.call(this, keyString)
+                } catch (e) {
+                  console.error('Failed to remove item from localStorage:', e)
+                }
               }
-            }
           
-            localStorage.setItem = function (keyString, value) {
-              try {
-                console.log('Storing item in localStorage:', keyString, value)
-                setItem.call(this, keyString, value)
-              } catch (e) {
-                console.error('Failed to store item in localStorage:', e)
+              localStorage.setItem = function (keyString, value) {
+                try {
+                  console.log('Storing item in localStorage:', keyString, value)
+                  setItem.call(this, keyString, value)
+                } catch (e) {
+                  console.error('Failed to store item in localStorage:', e)
+                }
               }
+            } catch (e) {
+              console.error('Failed to override localStorage methods:', e)
             }
           `}
         </Script>

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -84,9 +84,20 @@ export function TopLevelClientLogic({
 
     // Cannot override `window.localStorage` methods directly because it is read-only.
 
+    const originalClear = Storage.prototype.clear
     const originalGetItem = Storage.prototype.getItem
+    const originalKey = Storage.prototype.key
     const originalSetItem = Storage.prototype.setItem
     const originalRemoveItem = Storage.prototype.removeItem
+
+    Storage.prototype.clear = function () {
+      try {
+        console.log('Clearing localStorage')
+        originalClear.call(localStorage)
+      } catch (e) {
+        console.error('Failed to clear localStorage:', e)
+      }
+    }
 
     Storage.prototype.getItem = function (key) {
       try {
@@ -95,6 +106,25 @@ export function TopLevelClientLogic({
       } catch (e) {
         console.error('Failed to retrieve item from localStorage:', e)
         return null
+      }
+    }
+
+    Storage.prototype.key = function (index) {
+      try {
+        console.log('Getting key from localStorage:', index)
+        return originalKey.call(localStorage, index)
+      } catch (e) {
+        console.error('Failed to retrieve key from localStorage:', e)
+        return null
+      }
+    }
+
+    Storage.prototype.removeItem = function (key) {
+      try {
+        console.log('Removing item from localStorage:', key)
+        originalRemoveItem.call(localStorage, key)
+      } catch (e) {
+        console.error('Failed to remove item from localStorage:', e)
       }
     }
 
@@ -107,14 +137,11 @@ export function TopLevelClientLogic({
       }
     }
 
-    Storage.prototype.removeItem = function (key) {
-      try {
-        console.log('Removing item from localStorage:', key)
-        originalRemoveItem.call(localStorage, key)
-      } catch (e) {
-        console.error('Failed to remove item from localStorage:', e)
-      }
-    }
+    localStorage.clear = Storage.prototype.clear
+    localStorage.getItem = Storage.prototype.getItem
+    localStorage.key = Storage.prototype.key
+    localStorage.removeItem = Storage.prototype.removeItem
+    localStorage.setItem = Storage.prototype.setItem
   }
 
   return (

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -82,8 +82,6 @@ export function TopLevelClientLogic({
   if (typeof window !== 'undefined') {
     console.log('overriding localStorage methods')
 
-    // Cannot override `window.localStorage` methods directly because it is read-only.
-
     const originalClear = Storage.prototype.clear
     const originalGetItem = Storage.prototype.getItem
     const originalKey = Storage.prototype.key

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -78,60 +78,42 @@ export function TopLevelClientLogic({
   children: React.ReactNode
   locale: SupportedLocale
 }) {
+  console.log('TopLevelClientLogic')
   if (typeof window !== 'undefined') {
-    console.log('Checking if localStorage is available')
-    const isLocalStorageAvailable = () => {
+    console.log('overriding localStorage methods')
+
+    // Cannot override `window.localStorage` methods directly because it is read-only.
+
+    const originalGetItem = Storage.prototype.getItem
+    const originalSetItem = Storage.prototype.setItem
+    const originalRemoveItem = Storage.prototype.removeItem
+
+    Storage.prototype.getItem = function (key) {
       try {
-        const testKey = '__test__'
-        window.localStorage.setItem(testKey, testKey)
-        window.localStorage.removeItem(testKey)
-        return true
+        console.log('Getting item from localStorage:', key)
+        return originalGetItem.call(localStorage, key)
       } catch (e) {
-        return false
+        console.error('Failed to retrieve item from localStorage:', e)
+        return null
       }
     }
 
-    if (isLocalStorageAvailable()) {
-      console.log('localStorage is available')
-      // Safely overriding localStorage methods
-      const originalGetItem = Storage.prototype.getItem
-      const originalSetItem = Storage.prototype.setItem
-      const originalRemoveItem = Storage.prototype.removeItem
-
-      Storage.prototype.getItem = function (key) {
-        try {
-          console.log('Getting item from localStorage:', key)
-          return originalGetItem.call(localStorage, key)
-        } catch (e) {
-          console.error('Failed to retrieve item from localStorage:', e)
-          return null // Fallback value or error handling
-        }
+    Storage.prototype.setItem = function (key, value) {
+      try {
+        console.log('Storing item in localStorage:', key, value)
+        originalSetItem.call(localStorage, key, value)
+      } catch (e) {
+        console.error('Failed to store item in localStorage:', e)
       }
+    }
 
-      Storage.prototype.setItem = function (key, value) {
-        try {
-          console.log('Storing item in localStorage:', key, value)
-          originalSetItem.call(localStorage, key, value)
-        } catch (e) {
-          console.error('Failed to store item in localStorage:', e)
-          // Fallback or error handling
-        }
+    Storage.prototype.removeItem = function (key) {
+      try {
+        console.log('Removing item from localStorage:', key)
+        originalRemoveItem.call(localStorage, key)
+      } catch (e) {
+        console.error('Failed to remove item from localStorage:', e)
       }
-
-      Storage.prototype.removeItem = function (key) {
-        try {
-          console.log('Removing item from localStorage:', key)
-          originalRemoveItem.call(localStorage, key)
-        } catch (e) {
-          console.error('Failed to remove item from localStorage:', e)
-          // Fallback or error handling
-        }
-      }
-    } else {
-      console.warn(
-        'localStorage is not available. Modifications to localStorage methods will be no-ops.',
-      )
-      // Here you could define no-op functions or implement a fallback storage solution.
     }
   }
 

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -79,68 +79,68 @@ export function TopLevelClientLogic({
   locale: SupportedLocale
 }) {
   console.log('TopLevelClientLogic')
-  if (typeof window !== 'undefined') {
-    console.log('overriding localStorage methods')
+  // if (false) {
+  // console.log('overriding localStorage methods')
 
-    const originalClear = Storage.prototype.clear
-    const originalGetItem = Storage.prototype.getItem
-    const originalKey = Storage.prototype.key
-    const originalSetItem = Storage.prototype.setItem
-    const originalRemoveItem = Storage.prototype.removeItem
+  // const originalClear = Storage.prototype.clear
+  // const originalGetItem = Storage.prototype.getItem
+  // const originalKey = Storage.prototype.key
+  // const originalSetItem = Storage.prototype.setItem
+  // const originalRemoveItem = Storage.prototype.removeItem
 
-    Storage.prototype.clear = function () {
-      try {
-        console.log('Clearing localStorage')
-        originalClear.call(localStorage)
-      } catch (e) {
-        console.error('Failed to clear localStorage:', e)
-      }
-    }
+  // Storage.prototype.clear = function () {
+  //   try {
+  //     console.log('Clearing localStorage')
+  //     originalClear.call(localStorage)
+  //   } catch (e) {
+  //     console.error('Failed to clear localStorage:', e)
+  //   }
+  // }
 
-    Storage.prototype.getItem = function (key) {
-      try {
-        console.log('Getting item from localStorage:', key)
-        return originalGetItem.call(localStorage, key)
-      } catch (e) {
-        console.error('Failed to retrieve item from localStorage:', e)
-        return null
-      }
-    }
+  // Storage.prototype.getItem = function (key) {
+  //   try {
+  //     console.log('Getting item from localStorage:', key)
+  //     return originalGetItem.call(localStorage, key)
+  //   } catch (e) {
+  //     console.error('Failed to retrieve item from localStorage:', e)
+  //     return null
+  //   }
+  // }
 
-    Storage.prototype.key = function (index) {
-      try {
-        console.log('Getting key from localStorage:', index)
-        return originalKey.call(localStorage, index)
-      } catch (e) {
-        console.error('Failed to retrieve key from localStorage:', e)
-        return null
-      }
-    }
+  // Storage.prototype.key = function (index) {
+  //   try {
+  //     console.log('Getting key from localStorage:', index)
+  //     return originalKey.call(localStorage, index)
+  //   } catch (e) {
+  //     console.error('Failed to retrieve key from localStorage:', e)
+  //     return null
+  //   }
+  // }
 
-    Storage.prototype.removeItem = function (key) {
-      try {
-        console.log('Removing item from localStorage:', key)
-        originalRemoveItem.call(localStorage, key)
-      } catch (e) {
-        console.error('Failed to remove item from localStorage:', e)
-      }
-    }
+  // Storage.prototype.removeItem = function (key) {
+  //   try {
+  //     console.log('Removing item from localStorage:', key)
+  //     originalRemoveItem.call(localStorage, key)
+  //   } catch (e) {
+  //     console.error('Failed to remove item from localStorage:', e)
+  //   }
+  // }
 
-    Storage.prototype.setItem = function (key, value) {
-      try {
-        console.log('Storing item in localStorage:', key, value)
-        originalSetItem.call(localStorage, key, value)
-      } catch (e) {
-        console.error('Failed to store item in localStorage:', e)
-      }
-    }
+  // Storage.prototype.setItem = function (key, value) {
+  //   try {
+  //     console.log('Storing item in localStorage:', key, value)
+  //     originalSetItem.call(localStorage, key, value)
+  //   } catch (e) {
+  //     console.error('Failed to store item in localStorage:', e)
+  //   }
+  // }
 
-    localStorage.clear = Storage.prototype.clear
-    localStorage.getItem = Storage.prototype.getItem
-    localStorage.key = Storage.prototype.key
-    localStorage.removeItem = Storage.prototype.removeItem
-    localStorage.setItem = Storage.prototype.setItem
-  }
+  // localStorage.clear = Storage.prototype.clear
+  // localStorage.getItem = Storage.prototype.getItem
+  // localStorage.key = Storage.prototype.key
+  // localStorage.removeItem = Storage.prototype.removeItem
+  // localStorage.setItem = Storage.prototype.setItem
+  // }
 
   return (
     <LocaleContext.Provider value={locale}>

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -78,63 +78,71 @@ export function TopLevelClientLogic({
   children: React.ReactNode
   locale: SupportedLocale
 }) {
-  console.log('TopLevelClientLogic')
+  // console.log('overriding localStorage methods')
+  // try {
+  //   const clear = localStorage.clear
+  //   const getItem = localStorage.getItem
+  //   const key = localStorage.key
+  //   const removeItem = localStorage.removeItem
+  //   const setItem = localStorage.setItem
 
-  try {
-    const clear = localStorage.clear
-    const getItem = localStorage.getItem
-    const key = localStorage.key
-    const removeItem = localStorage.removeItem
-    const setItem = localStorage.setItem
+  //   localStorage.clear = function () {
+  //     try {
+  //       clear.call(this)
+  //     } catch (e) {
+  //       console.error('Failed to clear localStorage:', e)
+  //     }
+  //   }
 
-    localStorage.clear = function () {
-      try {
-        clear.call(this)
-      } catch (e) {
-        console.error('Failed to clear localStorage:', e)
-      }
-    }
+  //   localStorage.getItem = function (keyString) {
+  //     try {
+  //       console.log('Getting item from localStorage:', keyString)
+  //       return getItem.call(this, keyString)
+  //     } catch (e) {
+  //       console.error('Failed to retrieve item from localStorage:', e)
+  //       return null
+  //     }
+  //   }
 
-    localStorage.getItem = function (keyString) {
-      try {
-        console.log('Getting item from localStorage:', keyString)
-        return getItem.call(this, keyString)
-      } catch (e) {
-        console.error('Failed to retrieve item from localStorage:', e)
-        return null
-      }
-    }
+  //   localStorage.key = function (index) {
+  //     try {
+  //       console.log('Getting key from localStorage:', index)
+  //       return key.call(this, index)
+  //     } catch (e) {
+  //       console.error('Failed to retrieve key from localStorage:', e)
+  //       return null
+  //     }
+  //   }
 
-    localStorage.key = function (index) {
-      try {
-        console.log('Getting key from localStorage:', index)
-        return key.call(this, index)
-      } catch (e) {
-        console.error('Failed to retrieve key from localStorage:', e)
-        return null
-      }
-    }
+  //   localStorage.removeItem = function (keyString) {
+  //     try {
+  //       console.log('Removing item from localStorage:', keyString)
+  //       removeItem.call(this, keyString)
+  //     } catch (e) {
+  //       console.error('Failed to remove item from localStorage:', e)
+  //     }
+  //   }
 
-    localStorage.removeItem = function (keyString) {
-      try {
-        console.log('Removing item from localStorage:', keyString)
-        removeItem.call(this, keyString)
-      } catch (e) {
-        console.error('Failed to remove item from localStorage:', e)
-      }
-    }
-
-    localStorage.setItem = function (keyString, value) {
-      try {
-        console.log('Storing item in localStorage:', keyString, value)
-        setItem.call(this, keyString, value)
-      } catch (e) {
-        console.error('Failed to store item in localStorage:', e)
-      }
-    }
-  } catch (e) {
-    console.error('Failed to override localStorage methods:', e)
-  }
+  //   localStorage.setItem = function (keyString, value) {
+  //     try {
+  //       console.log('Storing item in localStorage:', keyString, value)
+  //       setItem.call(this, keyString, value)
+  //     } catch (e) {
+  //       console.error('Failed to store item in localStorage:', e)
+  //     }
+  //   }
+  // } catch (e) {
+  //   console.error('Failed to override localStorage methods:', e)
+  //   window.localStorage = {
+  //     getItem: () => null,
+  //     setItem: () => {},
+  //     removeItem: () => {},
+  //     clear: () => {},
+  //     key: () => null,
+  //     length: 0,
+  //   }
+  //   console.log('Initialized no-op localStorage:')
+  // }
 
   return (
     <LocaleContext.Provider value={locale}>

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -78,6 +78,63 @@ export function TopLevelClientLogic({
   children: React.ReactNode
   locale: SupportedLocale
 }) {
+  if (typeof window !== 'undefined') {
+    console.log('Checking if localStorage is available')
+    const isLocalStorageAvailable = () => {
+      try {
+        const testKey = '__test__'
+        window.localStorage.setItem(testKey, testKey)
+        window.localStorage.removeItem(testKey)
+        return true
+      } catch (e) {
+        return false
+      }
+    }
+
+    if (isLocalStorageAvailable()) {
+      console.log('localStorage is available')
+      // Safely overriding localStorage methods
+      const originalGetItem = Storage.prototype.getItem
+      const originalSetItem = Storage.prototype.setItem
+      const originalRemoveItem = Storage.prototype.removeItem
+
+      Storage.prototype.getItem = function (key) {
+        try {
+          console.log('Getting item from localStorage:', key)
+          return originalGetItem.call(localStorage, key)
+        } catch (e) {
+          console.error('Failed to retrieve item from localStorage:', e)
+          return null // Fallback value or error handling
+        }
+      }
+
+      Storage.prototype.setItem = function (key, value) {
+        try {
+          console.log('Storing item in localStorage:', key, value)
+          originalSetItem.call(localStorage, key, value)
+        } catch (e) {
+          console.error('Failed to store item in localStorage:', e)
+          // Fallback or error handling
+        }
+      }
+
+      Storage.prototype.removeItem = function (key) {
+        try {
+          console.log('Removing item from localStorage:', key)
+          originalRemoveItem.call(localStorage, key)
+        } catch (e) {
+          console.error('Failed to remove item from localStorage:', e)
+          // Fallback or error handling
+        }
+      }
+    } else {
+      console.warn(
+        'localStorage is not available. Modifications to localStorage methods will be no-ops.',
+      )
+      // Here you could define no-op functions or implement a fallback storage solution.
+    }
+  }
+
   return (
     <LocaleContext.Provider value={locale}>
       <ThirdwebProvider

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -78,69 +78,63 @@ export function TopLevelClientLogic({
   children: React.ReactNode
   locale: SupportedLocale
 }) {
-  // console.log('TopLevelClientLogic')
-  // if (false) {
-  // console.log('overriding localStorage methods')
+  console.log('TopLevelClientLogic')
 
-  // const originalClear = Storage.prototype.clear
-  // const originalGetItem = Storage.prototype.getItem
-  // const originalKey = Storage.prototype.key
-  // const originalSetItem = Storage.prototype.setItem
-  // const originalRemoveItem = Storage.prototype.removeItem
+  try {
+    const clear = localStorage.clear
+    const getItem = localStorage.getItem
+    const key = localStorage.key
+    const removeItem = localStorage.removeItem
+    const setItem = localStorage.setItem
 
-  // Storage.prototype.clear = function () {
-  //   try {
-  //     console.log('Clearing localStorage')
-  //     originalClear.call(localStorage)
-  //   } catch (e) {
-  //     console.error('Failed to clear localStorage:', e)
-  //   }
-  // }
+    localStorage.clear = function () {
+      try {
+        clear.call(this)
+      } catch (e) {
+        console.error('Failed to clear localStorage:', e)
+      }
+    }
 
-  // Storage.prototype.getItem = function (key) {
-  //   try {
-  //     console.log('Getting item from localStorage:', key)
-  //     return originalGetItem.call(localStorage, key)
-  //   } catch (e) {
-  //     console.error('Failed to retrieve item from localStorage:', e)
-  //     return null
-  //   }
-  // }
+    localStorage.getItem = function (keyString) {
+      try {
+        console.log('Getting item from localStorage:', keyString)
+        return getItem.call(this, keyString)
+      } catch (e) {
+        console.error('Failed to retrieve item from localStorage:', e)
+        return null
+      }
+    }
 
-  // Storage.prototype.key = function (index) {
-  //   try {
-  //     console.log('Getting key from localStorage:', index)
-  //     return originalKey.call(localStorage, index)
-  //   } catch (e) {
-  //     console.error('Failed to retrieve key from localStorage:', e)
-  //     return null
-  //   }
-  // }
+    localStorage.key = function (index) {
+      try {
+        console.log('Getting key from localStorage:', index)
+        return key.call(this, index)
+      } catch (e) {
+        console.error('Failed to retrieve key from localStorage:', e)
+        return null
+      }
+    }
 
-  // Storage.prototype.removeItem = function (key) {
-  //   try {
-  //     console.log('Removing item from localStorage:', key)
-  //     originalRemoveItem.call(localStorage, key)
-  //   } catch (e) {
-  //     console.error('Failed to remove item from localStorage:', e)
-  //   }
-  // }
+    localStorage.removeItem = function (keyString) {
+      try {
+        console.log('Removing item from localStorage:', keyString)
+        removeItem.call(this, keyString)
+      } catch (e) {
+        console.error('Failed to remove item from localStorage:', e)
+      }
+    }
 
-  // Storage.prototype.setItem = function (key, value) {
-  //   try {
-  //     console.log('Storing item in localStorage:', key, value)
-  //     originalSetItem.call(localStorage, key, value)
-  //   } catch (e) {
-  //     console.error('Failed to store item in localStorage:', e)
-  //   }
-  // }
-
-  // localStorage.clear = Storage.prototype.clear
-  // localStorage.getItem = Storage.prototype.getItem
-  // localStorage.key = Storage.prototype.key
-  // localStorage.removeItem = Storage.prototype.removeItem
-  // localStorage.setItem = Storage.prototype.setItem
-  // }
+    localStorage.setItem = function (keyString, value) {
+      try {
+        console.log('Storing item in localStorage:', keyString, value)
+        setItem.call(this, keyString, value)
+      } catch (e) {
+        console.error('Failed to store item in localStorage:', e)
+      }
+    }
+  } catch (e) {
+    console.error('Failed to override localStorage methods:', e)
+  }
 
   return (
     <LocaleContext.Provider value={locale}>

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -78,7 +78,7 @@ export function TopLevelClientLogic({
   children: React.ReactNode
   locale: SupportedLocale
 }) {
-  console.log('TopLevelClientLogic')
+  // console.log('TopLevelClientLogic')
   // if (false) {
   // console.log('overriding localStorage methods')
 


### PR DESCRIPTION
Closes #733  

## What changed? Why?

This PR wraps the Local Storage functions with a try-catch block. Why? Because we want to prevent the app from crashing on certain browsers (specifically Safari with all cookies blocked).

## UI changes


## PlanetScale Deploy Request

No PlanetScale schema changes.

## Notes to reviewers

N/A

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
