### PR TITLE
Fix politicians page e2e tests

### DIFF
--- a/cypress/e2e/3-page-politicians.cy.ts
+++ b/cypress/e2e/3-page-politicians.cy.ts
@@ -17,16 +17,31 @@ it('page - politicians interactions', () => {
    */
   cy.get('[data-testid="state-filter-trigger"]').as('stateFilterTrigger').scrollIntoView()
   cy.get('@stateFilterTrigger').should('be.visible').click()
-
   cy.get('[role="option"]').contains('div', 'AK').as('stateOption')
   cy.get('@stateOption').should('be.visible').click({
     // force: true // Bypass visibility checks, not ideal
   })
+  cy.get('@stateFilterTrigger').children().should('contain', 'AK')
   cy.get('tbody').find('tr').should('have.length', 4)
-
   cy.get('@stateFilterTrigger').click()
   cy.get('[role="option"]').contains('div', 'All').click()
   cy.get('tbody').find('tr').should('have.length', 100)
+
+  // filter table by role
+  cy.get('[data-testid="role-filter-trigger"]').as('roleFilterTrigger').scrollIntoView()
+  cy.get('@roleFilterTrigger').should('be.visible').click()
+  cy.get('[role="option"]').contains('div', 'Senator').as('roleOption')
+  cy.get('@roleOption').should('be.visible').click()
+  cy.get('@roleFilterTrigger').children().should('contain', 'Senator')
+  cy.get('tbody')
+    .find('td:nth-child(3)')
+    .each($cell => {
+      const value = $cell.text()
+      cy.wrap(value).should('eq', 'Senator')
+    })
+  cy.get('@roleFilterTrigger').click()
+  cy.get('[role="option"]').contains('div', 'All').click()
+  cy.get('@roleFilterTrigger').children().should('contain', 'All')
 
   // filter the table by name
   cy.get('input[placeholder="Search by name or state"]').as('nameFilter').should('be.visible')

--- a/cypress/e2e/3-page-politicians.cy.ts
+++ b/cypress/e2e/3-page-politicians.cy.ts
@@ -5,21 +5,35 @@ it('page - politicians interactions', () => {
 
   cy.get('h1').contains('politicians')
   cy.get('tbody').find('tr').should('have.length', 100)
-  // filter the table by state
 
-  // TODO: fix this test
-  // // find the element with the data-e2e attribute of "state-filter-trigger"
-  // cy.get('[data-testid="state-filter-trigger"]').click()
-  // cy.get('[role="option"]').contains('AK').click()
-  // cy.get('tbody').find('tr').should('have.length', 3)
-  // cy.get('[data-testid="state-filter-trigger"]').click()
-  // cy.get('[role="option"]').contains('All').click()
-  // cy.get('tbody').find('tr').should('have.length', 100)
-  // // filter the table by name
-  // cy.get('input[placeholder="Search by name"]').type('Cynthia Lummis')
-  // cy.get('tbody').find('tr').should('have.length', 1)
-  // cy.get('input[placeholder="Search by name"]').clear()
-  // cy.get('tbody').find('tr').should('have.length', 100)
+  // filter the table by state
+  /**
+   * find the element with the data-e2e attribute of "state-filter-trigger".
+   *
+   * When rendering in a small screen Cypress will define the element as not visible
+   * due to the parent having `position: fixed`, so we need to scroll it into view.
+   *
+   * NOTE: If the table rerenders too much the scroll state will reset.
+   */
+  cy.get('[data-testid="state-filter-trigger"]').as('stateFilterTrigger').scrollIntoView()
+  cy.get('@stateFilterTrigger').should('be.visible').click()
+
+  cy.get('[role="option"]').contains('div', 'AK').as('stateOption')
+  cy.get('@stateOption').should('be.visible').click({
+    // force: true // Bypass visibility checks, not ideal
+  })
+  cy.get('tbody').find('tr').should('have.length', 4)
+
+  cy.get('@stateFilterTrigger').click()
+  cy.get('[role="option"]').contains('div', 'All').click()
+  cy.get('tbody').find('tr').should('have.length', 100)
+
+  // filter the table by name
+  cy.get('input[placeholder="Search by name or state"]').as('nameFilter').should('be.visible')
+  cy.get('@nameFilter').type('Cynthia Lummis')
+  cy.get('tbody').find('tr').should('have.length', 1)
+  cy.get('@nameFilter').clear()
+  cy.get('tbody').find('tr').should('have.length', 100)
 
   // enter your address and see your rep
   cy.selectFromComboBox({

--- a/cypress/e2e/3-page-politicians.cy.ts
+++ b/cypress/e2e/3-page-politicians.cy.ts
@@ -22,7 +22,13 @@ it('page - politicians interactions', () => {
     // force: true // Bypass visibility checks, not ideal
   })
   cy.get('@stateFilterTrigger').children().should('contain', 'AK')
-  cy.get('tbody').find('tr').should('have.length', 4)
+  // cy.get('tbody').find('tr').should('have.length', 4)
+  cy.get('tbody')
+    .find('td:nth-child(4)')
+    .each($cell => {
+      const value = $cell.text()
+      cy.wrap(value).should('eq', 'Alaska')
+    })
   cy.get('@stateFilterTrigger').click()
   cy.get('[role="option"]').contains('div', 'All').click()
   cy.get('tbody').find('tr').should('have.length', 100)

--- a/src/components/app/dtsiClientPersonDataTable/columns.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/columns.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ColumnDef } from '@tanstack/react-table'
+import { createColumnHelper, FilterFn } from '@tanstack/react-table'
 import { isNil } from 'lodash-es'
 
 import { DTSIAvatar } from '@/components/app/dtsiAvatar'
@@ -22,14 +22,44 @@ import { cn } from '@/utils/web/cn'
 
 export type Person = Awaited<ReturnType<typeof queryDTSIAllPeople>>['people'][0]
 
-export const getDTSIClientPersonDataTableColumns = ({
-  locale,
-}: {
-  locale: SupportedLocale
-}): ColumnDef<Person>[] => [
-  {
-    accessorKey: 'fullName',
-    accessorFn: row => dtsiPersonFullName(row),
+/**
+ * Unique identifiers for eachPersonDataTable Column.
+ * Also used to bind a Column to a filter function.
+ */
+export enum PERSON_TABLE_COLUMNS_IDS {
+  FULL_NAME = 'fullName',
+  STANCE = 'swcStanceScore',
+  ROLE = 'primaryRole',
+  PARTY = 'politicalAffiliationCategory',
+  STATE = 'state',
+}
+
+/**
+ * `FilterFns` has to be augmented with the custom filter functions.
+ *
+ * @see https://tanstack.com/table/v8/docs/api/features/column-filtering#filterfns
+ */
+declare module '@tanstack/react-table' {
+  interface FilterFns {
+    [PERSON_TABLE_COLUMNS_IDS.FULL_NAME]: FilterFn<Person>
+    [PERSON_TABLE_COLUMNS_IDS.STANCE]: FilterFn<Person>
+    [PERSON_TABLE_COLUMNS_IDS.ROLE]: FilterFn<Person>
+    [PERSON_TABLE_COLUMNS_IDS.PARTY]: FilterFn<Person>
+    [PERSON_TABLE_COLUMNS_IDS.STATE]: FilterFn<Person>
+  }
+}
+
+const personColumnHelper = createColumnHelper<Person>()
+
+/**
+ * Columns definition for PersonDataTable.
+ *
+ * @see https://tanstack.com/table/latest/docs/guide/column-defs#column-helpers
+ */
+export const getDTSIClientPersonDataTableColumns = ({ locale }: { locale: SupportedLocale }) => [
+  personColumnHelper.accessor(dtsiPersonFullName, {
+    id: PERSON_TABLE_COLUMNS_IDS.FULL_NAME,
+    filterFn: PERSON_TABLE_COLUMNS_IDS.FULL_NAME,
     cell: ({ row }) => (
       <LinkBox className="flex items-center gap-3">
         <DTSIAvatar person={row.original} size={40} />
@@ -44,66 +74,74 @@ export const getDTSIClientPersonDataTableColumns = ({
     header: ({ column }) => {
       return <SortableHeader column={column}>Name</SortableHeader>
     },
-  },
-  {
-    accessorKey: 'swcStanceScore',
-    accessorFn: row => {
+  }),
+  personColumnHelper.accessor(
+    row => {
       const score = row.manuallyOverriddenStanceScore || row.computedStanceScore
       if (isNil(score)) {
         return -1
       }
       return score
     },
-    header: ({ column }) => {
-      return (
-        <SortableHeader column={column}>
-          <span>Stance</span> <span className="ml-1 hidden md:inline-block">on crypto</span>
-        </SortableHeader>
-      )
+    {
+      id: PERSON_TABLE_COLUMNS_IDS.STANCE,
+      filterFn: PERSON_TABLE_COLUMNS_IDS.STANCE,
+      header: ({ column }) => {
+        return (
+          <SortableHeader column={column}>
+            <span>Stance</span> <span className="ml-1 hidden md:inline-block">on crypto</span>
+          </SortableHeader>
+        )
+      },
+      cell: ({ row }) => (
+        <div className="flex items-center gap-2">
+          <DTSIFormattedLetterGrade className="h-7 w-7" person={row.original} />
+          <span className="hidden md:inline">
+            {convertDTSIPersonStanceScoreToCryptoSupportLanguage(row.original)}
+          </span>
+        </div>
+      ),
     },
-    cell: ({ row }) => (
-      <div className="flex items-center gap-2">
-        <DTSIFormattedLetterGrade className="h-7 w-7" person={row.original} />
-        <span className="hidden md:inline">
-          {convertDTSIPersonStanceScoreToCryptoSupportLanguage(row.original)}
-        </span>
-      </div>
-    ),
-  },
-  {
-    accessorKey: 'personRoleCategoryDisplayName',
-    accessorFn: row =>
-      row.primaryRole ? getDTSIPersonRoleCategoryDisplayName(row.primaryRole) : '-',
-    header: ({ column }) => {
-      return <SortableHeader column={column}>Role</SortableHeader>
+  ),
+  personColumnHelper.accessor(
+    row => (row.primaryRole ? getDTSIPersonRoleCategoryDisplayName(row.primaryRole) : '-'),
+    {
+      id: PERSON_TABLE_COLUMNS_IDS.ROLE,
+      filterFn: PERSON_TABLE_COLUMNS_IDS.ROLE,
+      header: ({ column }) => {
+        return <SortableHeader column={column}>Role</SortableHeader>
+      },
+      cell: ({ row }) => (
+        <>
+          {row.original.primaryRole
+            ? getDTSIPersonRoleCategoryDisplayName(row.original.primaryRole)
+            : '-'}
+        </>
+      ),
     },
-
-    cell: ({ row }) => (
-      <>
-        {row.original.primaryRole
-          ? getDTSIPersonRoleCategoryDisplayName(row.original.primaryRole)
-          : '-'}
-      </>
-    ),
-  },
-  {
-    accessorKey: 'primaryStateCodeWithDisplayName',
-    accessorFn: row =>
+  ),
+  personColumnHelper.accessor(
+    row =>
       row.primaryRole?.primaryState
         ? `${getUSStateNameFromStateCode(row.primaryRole.primaryState)} ${
             row.primaryRole.primaryState
           }`
         : '-',
-    header: ({ column }) => {
-      return <SortableHeader column={column}>Location</SortableHeader>
+    {
+      id: PERSON_TABLE_COLUMNS_IDS.STATE,
+      filterFn: PERSON_TABLE_COLUMNS_IDS.STATE,
+      header: ({ column }) => {
+        return <SortableHeader column={column}>Location</SortableHeader>
+      },
+      cell: ({ row }) =>
+        row.original.primaryRole?.primaryState
+          ? getUSStateNameFromStateCode(row.original.primaryRole.primaryState)
+          : '-',
     },
-    cell: ({ row }) =>
-      row.original.primaryRole?.primaryState
-        ? getUSStateNameFromStateCode(row.original.primaryRole.primaryState)
-        : '-',
-  },
-  {
-    accessorKey: 'politicalAffiliationCategory',
+  ),
+  personColumnHelper.accessor('politicalAffiliationCategory', {
+    id: PERSON_TABLE_COLUMNS_IDS.PARTY,
+    filterFn: PERSON_TABLE_COLUMNS_IDS.PARTY,
     header: ({ column }) => {
       return <SortableHeader column={column}>Party</SortableHeader>
     },
@@ -116,5 +154,5 @@ export const getDTSIClientPersonDataTableColumns = ({
           : '-'}
       </>
     ),
-  },
+  }),
 ]

--- a/src/components/app/dtsiClientPersonDataTable/filters.ts
+++ b/src/components/app/dtsiClientPersonDataTable/filters.ts
@@ -1,0 +1,75 @@
+import { FilterFn } from '@tanstack/react-table'
+import isNil from 'lodash-es/isNil'
+
+import {
+  Person,
+  PERSON_TABLE_COLUMNS_IDS,
+} from '@/components/app/dtsiClientPersonDataTable/columns'
+import {
+  PARTY_OPTIONS,
+  ROLE_OPTIONS,
+  StanceOnCryptoOptions,
+} from '@/components/app/dtsiClientPersonDataTable/globalFiltersUtils'
+import { DTSI_PersonRoleCategory, DTSI_PersonRoleStatus } from '@/data/dtsi/generated'
+
+/**
+ * Custom filter logic for each Column.
+ *
+ * @see https://tanstack.com/table/latest/docs/guide/column-filtering#filterfns
+ */
+export const getPersonDataTableFilterFns = (): Record<
+  PERSON_TABLE_COLUMNS_IDS,
+  FilterFn<Person>
+> => ({
+  [PERSON_TABLE_COLUMNS_IDS.FULL_NAME]: () => true,
+
+  [PERSON_TABLE_COLUMNS_IDS.STANCE]: (row, columnId, filterValue, addMeta) => {
+    if (filterValue === StanceOnCryptoOptions.ALL) {
+      return true
+    }
+    const scoreToUse =
+      row.original.manuallyOverriddenStanceScore ?? row.original.computedStanceScore
+    if (filterValue === StanceOnCryptoOptions.PENDING) {
+      return isNil(scoreToUse)
+    }
+    if (filterValue === StanceOnCryptoOptions.NEUTRAL) {
+      return scoreToUse === 50
+    }
+    const stance =
+      !scoreToUse || scoreToUse === 50
+        ? null
+        : scoreToUse > 50
+          ? StanceOnCryptoOptions.PRO_CRYPTO
+          : StanceOnCryptoOptions.ANTI_CRYPTO
+    return stance === filterValue
+  },
+
+  [PERSON_TABLE_COLUMNS_IDS.ROLE]: (row, columnId, filterValue, addMeta) => {
+    if (filterValue === ROLE_OPTIONS.ALL) {
+      return true
+    }
+    if ([ROLE_OPTIONS.SENATE, ROLE_OPTIONS.CONGRESS].includes(filterValue)) {
+      return (
+        filterValue === row.original.primaryRole?.roleCategory &&
+        row.original.primaryRole?.status === DTSI_PersonRoleStatus.HELD
+      )
+    }
+    return (
+      !row.original.primaryRole?.roleCategory ||
+      ![DTSI_PersonRoleCategory.SENATE, DTSI_PersonRoleCategory.CONGRESS].includes(
+        row.original.primaryRole?.roleCategory,
+      ) ||
+      row.original.primaryRole?.status !== DTSI_PersonRoleStatus.HELD
+    )
+  },
+
+  [PERSON_TABLE_COLUMNS_IDS.PARTY]: (row, columnId, filterValue, addMeta) => {
+    return (
+      filterValue === PARTY_OPTIONS.ALL || filterValue === row.original.politicalAffiliationCategory
+    )
+  },
+
+  [PERSON_TABLE_COLUMNS_IDS.STATE]: (row, columnId, filterValue, addMeta) => {
+    return filterValue === 'All' || row.original.primaryRole?.primaryState === filterValue
+  },
+})

--- a/src/components/app/dtsiClientPersonDataTable/filters.ts
+++ b/src/components/app/dtsiClientPersonDataTable/filters.ts
@@ -23,7 +23,7 @@ export const getPersonDataTableFilterFns = (): Record<
 > => ({
   [PERSON_TABLE_COLUMNS_IDS.FULL_NAME]: () => true,
 
-  [PERSON_TABLE_COLUMNS_IDS.STANCE]: (row, columnId, filterValue, addMeta) => {
+  [PERSON_TABLE_COLUMNS_IDS.STANCE]: (row, _columnId, filterValue, _addMeta) => {
     if (filterValue === StanceOnCryptoOptions.ALL) {
       return true
     }
@@ -44,7 +44,7 @@ export const getPersonDataTableFilterFns = (): Record<
     return stance === filterValue
   },
 
-  [PERSON_TABLE_COLUMNS_IDS.ROLE]: (row, columnId, filterValue, addMeta) => {
+  [PERSON_TABLE_COLUMNS_IDS.ROLE]: (row, _columnId, filterValue, _addMeta) => {
     if (filterValue === ROLE_OPTIONS.ALL) {
       return true
     }
@@ -63,13 +63,13 @@ export const getPersonDataTableFilterFns = (): Record<
     )
   },
 
-  [PERSON_TABLE_COLUMNS_IDS.PARTY]: (row, columnId, filterValue, addMeta) => {
+  [PERSON_TABLE_COLUMNS_IDS.PARTY]: (row, _columnId, filterValue, _addMeta) => {
     return (
       filterValue === PARTY_OPTIONS.ALL || filterValue === row.original.politicalAffiliationCategory
     )
   },
 
-  [PERSON_TABLE_COLUMNS_IDS.STATE]: (row, columnId, filterValue, addMeta) => {
+  [PERSON_TABLE_COLUMNS_IDS.STATE]: (row, _columnId, filterValue, _addMeta) => {
     return filterValue === 'All' || row.original.primaryRole?.primaryState === filterValue
   },
 })

--- a/src/components/app/dtsiClientPersonDataTable/globalFiltersUtils.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/globalFiltersUtils.tsx
@@ -88,7 +88,6 @@ const stateOptions = ['All', ...Object.keys(US_STATE_CODE_TO_DISPLAY_NAME_MAP).s
 export function GlobalFilters<TData extends Person = Person>({
   columns,
 }: GlobalFilterProps<TData>) {
-  // const namedColumns = Object.groupBy(columns, ({ id }) => id)
   const namedColumns = useMemo(() => {
     const ids: Record<string, Column<TData>> = {}
     columns.forEach(col => {


### PR DESCRIPTION
closes #568

## What changed? Why?
Fixed broken e2e test for politicians page.

## Notes to reviewers
<img width="526" alt="Screenshot 2024-04-22 at 13 51 33" src="https://github.com/Stand-With-Crypto/swc-web/assets/167582510/3925802c-914f-4b15-9f16-5f11d4daf9b4">

The test was breaking because Cypress flags the button as not-actionable due to it being outside the viewport. To fix it, we only need to call `scrollIntoView()`. Another option is to use `click({ force: true })` to skip visibility checks, but that's not ideal.

But theres another problem:

<img width="511" alt="Screenshot 2024-04-22 at 14 11 18" src="https://github.com/Stand-With-Crypto/swc-web/assets/167582510/dabefaa8-1655-49e4-aa5c-644bcbf63e86">

Interacting with the filters too fast may introduce too many rerenders and break the test. One band-aid solution would be to call `cy.wait()` after every filter is applied. However, the ideal solution is to let react-table handle the filters state.

I refactored the way filters are handled to be more in line with the react-table documentation. By doing so, rerenders have been reduced and there's no need for `cy.wait()` calls.


## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
