### PR TITLE
Removes underline from donate card on home page

### DIFF
--- a/src/components/app/userActionRowCTA/constants.tsx
+++ b/src/components/app/userActionRowCTA/constants.tsx
@@ -65,7 +65,10 @@ export const USER_ACTION_ROW_CTA_INFO: Record<
     WrapperComponent: ({ children }) => {
       const locale = useLocale()
       return (
-        <InternalLink className="block text-fontcolor" href={getIntlUrls(locale).donate()}>
+        <InternalLink
+          className="block text-fontcolor hover:no-underline"
+          href={getIntlUrls(locale).donate()}
+        >
           {children}
         </InternalLink>
       )


### PR DESCRIPTION
closes #572 

## What changed? Why?
The donation card in home page is rendered as the InternalLink component that has a style of hover:underline. This PR cancels this style in this specific use.

## UI changes

### Web

| Old 👴         | New 👶         |
| -------------- | -------------- |
| <img width="1085" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/165944245/5052bd1c-f466-4fc1-98b4-d048e7379826"> | new screenshot |

## Notes to reviewers

## How has it been tested?

- [X] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine
risk=low
impact=sev1
