### PR TITLE
convert get-user-metadata endpoint to POST to remove unpredictability of escaping GET params

### DIFF
--- a/src/app/api/verified-swc-partner/get-user-metadata/route.ts
+++ b/src/app/api/verified-swc-partner/get-user-metadata/route.ts
@@ -6,14 +6,9 @@ import {
 } from '@/data/verifiedSWCPartners/getUserMetadata'
 import { authenticateAndGetVerifiedSWCPartnerFromHeader } from '@/utils/server/verifiedSWCPartner/getVerifiedSWCPartnerFromHeader'
 
-export const dynamic = 'force-dynamic'
-
-export async function GET(
-  _request: NextRequest,
-  { params: { emailAddress } }: { params: { emailAddress: string } },
-) {
+export async function POST(request: NextRequest) {
   const partner = authenticateAndGetVerifiedSWCPartnerFromHeader()
-  const validatedFields = zodVerifiedSWCPartnersGetUserMetadata.parse({ emailAddress })
+  const validatedFields = zodVerifiedSWCPartnersGetUserMetadata.parse(await request.json())
   const result = await verifiedSWCPartnersGetUserMetadata({
     ...validatedFields,
     partner,


### PR DESCRIPTION
## What changed? Why?
on testing, passing an email address with "+" and other url-used characters causes weird behavior (not seen on local). Converting this to a POST request to reduce these edge cases. 

## How has it been tested?

- [X] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
