### PR TITLE
[bug] fix "mint NFT" flow when "logged-in" as session user

### DIFF
--- a/src/components/app/authentication/maybeAuthenticatedContent.tsx
+++ b/src/components/app/authentication/maybeAuthenticatedContent.tsx
@@ -6,10 +6,12 @@ export function MaybeAuthenticatedContent({
   children,
   authenticatedContent,
   loadingFallback,
+  useThirdwebSession,
 }: {
   children: React.ReactNode
   authenticatedContent: React.ReactNode
   loadingFallback?: React.ReactNode
+  useThirdwebSession?: boolean
 }) {
   const session = useSession()
 
@@ -17,7 +19,7 @@ export function MaybeAuthenticatedContent({
     return loadingFallback
   }
 
-  if (session.isLoggedIn) {
+  if (session.isLoggedIn && (!useThirdwebSession || session.isLoggedInThirdweb)) {
     return authenticatedContent
   }
 

--- a/src/components/app/userActionFormNFTMint/sections/intro.tsx
+++ b/src/components/app/userActionFormNFTMint/sections/intro.tsx
@@ -50,10 +50,11 @@ export function UserActionFormNFTMintIntro({
                     </Button>
                   }
                   loadingFallback={<FooterSkeleton />}
+                  useThirdwebSession={true}
                 >
                   <Button size="lg">Sign In</Button>
                 </LoginDialogWrapper>
-                <MaybeAuthenticatedContent authenticatedContent={null}>
+                <MaybeAuthenticatedContent authenticatedContent={null} useThirdwebSession={true}>
                   <p className="text-xs text-muted-foreground md:text-sm">
                     You will need to login first to mint the NFT
                   </p>

--- a/src/validation/fields/zodPhoneNumber.ts
+++ b/src/validation/fields/zodPhoneNumber.ts
@@ -2,4 +2,7 @@ import { string } from 'zod'
 
 import { PHONE_NUMBER_REGEX } from '@/utils/shared/phoneNumber'
 
-export const zodPhoneNumber = string().regex(PHONE_NUMBER_REGEX, 'Please enter a valid phone number')
+export const zodPhoneNumber = string().regex(
+  PHONE_NUMBER_REGEX,
+  'Please enter a valid phone number',
+)


### PR DESCRIPTION
## What changed? Why?

This small PR fixes the "mint NFT" flow when "logged-in" using user ID + session ID query parameters. Why? Because currently the "mint NFT" will hang due to incorrect log-in checks.

## UI changes

### Web

_BEFORE_:

https://github.com/Stand-With-Crypto/swc-web/assets/135282747/9d3e1ddc-c0cc-4bed-9b2d-cc31a5679663

_AFTER_:

https://github.com/Stand-With-Crypto/swc-web/assets/135282747/e673ae1e-a0ca-49bb-bd98-2bab2fcdf0a3

## PlanetScale Deploy Request

No PlanetScale schema changes.

## Notes to reviewers

No notes.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
