### PR TITLE
[feature] implement script to backfill SMS reply flag for SWC users

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -3,7 +3,10 @@ import { serve } from 'inngest/next'
 import { airdropNFTWithInngest } from '@/inngest/functions/airdropNFT/airdropNFT'
 import { backfillNFTWithInngest } from '@/inngest/functions/backfillNFT'
 import { backfillNFTInngestCronJob } from '@/inngest/functions/backfillNFTCronJob'
-import { backfillSMSOptInReplyWithInngest } from '@/inngest/functions/capitolCanary/backfillSMSOptInReply'
+import {
+  backfillSMSOptInReplyWithInngest,
+  backfillSMSOptInReplyWithInngestUpdateBatchOfUsers,
+} from '@/inngest/functions/capitolCanary/backfillSMSOptInReply'
 import { checkSMSOptInReplyWithInngest } from '@/inngest/functions/capitolCanary/checkSMSOptInReply'
 import { emailRepViaCapitolCanaryWithInngest } from '@/inngest/functions/capitolCanary/emailRepViaCapitolCanary'
 import { upsertAdvocateInCapitolCanaryWithInngest } from '@/inngest/functions/capitolCanary/upsertAdvocateInCapitolCanary'
@@ -30,6 +33,7 @@ export const { GET, POST, PUT } = serve({
     emailRepViaCapitolCanaryWithInngest,
     checkSMSOptInReplyWithInngest,
     backfillSMSOptInReplyWithInngest,
+    backfillSMSOptInReplyWithInngestUpdateBatchOfUsers,
     airdropNFTWithInngest,
     cleanupPostalCodesWithInngest,
     monitorBaseETHBalances,

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -3,6 +3,7 @@ import { serve } from 'inngest/next'
 import { airdropNFTWithInngest } from '@/inngest/functions/airdropNFT/airdropNFT'
 import { backfillNFTWithInngest } from '@/inngest/functions/backfillNFT'
 import { backfillNFTInngestCronJob } from '@/inngest/functions/backfillNFTCronJob'
+import { backfillSMSOptInReplyWithInngest } from '@/inngest/functions/capitolCanary/backfillSMSOptInReply'
 import { checkSMSOptInReplyWithInngest } from '@/inngest/functions/capitolCanary/checkSMSOptInReply'
 import { emailRepViaCapitolCanaryWithInngest } from '@/inngest/functions/capitolCanary/emailRepViaCapitolCanary'
 import { upsertAdvocateInCapitolCanaryWithInngest } from '@/inngest/functions/capitolCanary/upsertAdvocateInCapitolCanary'
@@ -28,6 +29,7 @@ export const { GET, POST, PUT } = serve({
     upsertAdvocateInCapitolCanaryWithInngest,
     emailRepViaCapitolCanaryWithInngest,
     checkSMSOptInReplyWithInngest,
+    backfillSMSOptInReplyWithInngest,
     airdropNFTWithInngest,
     cleanupPostalCodesWithInngest,
     monitorBaseETHBalances,

--- a/src/inngest/functions/capitolCanary/backfillSMSOptInReply.ts
+++ b/src/inngest/functions/capitolCanary/backfillSMSOptInReply.ts
@@ -15,6 +15,7 @@ export const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_FUNCTION_ID =
 export const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_EVENT_NAME =
   'capitol.canary/backfill.sms.opt.in.reply'
 
+// TODO: fan-out.
 export const backfillSMSOptInReplyWithInngest = inngest.createFunction(
   {
     id: CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_FUNCTION_ID,

--- a/src/inngest/functions/capitolCanary/backfillSMSOptInReply.ts
+++ b/src/inngest/functions/capitolCanary/backfillSMSOptInReply.ts
@@ -4,18 +4,59 @@ import { onFailureCapitolCanary } from '@/inngest/functions/capitolCanary/onFail
 import { inngest } from '@/inngest/inngest'
 import {
   fetchAdvocatesFromCapitolCanary,
+  FetchAdvocatesFromCapitolCanaryRequest,
   formatBackfillSMSOptInReplyRequest,
 } from '@/utils/server/capitolCanary/fetchAdvocates'
 import { prismaClient } from '@/utils/server/prismaClient'
 
 const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_RETRY_LIMIT = 10
+const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_PAGE_INTERVALS = 100
 
 export const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_FUNCTION_ID =
   'capitol-canary.backfill-sms-opt-in-reply'
 export const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_EVENT_NAME =
   'capitol.canary/backfill.sms.opt.in.reply'
 
-// TODO: fan-out.
+/**
+ * Fetches the advocates from Capitol Canary and returns the advocate IDs with subscribed phones.
+ * We return the minimal information instead of returning the full advocate payload from the step functions because
+ *   there is a 4MB memory limit for Inngest functions in which the memory usage is summed across all steps in a function.
+ *
+ * @param request
+ * @returns if there are advocates for a page and the advocate IDs with subscribed phones
+ */
+async function fetchMinimalSMSAdvocatesFromCapitolCanary(
+  request: FetchAdvocatesFromCapitolCanaryRequest,
+) {
+  const fullAdvocates = await fetchAdvocatesFromCapitolCanary(request)
+  const minimalAdvocateInformation: {
+    hasAdvocatesForPage: boolean
+    advocateIdsWithSubscribedPhones: number[]
+  } = { hasAdvocatesForPage: false, advocateIdsWithSubscribedPhones: [] }
+
+  if (fullAdvocates.data.length > 0) {
+    minimalAdvocateInformation.hasAdvocatesForPage = true
+  } else {
+    return minimalAdvocateInformation
+  }
+
+  for (const fullAdvocate of fullAdvocates.data) {
+    for (const phone of fullAdvocate.phones) {
+      if (phone.subscribed) {
+        minimalAdvocateInformation.advocateIdsWithSubscribedPhones.push(fullAdvocate.id)
+        break
+      }
+    }
+  }
+
+  return minimalAdvocateInformation
+}
+
+/**
+ * This function is used to backfill the `hasRepliedToOptInSms` field for users who have replied to the SMS opt-in message.
+ * We fan-out the process in page intervals of 100, where each batch will process 10500 advocates. We process each batch in parallel.
+ * Fanning-out is performed to avoid hitting the 1000 step limit per Inngest function.
+ */
 export const backfillSMSOptInReplyWithInngest = inngest.createFunction(
   {
     id: CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_FUNCTION_ID,
@@ -30,63 +71,107 @@ export const backfillSMSOptInReplyWithInngest = inngest.createFunction(
         cause: fetchRequest,
       })
     }
-    let advocates = await step.run(
-      `capitol-canary.backfill-sms-opt-in-reply.fetch-advocates-${fetchRequest.page!}`,
+    let hasAdvocatesForPage = await step.run(
+      `capitol-canary.backfill-sms-opt-in-reply.check-advocates-for-page-${fetchRequest.page!}`,
       async () => {
-        return fetchAdvocatesFromCapitolCanary(fetchRequest)
+        const fullAdvocates = await fetchAdvocatesFromCapitolCanary(fetchRequest)
+        if (fullAdvocates.data.length > 0) {
+          return true
+        }
+        return false
+      },
+    )
+
+    while (hasAdvocatesForPage) {
+      await step.sendEvent(
+        `capitol-canary.backfill-sms-opt-in-reply.send-batch-for-page-${fetchRequest.page!}`,
+        {
+          name: CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_UPDATE_BATCH_OF_USERS_EVENT_NAME,
+          data: {
+            page: fetchRequest.page!,
+          },
+        },
+      )
+
+      fetchRequest.page! += CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_PAGE_INTERVALS
+      hasAdvocatesForPage = await step.run(
+        `capitol-canary.backfill-sms-opt-in-reply.check-advocates-for-page-${fetchRequest.page!}`,
+        async () => {
+          const fullAdvocates = await fetchAdvocatesFromCapitolCanary(fetchRequest)
+          if (fullAdvocates.data.length > 0) {
+            return true
+          }
+          return false
+        },
+      )
+    }
+  },
+)
+
+const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_PAGES_FOR_BATCH = 105
+
+export const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_UPDATE_BATCH_OF_USERS_FUNCTION_ID =
+  'capitol-canary.backfill-sms-opt-in-reply.update-batch-of-users'
+export const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_UPDATE_BATCH_OF_USERS_EVENT_NAME =
+  'capitol.canary/backfill.sms.opt.in.reply/update.batch.of.users'
+
+/**
+ * In case you want to process a specific batch of users, you can use this function.
+ * Just pass in `page` as a data parameter in the event.
+ */
+export const backfillSMSOptInReplyWithInngestUpdateBatchOfUsers = inngest.createFunction(
+  {
+    id: CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_UPDATE_BATCH_OF_USERS_FUNCTION_ID,
+    retries: CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_RETRY_LIMIT,
+    onFailure: onFailureCapitolCanary,
+  },
+  { event: CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_UPDATE_BATCH_OF_USERS_EVENT_NAME },
+  async ({ event, step }) => {
+    const initialPage = event.data.page as number
+    const pageOffset = initialPage
+    const fetchRequest = formatBackfillSMSOptInReplyRequest({ page: initialPage })
+    if (fetchRequest instanceof Error) {
+      throw new NonRetriableError(fetchRequest.message, {
+        cause: fetchRequest,
+      })
+    }
+    let minimalAdvocates = await step.run(
+      `capitol-canary.backfill-sms-opt-in-reply.fetch-minimal-advocates-for-page-${fetchRequest.page!}`,
+      async () => {
+        return fetchMinimalSMSAdvocatesFromCapitolCanary(fetchRequest)
       },
     )
 
     let totalUsersProcessed = 0
-    // Break condition.
-    while (advocates.data.length > 0) {
+    while (
+      minimalAdvocates.hasAdvocatesForPage &&
+      fetchRequest.page! - pageOffset < CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_PAGES_FOR_BATCH
+    ) {
       totalUsersProcessed += await step.run(
-        `capitol-canary.backfill-sms-opt-in-reply.process-advocates-${fetchRequest.page!}`,
+        `capitol-canary.backfill-sms-opt-in-reply.process-advocates-for-page-${fetchRequest.page!}`,
         async () => {
-          let numUsersProcessed = 0
-          for (const advocate of advocates.data) {
-            const matchingUsers = await prismaClient.user.findMany({
-              where: {
-                capitolCanaryAdvocateId: advocate.id, // We only care about matching by advocate ID because the "SMS reply" flag is user-specific, not phone-number-specific.
-              },
-            })
-            if (matchingUsers.length === 0) {
-              continue
-            }
-
-            let hasRepliedToOptInSms = false
-            for (const phone of advocate.phones) {
-              if (phone.subscribed) {
-                hasRepliedToOptInSms = true
-                break
-              }
-            }
-            if (!hasRepliedToOptInSms) {
-              continue
-            }
-
-            await prismaClient.user.updateMany({
-              where: {
-                id: {
-                  in: matchingUsers.map(user => user.id),
-                },
-              },
-              data: {
-                hasRepliedToOptInSms: true,
-              },
-            })
-            numUsersProcessed += matchingUsers.length
+          if (minimalAdvocates.advocateIdsWithSubscribedPhones.length === 0) {
+            return 0
           }
-          return numUsersProcessed
+          await prismaClient.user.updateMany({
+            where: {
+              capitolCanaryAdvocateId: {
+                in: minimalAdvocates.advocateIdsWithSubscribedPhones, // We only care about matching by advocate ID because the "SMS reply" flag is user-specific, not phone-number-specific.
+              },
+            },
+            data: {
+              hasRepliedToOptInSms: true,
+            },
+          })
+          return minimalAdvocates.advocateIdsWithSubscribedPhones.length
         },
       )
 
-      // Fetch next page.
       fetchRequest.page! += 1
-      advocates = await step.run(
-        `capitol-canary.backfill-sms-opt-in-reply.fetch-advocates-${fetchRequest.page!}`,
+      minimalAdvocates = await step.run(
+        `capitol-canary.backfill-sms-opt-in-reply.fetch-minimal-advocates-for-page-${fetchRequest.page!}`,
         async () => {
-          return fetchAdvocatesFromCapitolCanary(fetchRequest)
+          return fetchMinimalSMSAdvocatesFromCapitolCanary(fetchRequest)
         },
       )
     }

--- a/src/inngest/functions/capitolCanary/backfillSMSOptInReply.ts
+++ b/src/inngest/functions/capitolCanary/backfillSMSOptInReply.ts
@@ -12,9 +12,9 @@ import { prismaClient } from '@/utils/server/prismaClient'
 const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_RETRY_LIMIT = 10
 const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_PAGE_INTERVALS = 100
 
-export const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_FUNCTION_ID =
+const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_FUNCTION_ID =
   'capitol-canary.backfill-sms-opt-in-reply'
-export const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_EVENT_NAME =
+const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_EVENT_NAME =
   'capitol.canary/backfill.sms.opt.in.reply'
 
 /**
@@ -110,9 +110,9 @@ export const backfillSMSOptInReplyWithInngest = inngest.createFunction(
 
 const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_PAGES_FOR_BATCH = 105
 
-export const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_UPDATE_BATCH_OF_USERS_FUNCTION_ID =
+const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_UPDATE_BATCH_OF_USERS_FUNCTION_ID =
   'capitol-canary.backfill-sms-opt-in-reply.update-batch-of-users'
-export const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_UPDATE_BATCH_OF_USERS_EVENT_NAME =
+const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_UPDATE_BATCH_OF_USERS_EVENT_NAME =
   'capitol.canary/backfill.sms.opt.in.reply/update.batch.of.users'
 
 /**

--- a/src/inngest/functions/capitolCanary/backfillSMSOptInReply.ts
+++ b/src/inngest/functions/capitolCanary/backfillSMSOptInReply.ts
@@ -1,0 +1,95 @@
+import { NonRetriableError } from 'inngest'
+
+import { onFailureCapitolCanary } from '@/inngest/functions/capitolCanary/onFailureCapitolCanary'
+import { inngest } from '@/inngest/inngest'
+import {
+  backfillCheckSMSOptInReplyRequest,
+  fetchAdvocatesFromCapitolCanary,
+} from '@/utils/server/capitolCanary/fetchAdvocates'
+import { prismaClient } from '@/utils/server/prismaClient'
+
+const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_RETRY_LIMIT = 10
+
+export const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_FUNCTION_ID =
+  'capitol-canary.backfill-sms-opt-in-reply'
+export const CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_EVENT_NAME =
+  'capitol.canary/backfill.sms.opt.in.reply'
+
+export const backfillSMSOptInReplyWithInngest = inngest.createFunction(
+  {
+    id: CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_FUNCTION_ID,
+    retries: CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_RETRY_LIMIT,
+    onFailure: onFailureCapitolCanary,
+  },
+  { event: CAPITOL_CANARY_BACKFILL_SMS_OPT_IN_REPLY_EVENT_NAME },
+  async ({ step }) => {
+    const fetchRequest = backfillCheckSMSOptInReplyRequest({ page: 1 })
+    if (fetchRequest instanceof Error) {
+      throw new NonRetriableError(fetchRequest.message, {
+        cause: fetchRequest,
+      })
+    }
+    let advocates = await step.run(
+      `capitol-canary.check-sms-opt-in-reply.fetch-advocates-${fetchRequest.page!}`,
+      async () => {
+        return fetchAdvocatesFromCapitolCanary(fetchRequest)
+      },
+    )
+
+    let totalUsersProcessed = 0
+    // Break condition.
+    while (advocates.data.length > 0) {
+      totalUsersProcessed += await step.run(
+        `capitol-canary.check-sms-opt-in-reply.process-advocates-${fetchRequest.page!}`,
+        async () => {
+          let numUsersProcessed = 0
+          for (const advocate of advocates.data) {
+            const matchingUsers = await prismaClient.user.findMany({
+              where: {
+                capitolCanaryAdvocateId: advocate.id, // We only care about matching by advocate ID because the "SMS reply" flag is user-specific, not phone-number-specific.
+              },
+            })
+            if (matchingUsers.length === 0) {
+              continue
+            }
+
+            let hasRepliedToOptInSms = false
+            for (const phone of advocate.phones) {
+              if (phone.subscribed) {
+                hasRepliedToOptInSms = true
+                break
+              }
+            }
+            if (!hasRepliedToOptInSms) {
+              continue
+            }
+
+            await prismaClient.user.updateMany({
+              where: {
+                id: {
+                  in: matchingUsers.map(user => user.id),
+                },
+              },
+              data: {
+                hasRepliedToOptInSms: true,
+              },
+            })
+            numUsersProcessed += matchingUsers.length
+          }
+          return numUsersProcessed
+        },
+      )
+
+      // Fetch next page.
+      fetchRequest.page! += 1
+      advocates = await step.run(
+        `capitol-canary.check-sms-opt-in-reply.fetch-advocates-${fetchRequest.page!}`,
+        async () => {
+          return fetchAdvocatesFromCapitolCanary(fetchRequest)
+        },
+      )
+    }
+
+    return totalUsersProcessed
+  },
+)

--- a/src/utils/server/capitolCanary/fetchAdvocates.ts
+++ b/src/utils/server/capitolCanary/fetchAdvocates.ts
@@ -1,4 +1,7 @@
-import { CheckSMSOptInReplyPayloadRequirements } from '@/utils/server/capitolCanary/payloadRequirements'
+import {
+  BackfillSMSOptInReplyPayloadRequirements,
+  CheckSMSOptInReplyPayloadRequirements,
+} from '@/utils/server/capitolCanary/payloadRequirements'
 import { sendCapitolCanaryRequest } from '@/utils/server/capitolCanary/sendCapitolCanaryRequest'
 
 const CAPITOL_CANARY_CREATE_ADVOCATE_API_URL = 'https://api.phone2action.com/2.0/advocates'
@@ -80,6 +83,20 @@ export function formatCheckSMSOptInReplyRequest(request: CheckSMSOptInReplyPaylo
   if (request.campaignId) {
     formattedRequest.campaignid = request.campaignId
   }
+  return formattedRequest
+}
+
+export function backfillCheckSMSOptInReplyRequest(
+  request: BackfillSMSOptInReplyPayloadRequirements,
+) {
+  if (!request.page) {
+    return new Error('page number is required')
+  }
+
+  const formattedRequest: FetchAdvocatesFromCapitolCanaryRequest = {
+    page: request.page,
+  }
+
   return formattedRequest
 }
 

--- a/src/utils/server/capitolCanary/fetchAdvocates.ts
+++ b/src/utils/server/capitolCanary/fetchAdvocates.ts
@@ -86,7 +86,7 @@ export function formatCheckSMSOptInReplyRequest(request: CheckSMSOptInReplyPaylo
   return formattedRequest
 }
 
-export function backfillCheckSMSOptInReplyRequest(
+export function formatBackfillSMSOptInReplyRequest(
   request: BackfillSMSOptInReplyPayloadRequirements,
 ) {
   if (!request.page) {

--- a/src/utils/server/capitolCanary/fetchAdvocates.ts
+++ b/src/utils/server/capitolCanary/fetchAdvocates.ts
@@ -58,7 +58,7 @@ type FetchAdvocatesFromCapitolCanaryMembership = {
   source: string
 }
 
-export type FetchAdvocatesFromCapitolCanaryContact = {
+type FetchAdvocatesFromCapitolCanaryContact = {
   id: number
   address: string
   subscribed: boolean

--- a/src/utils/server/capitolCanary/fetchAdvocates.ts
+++ b/src/utils/server/capitolCanary/fetchAdvocates.ts
@@ -6,7 +6,7 @@ import { sendCapitolCanaryRequest } from '@/utils/server/capitolCanary/sendCapit
 
 const CAPITOL_CANARY_CREATE_ADVOCATE_API_URL = 'https://api.phone2action.com/2.0/advocates'
 
-type FetchAdvocatesFromCapitolCanaryRequest = {
+export type FetchAdvocatesFromCapitolCanaryRequest = {
   updatedSince?: number
   page?: number
   campaignid?: number
@@ -58,7 +58,7 @@ type FetchAdvocatesFromCapitolCanaryMembership = {
   source: string
 }
 
-type FetchAdvocatesFromCapitolCanaryContact = {
+export type FetchAdvocatesFromCapitolCanaryContact = {
   id: number
   address: string
   subscribed: boolean

--- a/src/utils/server/capitolCanary/payloadRequirements.ts
+++ b/src/utils/server/capitolCanary/payloadRequirements.ts
@@ -25,3 +25,7 @@ export interface CheckSMSOptInReplyPayloadRequirements {
   campaignId?: CapitolCanaryCampaignId | SandboxCapitolCanaryCampaignId
   user: User
 }
+
+export interface BackfillSMSOptInReplyPayloadRequirements {
+  page: number
+}


### PR DESCRIPTION
closes internal issue 16

## What changed? Why?

This PR implements an Inngest script that will backfill the SMS reply flag for the SWC users using all the Capitol Canary advocate information. Why? Since [this PR](https://github.com/Stand-With-Crypto/swc-web/pull/738) is already merged, we should update the SWC users that have already existed before the PR.

## UI changes

No UI changes.

## PlanetScale Deploy Request

No PlanetScale schema changes.

## Notes to reviewers

This script is implemented with the limitations of Inngest and Vercel in mind. This script is also design to run ad-hoc.

## How has it been tested?

Used a testing database that contains production information and the production Capitol Canary API credentials.

![Screenshot 2024-04-03 at 12 49 56 PM](https://github.com/Stand-With-Crypto/swc-web/assets/135282747/f7404f5e-1505-4f88-bb60-402b2ae2afe6)

- [X] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
