### PR TITLE
fix: remove setting the callback name for use-places-autocomplete

### DIFF
--- a/src/components/ui/googlePlacesSelect/index.tsx
+++ b/src/components/ui/googlePlacesSelect/index.tsx
@@ -8,8 +8,6 @@ import { useGoogleMapsScript } from '@/hooks/useGoogleMapsScript'
 import { cn } from '@/utils/web/cn'
 import { GooglePlaceAutocompletePrediction } from '@/utils/web/googlePlaceUtils'
 
-const CALLBACK_NAME = 'PLACES_AUTOCOMPLETE'
-
 export type GooglePlacesSelectProps = {
   value: GooglePlaceAutocompletePrediction | null
   onChange: (val: GooglePlaceAutocompletePrediction | null) => void
@@ -28,14 +26,13 @@ export const GooglePlacesSelect = React.forwardRef<
     setValue,
     init,
   } = usePlacesAutocomplete({
-    callbackName: CALLBACK_NAME,
     // note on why we aren't restricting to just addresses https://stackoverflow.com/a/65206036
     requestOptions: {
       locationBias: 'IP_BIAS',
       language: 'en',
     },
   })
-  const scriptStatus = useGoogleMapsScript(CALLBACK_NAME)
+  const scriptStatus = useGoogleMapsScript()
 
   useEffect(() => {
     if (scriptStatus === 'ready') {

--- a/src/hooks/useGoogleMapsScript.ts
+++ b/src/hooks/useGoogleMapsScript.ts
@@ -7,12 +7,12 @@ const NEXT_PUBLIC_GOOGLE_PLACES_API_KEY = requiredEnv(
 )
 
 /**
- * See https://stackoverflow.com/a/75212692 for why we default de callback to `Function.prototype`
+ * See https://stackoverflow.com/a/75212692 for why we set callback to `Function.prototype`
  */
-export function getGoogleMapsScriptSrc(callbackFnName = 'Function.prototype') {
-  return `https://maps.googleapis.com/maps/api/js?key=${NEXT_PUBLIC_GOOGLE_PLACES_API_KEY}&libraries=places&callback=${callbackFnName}`
+export function getGoogleMapsScriptSrc() {
+  return `https://maps.googleapis.com/maps/api/js?key=${NEXT_PUBLIC_GOOGLE_PLACES_API_KEY}&libraries=places&callback=Function.prototype`
 }
 
-export function useGoogleMapsScript(callbackFnName?: string) {
-  return useScript(getGoogleMapsScriptSrc(callbackFnName))
+export function useGoogleMapsScript() {
+  return useScript(getGoogleMapsScriptSrc())
 }

--- a/src/hooks/usePlacesAutocompleteAddress.ts
+++ b/src/hooks/usePlacesAutocompleteAddress.ts
@@ -3,8 +3,6 @@ import usePlacesAutocomplete from 'use-places-autocomplete'
 
 import { useGoogleMapsScript } from '@/hooks/useGoogleMapsScript'
 
-const CALLBACK_NAME = 'PLACES_AUTOCOMPLETE'
-
 /**
  * Wraps `usePlacesAutocomplete` to fetch the suggestions for a given address without relying on user input
  */
@@ -15,7 +13,6 @@ export function usePlacesAutocompleteAddress(address: string) {
     setValue,
     ready,
   } = usePlacesAutocomplete({
-    callbackName: CALLBACK_NAME,
     // note on why we aren't restricting to just addresses https://stackoverflow.com/a/65206036
     requestOptions: {
       locationBias: 'IP_BIAS',
@@ -25,7 +22,7 @@ export function usePlacesAutocompleteAddress(address: string) {
   // the library returns a loading prop but it appears to always be false. Status will be an empty string unless it returns something
   const loading = !status
 
-  const scriptStatus = useGoogleMapsScript(CALLBACK_NAME)
+  const scriptStatus = useGoogleMapsScript()
 
   useEffect(() => {
     if (scriptStatus === 'ready') {


### PR DESCRIPTION
closes #748
fixes PROD-SWC-WEB-1NK

## What changed? Why?

Since we now add the google maps script without `PLACES_AUTOCOMPLETE` as callback (that's because it isn't defined) we started getting an undefined callback error when we tried to load a second `script`, to solve that we're just removing manually setting this name in `usePlacesAutocomplete` and using the default `Function.prototype` for all use cases. That should stop rendering multiple `script` tags.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
