### PR TITLE
fix bug where stances were being shown as pending when score was zero

### DIFF
--- a/src/components/app/cryptoSupportHighlight/index.tsx
+++ b/src/components/app/cryptoSupportHighlight/index.tsx
@@ -14,7 +14,7 @@ export function CryptoSupportHighlight({
   className,
 }: {
   className?: string
-  stanceScore: number | null
+  stanceScore: number | null | undefined
   text?: string
 }) {
   return (

--- a/src/components/app/pagePoliticianDetails/index.tsx
+++ b/src/components/app/pagePoliticianDetails/index.tsx
@@ -24,7 +24,6 @@ import {
   getDTSIPersonProfilePictureUrlDimensions,
 } from '@/utils/dtsi/dtsiPersonUtils'
 import { dtsiTwitterAccountUrl } from '@/utils/dtsi/dtsiTwitterAccountUtils'
-import { prettyLog } from '@/utils/shared/prettyLog'
 
 const POLITICIAN_IMAGE_SIZE_PX = 230
 
@@ -36,7 +35,6 @@ export function PagePoliticianDetails({
   locale: SupportedLocale
 }) {
   const stances = orderBy(person.stances, x => -1 * new Date(x.dateStanceMade).getTime())
-  prettyLog(stances)
   return (
     <div className="container max-w-3xl">
       <section>

--- a/src/components/app/pagePoliticianDetails/index.tsx
+++ b/src/components/app/pagePoliticianDetails/index.tsx
@@ -24,6 +24,7 @@ import {
   getDTSIPersonProfilePictureUrlDimensions,
 } from '@/utils/dtsi/dtsiPersonUtils'
 import { dtsiTwitterAccountUrl } from '@/utils/dtsi/dtsiTwitterAccountUtils'
+import { prettyLog } from '@/utils/shared/prettyLog'
 
 const POLITICIAN_IMAGE_SIZE_PX = 230
 
@@ -35,6 +36,7 @@ export function PagePoliticianDetails({
   locale: SupportedLocale
 }) {
   const stances = orderBy(person.stances, x => -1 * new Date(x.dateStanceMade).getTime())
+  prettyLog(stances)
   return (
     <div className="container max-w-3xl">
       <section>
@@ -134,7 +136,7 @@ export function PagePoliticianDetails({
                 <DTSIStanceDetails locale={locale} person={person} stance={stance} />
                 <CryptoSupportHighlight
                   className="mx-auto mt-2"
-                  stanceScore={stance.computedStanceScore || null}
+                  stanceScore={stance.computedStanceScore}
                 />
               </div>
             )

--- a/src/utils/dtsi/dtsiStanceScoreUtils.ts
+++ b/src/utils/dtsi/dtsiStanceScoreUtils.ts
@@ -102,7 +102,7 @@ export const convertDTSIStanceScoreToCryptoSupportLanguage = (score: number | nu
   return 'Very anti-crypto'
 }
 
-export const convertDTSIStanceScoreToTextColorClass = (score: number | null) => {
+export const convertDTSIStanceScoreToTextColorClass = (score: number | null | undefined) => {
   if (isNil(score)) {
     return twNoop('text-gray-600')
   }
@@ -115,7 +115,7 @@ export const convertDTSIStanceScoreToTextColorClass = (score: number | null) => 
   return twNoop('text-red-600')
 }
 
-export const convertDTSIStanceScoreToBgColorClass = (score: number | null) => {
+export const convertDTSIStanceScoreToBgColorClass = (score: number | null | undefined) => {
   if (isNil(score)) {
     return twNoop('bg-gray-100')
   }

--- a/src/utils/dtsi/dtsiStanceScoreUtils.ts
+++ b/src/utils/dtsi/dtsiStanceScoreUtils.ts
@@ -83,7 +83,7 @@ export const convertDTSIPersonStanceScoreToCryptoSupportLanguageSentence = (
   return 'Strongly against crypto'
 }
 
-export const convertDTSIStanceScoreToCryptoSupportLanguage = (score: number | null) => {
+export const convertDTSIStanceScoreToCryptoSupportLanguage = (score: number | null | undefined) => {
   if (isNil(score)) {
     return 'Pending Analysis'
   }


### PR DESCRIPTION
fix bug where stances were being shown as pending when score was zero

## UI changes

### Web

| Old 👴         | New 👶         |
| -------------- | -------------- |
| ![image](https://github.com/Stand-With-Crypto/swc-web/assets/153657370/db82e514-c805-4da4-bd8a-72d23b3ee7bb) | ![image](https://github.com/Stand-With-Crypto/swc-web/assets/153657370/232807ad-9863-4ff9-b678-2e67e4bfd2bb) |


## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Change management

type=routine <!-- routine nonroutine emergency -->
risk=low <!-- low medium high -->
impact=sev5 <!-- sev5 sev4 sev3 sev2 sev1  -->
