### PR TITLE
[bug] bump version of `thirdweb` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "@radix-ui/react-tooltip": "^1.0.7",
         "@sentry/nextjs": "^7.91.0",
         "@tailwindcss/aspect-ratio": "^0.4.2",
-        "@tanstack/react-query": "^5.29.0",
         "@tanstack/react-table": "^8.11.2",
         "@thirdweb-dev/auth": "^4.1.30",
         "@thirdweb-dev/engine": "^0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "swr": "^2.2.4",
         "tailwind-merge": "^2.2.0",
         "tailwindcss-animate": "^1.0.7",
-        "thirdweb": "^5.4.1",
+        "thirdweb": "^5.6.0",
         "twemoji": "^14.0.2",
         "twemoji-parser": "^14.0.0",
         "twitter-api-v2": "^1.15.2",
@@ -11185,9 +11185,9 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.29.0.tgz",
-      "integrity": "sha512-yxlhHB73jaBla6h5B6zPaGmQjokkzAhMHN4veotkPNiQ3Ac/mCxgABRZPsJJrgCTvhpcncBZcDBFxaR2B37vug==",
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.29.2.tgz",
+      "integrity": "sha512-nyuWILR4u7H5moLGSiifLh8kIqQDLNOHGuSz0rcp+J75fNc8aQLyr5+I2JCHU3n+nJrTTW1ssgAD8HiKD7IFBQ==",
       "dependencies": {
         "@tanstack/query-core": "5.29.0"
       },
@@ -13938,26 +13938,26 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/ethereum-provider": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.12.1.tgz",
-      "integrity": "sha512-C57sIcKDNKx6UgnW4EVrmBGAXGddfjgC88vpkOTBrClFF8zhSfdf/fKnLLo70spr8z3u77IppD36m6DGhJ+xpw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.12.2.tgz",
+      "integrity": "sha512-vBl2zCnNm2iPaomJdr5YT16cT7aa8cH2WFs6879XPngU5i7HXS3bU6TamhyhKKl13sdIfifmCkCC+RWn5GdPMw==",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.3",
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/modal": "^2.6.2",
-        "@walletconnect/sign-client": "2.12.1",
-        "@walletconnect/types": "2.12.1",
-        "@walletconnect/universal-provider": "2.12.1",
-        "@walletconnect/utils": "2.12.1",
+        "@walletconnect/sign-client": "2.12.2",
+        "@walletconnect/types": "2.12.2",
+        "@walletconnect/universal-provider": "2.12.2",
+        "@walletconnect/utils": "2.12.2",
         "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/core": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.12.1.tgz",
-      "integrity": "sha512-CIxWNRNvmFNwn+8kPbKyBXS1JHBFJpDE8f73dXtUIElVnZhmXzEOSE5fug91EX57wTrv4/qW66H9kNB3c7Pp5g==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.12.2.tgz",
+      "integrity": "sha512-7Adv/b3pp9F42BkvReaaM4KS8NEvlkS7AMtwO3uF/o6aRMKtcfTJq9/jgWdKJh4RP8pPRTRFjCw6XQ/RZtT4aQ==",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
@@ -13965,13 +13965,13 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/jsonrpc-ws-connection": "1.0.14",
         "@walletconnect/keyvaluestorage": "^1.1.1",
-        "@walletconnect/logger": "^2.1.0",
+        "@walletconnect/logger": "^2.1.2",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.12.1",
-        "@walletconnect/utils": "2.12.1",
+        "@walletconnect/types": "2.12.2",
+        "@walletconnect/utils": "2.12.2",
         "events": "^3.3.0",
         "isomorphic-unfetch": "3.1.0",
         "lodash.isequal": "4.5.0",
@@ -13988,25 +13988,25 @@
       }
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/sign-client": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.12.1.tgz",
-      "integrity": "sha512-6PegtNZgqmOX2G022fyrHjyN3PW6Ov2GVFvG8f+80uqikEO3IAL3dgazlnUYtuaUNYs+Hx7sSvjNVanMiJsE1Q==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.12.2.tgz",
+      "integrity": "sha512-cM0ualXj6nVvLqS4BDNRk+ZWR+lubcsz/IHreH+3wYrQ2sV+C0fN6ctrd7MMGZss0C0qacWCx0pm62ZBuoKvqA==",
       "dependencies": {
-        "@walletconnect/core": "2.12.1",
+        "@walletconnect/core": "2.12.2",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/logger": "^2.1.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.12.1",
-        "@walletconnect/utils": "2.12.1",
+        "@walletconnect/types": "2.12.2",
+        "@walletconnect/utils": "2.12.2",
         "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/types": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.12.1.tgz",
-      "integrity": "sha512-mPzGj5ssgcOJKqwn8qsdCr+J9swsjTmDPAV10CghXIe3GGQKOb4noTUhOofb4LDbFaio1GBql8+Xfy+6bulobw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.12.2.tgz",
+      "integrity": "sha512-9CmwTlPbrFTzayTL9q7xM7s3KTJkS6kYFtH2m1/fHFgALs6pIUjf1qAx1TF2E4tv7SEzLAIzU4NqgYUt2vWXTg==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -14017,9 +14017,9 @@
       }
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/utils": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.12.1.tgz",
-      "integrity": "sha512-v2Oc8mTb+3y8MW94Rnj9hxVjJU3wdnE1g8eLZXmcNf7zAvsm1iJPtHl7ZxZsjpVpo1Vg79Oo1rS9gWq9z0kKKw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.12.2.tgz",
+      "integrity": "sha512-zf50HeS3SfoLv1N9GPl2IXTZ9TsXfet4usVAsZmX9P6/Xzq7d/7QakjVQCHH/Wk1O9XkcsfeoZoUhRxoMJ5uJw==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -14029,7 +14029,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.12.1",
+        "@walletconnect/types": "2.12.2",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -14305,25 +14305,25 @@
       }
     },
     "node_modules/@walletconnect/universal-provider": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.12.1.tgz",
-      "integrity": "sha512-ZLl5+wY3A7pss5UbIOKBcTwoFQmhW6ilDq33vX2Hu69yUnK+OEKlKcgAy4vjN2wAWakUctO4j7RhpionKBZfCw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.12.2.tgz",
+      "integrity": "sha512-0k5ZgSkABopQLVhkiwl2gRGG7dAP4SWiI915pIlyN5sRvWV+qX1ALhWAmRcdv0TXWlKHDcDgPJw/q2sCSAHuMQ==",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
         "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
-        "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.12.1",
-        "@walletconnect/types": "2.12.1",
-        "@walletconnect/utils": "2.12.1",
+        "@walletconnect/logger": "^2.1.2",
+        "@walletconnect/sign-client": "2.12.2",
+        "@walletconnect/types": "2.12.2",
+        "@walletconnect/utils": "2.12.2",
         "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/core": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.12.1.tgz",
-      "integrity": "sha512-CIxWNRNvmFNwn+8kPbKyBXS1JHBFJpDE8f73dXtUIElVnZhmXzEOSE5fug91EX57wTrv4/qW66H9kNB3c7Pp5g==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.12.2.tgz",
+      "integrity": "sha512-7Adv/b3pp9F42BkvReaaM4KS8NEvlkS7AMtwO3uF/o6aRMKtcfTJq9/jgWdKJh4RP8pPRTRFjCw6XQ/RZtT4aQ==",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
@@ -14331,13 +14331,13 @@
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/jsonrpc-ws-connection": "1.0.14",
         "@walletconnect/keyvaluestorage": "^1.1.1",
-        "@walletconnect/logger": "^2.1.0",
+        "@walletconnect/logger": "^2.1.2",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.12.1",
-        "@walletconnect/utils": "2.12.1",
+        "@walletconnect/types": "2.12.2",
+        "@walletconnect/utils": "2.12.2",
         "events": "^3.3.0",
         "isomorphic-unfetch": "3.1.0",
         "lodash.isequal": "4.5.0",
@@ -14354,25 +14354,25 @@
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/sign-client": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.12.1.tgz",
-      "integrity": "sha512-6PegtNZgqmOX2G022fyrHjyN3PW6Ov2GVFvG8f+80uqikEO3IAL3dgazlnUYtuaUNYs+Hx7sSvjNVanMiJsE1Q==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.12.2.tgz",
+      "integrity": "sha512-cM0ualXj6nVvLqS4BDNRk+ZWR+lubcsz/IHreH+3wYrQ2sV+C0fN6ctrd7MMGZss0C0qacWCx0pm62ZBuoKvqA==",
       "dependencies": {
-        "@walletconnect/core": "2.12.1",
+        "@walletconnect/core": "2.12.2",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "^2.0.1",
+        "@walletconnect/logger": "^2.1.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.12.1",
-        "@walletconnect/utils": "2.12.1",
+        "@walletconnect/types": "2.12.2",
+        "@walletconnect/utils": "2.12.2",
         "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/types": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.12.1.tgz",
-      "integrity": "sha512-mPzGj5ssgcOJKqwn8qsdCr+J9swsjTmDPAV10CghXIe3GGQKOb4noTUhOofb4LDbFaio1GBql8+Xfy+6bulobw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.12.2.tgz",
+      "integrity": "sha512-9CmwTlPbrFTzayTL9q7xM7s3KTJkS6kYFtH2m1/fHFgALs6pIUjf1qAx1TF2E4tv7SEzLAIzU4NqgYUt2vWXTg==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -14383,9 +14383,9 @@
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/utils": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.12.1.tgz",
-      "integrity": "sha512-v2Oc8mTb+3y8MW94Rnj9hxVjJU3wdnE1g8eLZXmcNf7zAvsm1iJPtHl7ZxZsjpVpo1Vg79Oo1rS9gWq9z0kKKw==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.12.2.tgz",
+      "integrity": "sha512-zf50HeS3SfoLv1N9GPl2IXTZ9TsXfet4usVAsZmX9P6/Xzq7d/7QakjVQCHH/Wk1O9XkcsfeoZoUhRxoMJ5uJw==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -14395,7 +14395,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.12.1",
+        "@walletconnect/types": "2.12.2",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -34368,9 +34368,9 @@
       }
     },
     "node_modules/thirdweb": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/thirdweb/-/thirdweb-5.4.1.tgz",
-      "integrity": "sha512-Ca0DibXAm3hBe2iwB5KGSR1axMqkJxd4KiNV5Nu59mvLxJITgU03UvWrEsa00Y7WIuAZATDh7fw6b7vCC+cohw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/thirdweb/-/thirdweb-5.6.0.tgz",
+      "integrity": "sha512-OcBJitC4Px0XSSFCyTf8wuTolj9OG5RC6+sPLwGTdTIq7nPkWUQVvrplwiAu3OKzsqAsYo4e8cOcOhUvclGo0w==",
       "dependencies": {
         "@coinbase/wallet-sdk": "3.7.2",
         "@emotion/react": "11.11.4",
@@ -34382,15 +34382,15 @@
         "@radix-ui/react-focus-scope": "1.0.4",
         "@radix-ui/react-icons": "1.3.0",
         "@radix-ui/react-tooltip": "1.0.7",
-        "@tanstack/react-query": "5.29.0",
-        "@walletconnect/ethereum-provider": "2.12.1",
+        "@tanstack/react-query": "5.29.2",
+        "@walletconnect/ethereum-provider": "2.12.2",
         "abitype": "1.0.0",
         "fast-text-encoding": "^1.0.6",
         "fuse.js": "7.0.0",
         "mipd": "0.0.7",
         "node-libs-browser": "2.2.1",
         "uqr": "0.1.2",
-        "viem": "2.9.9"
+        "viem": "2.9.16"
       },
       "bin": {
         "thirdweb": "dist/esm/cli/bin.js",
@@ -36084,9 +36084,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.9.9",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.9.9.tgz",
-      "integrity": "sha512-SUIHBL6M5IIlqDCMEQwAAvHzeglaM4FEqM6bCI+srLXtFYmrpV4tWhnpobQRNwh4f7HIksmKLLZ+cytv8FfnJQ==",
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.9.16.tgz",
+      "integrity": "sha512-FQRfN4G7uKEUs5DYvVrH/kZmTkwcSDpTBxnadpwG1EEP8nHm57WDpSaGN7PwSPVgJ6rMo5MENT5hgnqaNTlb2w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@radix-ui/react-tooltip": "^1.0.7",
     "@sentry/nextjs": "^7.91.0",
     "@tailwindcss/aspect-ratio": "^0.4.2",
-    "@tanstack/react-query": "^5.29.0",
     "@tanstack/react-table": "^8.11.2",
     "@thirdweb-dev/auth": "^4.1.30",
     "@thirdweb-dev/engine": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "swr": "^2.2.4",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
-    "thirdweb": "^5.4.1",
+    "thirdweb": "^5.6.0",
     "twemoji": "^14.0.2",
     "twemoji-parser": "^14.0.0",
     "twitter-api-v2": "^1.15.2",


### PR DESCRIPTION
closes #739 (officially)

## What changed? Why?

This small PR bumps the version of the `thirdweb` package to the latest version (`5.6.0`). Why? Because our current version does not have claim allowlist support, but the latest package has that implemented, so we should bump.

## UI changes

No UI changes.

## PlanetScale Deploy Request

No PlanetScale schema changes.

## Notes to reviewers

No specific notes.

## How has it been tested?

- [ ] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
