### PR TITLE
match reps who have dashes in dtsi but no dashes in google

### DIFF
--- a/src/utils/shared/googleCivicInfo.ts
+++ b/src/utils/shared/googleCivicInfo.ts
@@ -154,7 +154,9 @@ export function getGoogleCivicOfficialByDTSIName(
   dtsiPersonName: { firstName: string; lastName: string; firstNickname: string },
   googleCivicInfoResponse: GoogleCivicInfoResponse,
 ) {
-  const normalizeName = (name: string) => convertToOnlyEnglishCharacters(name.toLowerCase().trim())
+  const normalizeName = (name: string) => {
+    return convertToOnlyEnglishCharacters(name.toLowerCase().trim()).replace(/[.-\s]/g, '')
+  }
   const normalizedDTSIFirstNickname = normalizeName(dtsiPersonName.firstNickname)
   const normalizedDTSIFirstName = normalizeName(dtsiPersonName.firstName)
   const normalizedDTSILastName = normalizeName(dtsiPersonName.lastName)


### PR DESCRIPTION
fixes https://stand-with-crypto.sentry.io/issues/4947101303/?environment=production&project=4506490717470720&query=is%3Aunresolved+timesSeen%3A%3E%3D10&referrer=issue-stream&statsPeriod=30d&stream_index=3

## What changed? Why?

Reps like cherfilus-mccormick have a dash in DTSI but no dash in google civic api. This fix ensures we can fuzzy match them accurately.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
