### PR TITLE
disable donation CTAs until re-enabled

### DIFF
--- a/cypress/e2e/6-donation-card-redirect.cy.ts
+++ b/cypress/e2e/6-donation-card-redirect.cy.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-it('donation card redirects to donation page', () => {
+it.skip('donation card redirects to donation page', () => {
   cy.visit('/')
 
   cy.contains('Donate to Stand With Crypto').click()

--- a/src/components/app/navbar/index.tsx
+++ b/src/components/app/navbar/index.tsx
@@ -36,10 +36,10 @@ export function Navbar({ locale }: { locale: SupportedLocale }) {
       href: urls.resources(),
       text: 'Resources',
     },
-    {
-      href: urls.donate(),
-      text: 'Donate',
-    },
+    // {
+    //   href: urls.donate(),
+    //   text: 'Donate',
+    // },
     {
       href: urls.partners(),
       text: 'Partners',

--- a/src/components/app/pageDonate/donateButton.tsx
+++ b/src/components/app/pageDonate/donateButton.tsx
@@ -34,7 +34,7 @@ export function DonateButton() {
   return (
     <div className="flex justify-center">
       <Button disabled={buttonState === 'loading'} onClick={handleDonateClick} size="lg">
-        Donate
+        Donate (Coming Soon)
       </Button>
     </div>
   )

--- a/src/components/app/userActionRowCTA/constants.tsx
+++ b/src/components/app/userActionRowCTA/constants.tsx
@@ -10,11 +10,8 @@ import { UserActionFormEmailCongresspersonDialog } from '@/components/app/userAc
 import { UserActionFormNFTMintDialog } from '@/components/app/userActionFormNFTMint/dialog'
 import { UserActionFormVoterRegistrationDialog } from '@/components/app/userActionFormVoterRegistration/dialog'
 import { UserActionRowCTAProps } from '@/components/app/userActionRowCTA'
-import { InternalLink } from '@/components/ui/link'
 import { UserActionTweetLink } from '@/components/ui/userActionTweetLink'
-import { useLocale } from '@/hooks/useLocale'
 import { ActiveClientUserActionType } from '@/utils/shared/activeUserAction'
-import { getIntlUrls } from '@/utils/shared/urls'
 import { getYourPoliticianCategoryShortDisplayName } from '@/utils/shared/yourPoliticianCategory'
 
 export const USER_ACTION_ROW_CTA_INFO: Record<
@@ -56,24 +53,24 @@ export const USER_ACTION_ROW_CTA_INFO: Record<
     canBeTriggeredMultipleTimes: true,
     WrapperComponent: UserActionFormEmailCongresspersonDialog,
   },
-  [UserActionType.DONATION]: {
-    actionType: UserActionType.DONATION,
-    image: '/actionTypeIcons/donate.png',
-    text: 'Donate to Stand With Crypto',
-    subtext: 'Support our aim to mobilize 52 million crypto advocates in the U.S.',
-    canBeTriggeredMultipleTimes: true,
-    WrapperComponent: ({ children }) => {
-      const locale = useLocale()
-      return (
-        <InternalLink
-          className="block text-fontcolor hover:no-underline"
-          href={getIntlUrls(locale).donate()}
-        >
-          {children}
-        </InternalLink>
-      )
-    },
-  },
+  // [UserActionType.DONATION]: {
+  //   actionType: UserActionType.DONATION,
+  //   image: '/actionTypeIcons/donate.png',
+  //   text: 'Donate to Stand With Crypto',
+  //   subtext: 'Support our aim to mobilize 52 million crypto advocates in the U.S.',
+  //   canBeTriggeredMultipleTimes: true,
+  //   WrapperComponent: ({ children }) => {
+  //     const locale = useLocale()
+  //     return (
+  //       <InternalLink
+  //         className="block text-fontcolor hover:no-underline"
+  //         href={getIntlUrls(locale).donate()}
+  //       >
+  //         {children}
+  //       </InternalLink>
+  //     )
+  //   },
+  // },
   [UserActionType.TWEET]: {
     actionType: UserActionType.TWEET,
     image: '/actionTypeIcons/tweet.png',

--- a/src/utils/shared/activeUserAction.ts
+++ b/src/utils/shared/activeUserAction.ts
@@ -3,7 +3,7 @@ import { UserActionType } from '@prisma/client'
 export const ACTIVE_CLIENT_USER_ACTION_TYPES = [
   UserActionType.CALL,
   UserActionType.EMAIL,
-  UserActionType.DONATION,
+  // UserActionType.DONATION,
   UserActionType.OPT_IN,
   UserActionType.TWEET,
   UserActionType.NFT_MINT,

--- a/src/utils/shared/urlsDeeplinkUserActions.tsx
+++ b/src/utils/shared/urlsDeeplinkUserActions.tsx
@@ -27,11 +27,11 @@ export const USER_ACTION_DEEPLINK_MAP: Omit<
       return `${getIntlPrefix(locale)}/action/email`
     },
   },
-  [UserActionType.DONATION]: {
-    getDeeplinkUrl: ({ locale }) => {
-      return `${getIntlPrefix(locale)}/donate`
-    },
-  },
+  // [UserActionType.DONATION]: {
+  //   getDeeplinkUrl: ({ locale }) => {
+  //     return `${getIntlPrefix(locale)}/donate`
+  //   },
+  // },
   [UserActionType.NFT_MINT]: {
     getDeeplinkUrl: ({ locale }) => {
       return `${getIntlPrefix(locale)}/action/nft-mint`

--- a/src/utils/web/userActionUtils.ts
+++ b/src/utils/web/userActionUtils.ts
@@ -7,7 +7,7 @@ export const USER_ACTION_TYPE_CTA_PRIORITY_ORDER: ReadonlyArray<ActiveClientUser
   UserActionType.VOTER_REGISTRATION,
   UserActionType.CALL,
   UserActionType.EMAIL,
-  UserActionType.DONATION,
+  // UserActionType.DONATION,
   UserActionType.TWEET,
   UserActionType.NFT_MINT,
 ]


### PR DESCRIPTION
## What changed? Why?
Our donation's provider is currently down. Disabling our main CTAs until they're back online.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
