### PR TITLE
Fix: google places select overflowing

### DIFF
--- a/src/components/ui/googlePlacesSelect/index.tsx
+++ b/src/components/ui/googlePlacesSelect/index.tsx
@@ -47,7 +47,7 @@ export const GooglePlacesSelect = React.forwardRef<
         <InputWithIcons
           className={cn(
             triggerProps.value || 'text-gray-500',
-            'cursor-pointer',
+            'h-auto cursor-pointer whitespace-normal',
             triggerProps.open && 'outline-none ring-2 ring-ring ring-offset-2',
             className,
           )}


### PR DESCRIPTION

## What changed? Why?
Reverted the removal of whitespace-normal in google places select component

## Change management

type=routine
risk=low
impact=sev1
