### PR TITLE
endpoint for verified partners to get back session/user ids

### DIFF
--- a/src/app/api/verified-swc-partner/get-user-metadata/[emailAddress]/route.ts
+++ b/src/app/api/verified-swc-partner/get-user-metadata/[emailAddress]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import {
+  verifiedSWCPartnersGetUserMetadata,
+  zodVerifiedSWCPartnersGetUserMetadata,
+} from '@/data/verifiedSWCPartners/getUserMetadata'
+import { authenticateAndGetVerifiedSWCPartnerFromHeader } from '@/utils/server/verifiedSWCPartner/getVerifiedSWCPartnerFromHeader'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(
+  _request: NextRequest,
+  { params: { emailAddress } }: { params: { emailAddress: string } },
+) {
+  const partner = authenticateAndGetVerifiedSWCPartnerFromHeader()
+  const validatedFields = zodVerifiedSWCPartnersGetUserMetadata.parse({ emailAddress })
+  const result = await verifiedSWCPartnersGetUserMetadata({
+    ...validatedFields,
+    partner,
+  })
+  return NextResponse.json(result)
+}

--- a/src/data/verifiedSWCPartners/getUserMetadata.ts
+++ b/src/data/verifiedSWCPartners/getUserMetadata.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod'
+
+import { prismaClient } from '@/utils/server/prismaClient'
+import {
+  VerifiedSWCPartner,
+  VerifiedSWCPartnerApiResponse,
+} from '@/utils/server/verifiedSWCPartner/constants'
+import { getOrCreateSessionIdToSendBackToPartner } from '@/utils/server/verifiedSWCPartner/getOrCreateSessionIdToSendBackToPartner'
+import { getLogger } from '@/utils/shared/logger'
+import { zodEmailAddress } from '@/validation/fields/zodEmailAddress'
+
+export const zodVerifiedSWCPartnersGetUserMetadata = z.object({
+  emailAddress: zodEmailAddress,
+})
+
+const logger = getLogger('verifiedSWCPartnerGetUserMetadata')
+
+export enum VerifiedSWCPartnersGetUserMetadataResult {
+  EXISTS = 'exists',
+}
+
+type Input = z.infer<typeof zodVerifiedSWCPartnersGetUserMetadata> & {
+  partner: VerifiedSWCPartner
+}
+
+export async function verifiedSWCPartnersGetUserMetadata(
+  input: Input,
+): Promise<VerifiedSWCPartnerApiResponse<'exists'> | null> {
+  const { emailAddress } = input
+  const user = await prismaClient.user.findFirst({
+    include: {
+      userEmailAddresses: true,
+      userSessions: true,
+    },
+    where: {
+      userEmailAddresses: {
+        some: { emailAddress: emailAddress },
+      },
+    },
+  })
+
+  if (!user) {
+    logger.info(`User not found`)
+    return null
+  }
+
+  logger.info(`User found`)
+  return {
+    result: VerifiedSWCPartnersGetUserMetadataResult.EXISTS,
+    resultOptions: Object.values(VerifiedSWCPartnersGetUserMetadataResult),
+    sessionId: await getOrCreateSessionIdToSendBackToPartner(user),
+    userId: user.id,
+  }
+}


### PR DESCRIPTION
## What changed? Why?

New endpoint verified partners can leverage to deep link users in to the app

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
