### PR TITLE
[feature] style "Finish your profile" dialog links as purple

### DIFF
--- a/src/components/app/updateUserProfileForm/step1.tsx
+++ b/src/components/app/updateUserProfileForm/step1.tsx
@@ -212,7 +212,7 @@ export function UpdateUserProfileForm({
                       <FormDescription>
                         By checking this box, I agree to become a Stand With Crypto Alliance member.{' '}
                         <SWCMembershipDialog>
-                          <button>Learn More</button>
+                          <button className="text-primary-cta">Learn More</button>
                         </SWCMembershipDialog>
                         .
                       </FormDescription>
@@ -239,7 +239,7 @@ export function UpdateUserProfileForm({
                         messages about Stand With Crypto at the phone number provided. Reply STOP to
                         stop. Msg and data rates may apply. See{' '}
                         <PrivacyPolicyDialog>
-                          <button>Privacy Policy</button>
+                          <button className="text-primary-cta">Privacy Policy</button>
                         </PrivacyPolicyDialog>
                         .
                       </FormDescription>


### PR DESCRIPTION
closes #582 

## What changed? Why?

This small PR changes the style of the "Finish your profile" dialog links to be purple. Why? So that it is more obvious that those specific words are clickable and would show a dialog. However, we do not underline because underlines are usually recognized as links that lead to a new page.

## UI changes

_OLD_:

https://github.com/Stand-With-Crypto/swc-web/assets/135282747/746b102a-328e-4022-b31e-425ed24c4e28

_NEW_:

https://github.com/Stand-With-Crypto/swc-web/assets/135282747/6230c269-7ded-4812-ae85-646f640b35f7

## PlanetScale Deploy Request

No PlanetScale schema changes.

## Notes to reviewers

No specific notes.

## How has it been tested?

- [X] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
