### PR TITLE
[bug] fix bug related to Capitol Canary SMS explicit opt-outs 

### DIFF
--- a/src/actions/actionUpdateUserProfile.ts
+++ b/src/actions/actionUpdateUserProfile.ts
@@ -168,9 +168,11 @@ async function handleCapitolCanaryAdvocateUpsert(
     (!primaryUserEmailAddress ||
       oldUser.primaryUserEmailAddress.emailAddress !== primaryUserEmailAddress.emailAddress)
   // `hasChangedPhone` is true if an old phone number exists and the new phone number is different from the old phone number.
+  // However, we only want to explicitly opt-out if the old number was opted in to work around Capitol Canary limitations.
   const hasChangedPhone =
     !!oldUser.phoneNumber &&
-    (!updatedUser.phoneNumber || oldUser.phoneNumber !== updatedUser.phoneNumber)
+    (!updatedUser.phoneNumber || oldUser.phoneNumber !== updatedUser.phoneNumber) &&
+    oldUser.hasOptedInToSms
   if (hasChangedEmail || hasChangedPhone) {
     const unsubscribePayload: UpsertAdvocateInCapitolCanaryPayloadRequirements = {
       campaignId: getCapitolCanaryCampaignID(CapitolCanaryCampaignName.DEFAULT_SUBSCRIBER),


### PR DESCRIPTION
relates to internal issue 16

## What changed? Why?

This PR fixes a bug(?) related to the Capitol Canary SMS opt-outs where, if a user is inputting a new phone number, then we only want to _explicitly_ opt-out a user's old phone number from SMS if their old phone number was _explicitly_ opted-in. Why? This is also to work around some Capitol Canary limitations around opt-ins/outs.

## UI changes

No UI changes.

## PlanetScale Deploy Request

No PlanetScale schema changes.

## Notes to reviewers

No notes.

## How has it been tested?

- [X] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
