### PR TITLE
fix: add support for international phone numbers on zodPhoneNumber schema

### DIFF
--- a/src/utils/shared/phoneNumber.test.ts
+++ b/src/utils/shared/phoneNumber.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect } from '@jest/globals'
+import { describe, expect, it } from '@jest/globals'
 import { uniq } from 'lodash-es'
 
-import { normalizePhoneNumber } from '@/utils/shared/phoneNumber'
+import { normalizePhoneNumber, PHONE_NUMBER_REGEX } from '@/utils/shared/phoneNumber'
 
 describe('utils/normalizePhoneNumber', () => {
   it('Correctly parses phone number strings', () => {
@@ -22,5 +22,21 @@ describe('utils/normalizePhoneNumber', () => {
     expect(uniq(['222 888 3333 x61835', '222 888 3333x61835'].map(normalizePhoneNumber))).toEqual([
       '+12228883333x61835',
     ])
+  })
+})
+
+describe('utils/PHONE_NUMBER_REGEX', () => {
+  it.each([
+    '(123) 456-7890',
+    '(123)456-7890',
+    '123-456-7890',
+    '123.456.7890',
+    '1234567890',
+    '+31636363634',
+    '075-63546725',
+    '+5562912341234',
+    '+55 (62) 91234-1234',
+  ])('should test positive for `%s`', value => {
+    expect(PHONE_NUMBER_REGEX.test(value)).toEqual(true)
   })
 })

--- a/src/utils/shared/phoneNumber.ts
+++ b/src/utils/shared/phoneNumber.ts
@@ -1,3 +1,5 @@
+export const PHONE_NUMBER_REGEX = new RegExp(/^[+(\s.\-/\d)]{5,30}$/)
+
 // https://stackoverflow.com/a/43687969
 export function normalizePhoneNumber(passed: string) {
   // Split number and extension

--- a/src/validation/fields/zodPhoneNumber.ts
+++ b/src/validation/fields/zodPhoneNumber.ts
@@ -1,5 +1,5 @@
 import { string } from 'zod'
 
-const phoneRegex = new RegExp(/^(\+\d{1,2}\s?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$/)
+import { PHONE_NUMBER_REGEX } from '@/utils/shared/phoneNumber'
 
-export const zodPhoneNumber = string().regex(phoneRegex, 'Please enter a valid phone number')
+export const zodPhoneNumber = string().regex(PHONE_NUMBER_REGEX, 'Please enter a valid phone number')


### PR DESCRIPTION
## What changed? Why?

Adds support for international phone number to the default zod field schema. This is causing coinbase 1-click signup registrations to fail

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
