### PR TITLE
fix crash that occurs when api fails

### DIFF
--- a/src/components/app/dtsiAvatar.tsx
+++ b/src/components/app/dtsiAvatar.tsx
@@ -36,7 +36,7 @@ export const DTSIAvatar: React.FC<
   return (
     <InitialsAvatar
       className="rounded-md"
-      firstInitial={(person.firstNickname || person.firstName || '').slice(0, 1)}
+      firstInitial={(person.firstNickname || person.firstName).slice(0, 1)}
       lastInitial={person.lastName.slice(0, 1)}
       {...props}
     />

--- a/src/hooks/useGetDTSIPeopleFromAddress.ts
+++ b/src/hooks/useGetDTSIPeopleFromAddress.ts
@@ -22,16 +22,19 @@ async function getDTSIPeopleFromCongressionalDistrict(result: CongressionalDistr
 
   const data = await fetchReq(apiUrls.dtsiPeopleByCongressionalDistrict(result))
     .then(res => res.json())
+    .then(data => data as DTSIPeopleByCongressionalDistrictQueryResult)
     .catch(e => {
       catchUnexpectedServerErrorAndTriggerToast(e)
       return { notFoundReason: 'UNEXPECTED_ERROR' as const }
     })
-
+  if ('notFoundReason' in data) {
+    return data
+  }
   if (!data) {
     return { notFoundReason: 'MISSING_FROM_DTSI' as const }
   }
 
-  const dtsiPerson = data as DTSIPeopleByCongressionalDistrictQueryResult
+  const dtsiPerson = data
   return { ...result, dtsiPerson } as DTSIPeopleFromCongressionalDistrict
 }
 


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->
fixes https://stand-with-crypto.sentry.io/issues/5055966004/?environment=production&project=4506490717470720&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=3

## What changed? Why?
Bug with our type definitions

## How has it been tested?

- [ \X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
