### PR TITLE
Prevents overscroll on deeplinks

### DIFF
--- a/src/app/[locale]/(homepageDialogDeeplink)/action/nft-mint/page.tsx
+++ b/src/app/[locale]/(homepageDialogDeeplink)/action/nft-mint/page.tsx
@@ -1,6 +1,9 @@
+'use client'
+
 import { HomepageDialogDeeplinkLayout } from '@/components/app/homepageDialogDeeplinkLayout'
 import { UserActionFormNFTMint } from '@/components/app/userActionFormNFTMint'
 import { dialogContentPaddingStyles } from '@/components/ui/dialog/styles'
+import { usePreventOverscroll } from '@/hooks/usePreventOverscroll'
 import { PageProps } from '@/types'
 import { SECONDS_DURATION } from '@/utils/shared/seconds'
 import { cn } from '@/utils/web/cn'
@@ -9,6 +12,8 @@ export const revalidate = SECONDS_DURATION.HOUR
 export const dynamic = 'error'
 
 export default function UserActionNFTMintDeepLink({ params }: PageProps) {
+  usePreventOverscroll()
+
   return (
     <HomepageDialogDeeplinkLayout pageParams={params}>
       <div

--- a/src/app/[locale]/(homepageDialogDeeplink)/action/nft-mint/page.tsx
+++ b/src/app/[locale]/(homepageDialogDeeplink)/action/nft-mint/page.tsx
@@ -1,9 +1,6 @@
-'use client'
-
 import { HomepageDialogDeeplinkLayout } from '@/components/app/homepageDialogDeeplinkLayout'
-import { UserActionFormNFTMint } from '@/components/app/userActionFormNFTMint'
+import { HomepageDialogDeeplinkNFTMintWrapper } from '@/components/app/userActionFormNFTMint/homepageDialogDeeplinkNFTMintWrapper'
 import { dialogContentPaddingStyles } from '@/components/ui/dialog/styles'
-import { usePreventOverscroll } from '@/hooks/usePreventOverscroll'
 import { PageProps } from '@/types'
 import { SECONDS_DURATION } from '@/utils/shared/seconds'
 import { cn } from '@/utils/web/cn'
@@ -12,8 +9,6 @@ export const revalidate = SECONDS_DURATION.HOUR
 export const dynamic = 'error'
 
 export default function UserActionNFTMintDeepLink({ params }: PageProps) {
-  usePreventOverscroll()
-
   return (
     <HomepageDialogDeeplinkLayout pageParams={params}>
       <div
@@ -22,7 +17,7 @@ export default function UserActionNFTMintDeepLink({ params }: PageProps) {
           dialogContentPaddingStyles,
         )}
       >
-        <UserActionFormNFTMint trackMount />
+        <HomepageDialogDeeplinkNFTMintWrapper />
       </div>
     </HomepageDialogDeeplinkLayout>
   )

--- a/src/app/[locale]/(homepageDialogDeeplink)/action/sign-up/page.tsx
+++ b/src/app/[locale]/(homepageDialogDeeplink)/action/sign-up/page.tsx
@@ -5,10 +5,13 @@ import { useRouter } from 'next/navigation'
 import { ThirdwebLoginContent } from '@/components/app/authentication/thirdwebLoginContent'
 import { dialogContentPaddingStyles } from '@/components/ui/dialog/styles'
 import { useIntlUrls } from '@/hooks/useIntlUrls'
+import { usePreventOverscroll } from '@/hooks/usePreventOverscroll'
 import { useSession } from '@/hooks/useSession'
 import { cn } from '@/utils/web/cn'
 
 export default function UserActionOptInSWCDeepLink() {
+  usePreventOverscroll()
+
   const urls = useIntlUrls()
   const router = useRouter()
   const session = useSession()

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -70,6 +70,20 @@ const InitialOrchestration = () => {
   return null
 }
 
+export function DeeplinkPagesLogic() {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (pathname?.includes('/action/')) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'scroll'
+    }
+  }, [pathname])
+
+  return null
+}
+
 // This component includes all top level client-side logic
 export function TopLevelClientLogic({
   children,
@@ -104,6 +118,7 @@ export function TopLevelClientLogic({
           <InitialOrchestration />
         </Suspense>
         {children}
+        <DeeplinkPagesLogic />
       </ThirdwebProvider>
     </LocaleContext.Provider>
   )

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -15,6 +15,7 @@ import { usePathname, useSearchParams } from 'next/navigation'
 import { useThirdwebAuthUser } from '@/hooks/useAuthUser'
 import { useDetectWipedDatabaseAndLogOutUser } from '@/hooks/useDetectWipedDatabaseAndLogOutUser'
 import { LocaleContext } from '@/hooks/useLocale'
+import { usePreventOverscroll } from '@/hooks/usePreventOverscroll'
 import { SupportedLocale } from '@/intl/locales'
 import { requiredEnv } from '@/utils/shared/requiredEnv'
 import { AnalyticActionType, AnalyticComponentType } from '@/utils/shared/sharedAnalytics'
@@ -70,20 +71,6 @@ const InitialOrchestration = () => {
   return null
 }
 
-function DeeplinkPagesLogic() {
-  const pathname = usePathname()
-
-  useEffect(() => {
-    if (pathname?.includes('/action/')) {
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = 'scroll'
-    }
-  }, [pathname])
-
-  return null
-}
-
 // This component includes all top level client-side logic
 export function TopLevelClientLogic({
   children,
@@ -92,6 +79,8 @@ export function TopLevelClientLogic({
   children: React.ReactNode
   locale: SupportedLocale
 }) {
+  usePreventOverscroll()
+
   return (
     <LocaleContext.Provider value={locale}>
       <ThirdwebProvider
@@ -118,7 +107,6 @@ export function TopLevelClientLogic({
           <InitialOrchestration />
         </Suspense>
         {children}
-        <DeeplinkPagesLogic />
       </ThirdwebProvider>
     </LocaleContext.Provider>
   )

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -70,7 +70,7 @@ const InitialOrchestration = () => {
   return null
 }
 
-export function DeeplinkPagesLogic() {
+function DeeplinkPagesLogic() {
   const pathname = usePathname()
 
   useEffect(() => {

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -15,7 +15,6 @@ import { usePathname, useSearchParams } from 'next/navigation'
 import { useThirdwebAuthUser } from '@/hooks/useAuthUser'
 import { useDetectWipedDatabaseAndLogOutUser } from '@/hooks/useDetectWipedDatabaseAndLogOutUser'
 import { LocaleContext } from '@/hooks/useLocale'
-import { usePreventOverscroll } from '@/hooks/usePreventOverscroll'
 import { SupportedLocale } from '@/intl/locales'
 import { requiredEnv } from '@/utils/shared/requiredEnv'
 import { AnalyticActionType, AnalyticComponentType } from '@/utils/shared/sharedAnalytics'
@@ -79,8 +78,6 @@ export function TopLevelClientLogic({
   children: React.ReactNode
   locale: SupportedLocale
 }) {
-  usePreventOverscroll()
-
   return (
     <LocaleContext.Provider value={locale}>
       <ThirdwebProvider

--- a/src/components/app/userActionFormCallCongressperson/homepageDialogDeeplinkWrapper.tsx
+++ b/src/components/app/userActionFormCallCongressperson/homepageDialogDeeplinkWrapper.tsx
@@ -11,8 +11,11 @@ import { trackDialogOpen } from '@/components/ui/dialog/trackDialogOpen'
 import { useApiResponseForUserFullProfileInfo } from '@/hooks/useApiResponseForUserFullProfileInfo'
 import { useEncodedInitialValuesQueryParam } from '@/hooks/useEncodedInitialValuesQueryParam'
 import { useIntlUrls } from '@/hooks/useIntlUrls'
+import { usePreventOverscroll } from '@/hooks/usePreventOverscroll'
 
 function UserActionFormCallCongresspersonDeeplinkWrapperContent() {
+  usePreventOverscroll()
+
   const fetchUser = useApiResponseForUserFullProfileInfo()
   const urls = useIntlUrls()
   const router = useRouter()

--- a/src/components/app/userActionFormEmailCongressperson/homepageDialogDeeplinkWrapper.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/homepageDialogDeeplinkWrapper.tsx
@@ -13,10 +13,13 @@ import { trackDialogOpen } from '@/components/ui/dialog/trackDialogOpen'
 import { useApiResponseForUserFullProfileInfo } from '@/hooks/useApiResponseForUserFullProfileInfo'
 import { useEncodedInitialValuesQueryParam } from '@/hooks/useEncodedInitialValuesQueryParam'
 import { useLocale } from '@/hooks/useLocale'
+import { usePreventOverscroll } from '@/hooks/usePreventOverscroll'
 import { getIntlUrls } from '@/utils/shared/urls'
 import { cn } from '@/utils/web/cn'
 
 function UserActionFormEmailCongresspersonDeeplinkWrapperContent() {
+  usePreventOverscroll()
+
   const fetchUser = useApiResponseForUserFullProfileInfo()
   const router = useRouter()
   const locale = useLocale()

--- a/src/components/app/userActionFormEmailCongressperson/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/index.tsx
@@ -130,7 +130,7 @@ export function UserActionFormEmailCongressperson({
   return (
     <Form {...form}>
       <form
-        className="flex h-full max-h-dvh flex-col"
+        className="flex min-h-dvh flex-col"
         onSubmit={form.handleSubmit(async values => {
           const address = await convertGooglePlaceAutoPredictionToAddressSchema(
             values.address,

--- a/src/components/app/userActionFormEmailCongressperson/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/index.tsx
@@ -130,7 +130,7 @@ export function UserActionFormEmailCongressperson({
   return (
     <Form {...form}>
       <form
-        className="flex min-h-dvh flex-col"
+        className="flex h-full min-h-[calc(100dvh-4px)] flex-col"
         onSubmit={form.handleSubmit(async values => {
           const address = await convertGooglePlaceAutoPredictionToAddressSchema(
             values.address,

--- a/src/components/app/userActionFormLiveEvent/homepageDialogDeeplinkWrapper.tsx.tsx
+++ b/src/components/app/userActionFormLiveEvent/homepageDialogDeeplinkWrapper.tsx.tsx
@@ -11,11 +11,14 @@ import { ANALYTICS_NAME_USER_ACTION_FORM_LIVE_EVENT } from '@/components/app/use
 import { UserActionFormLiveEventSkeleton } from '@/components/app/userActionFormLiveEvent/skeleton'
 import { trackDialogOpen } from '@/components/ui/dialog/trackDialogOpen'
 import { useIntlUrls } from '@/hooks/useIntlUrls'
+import { usePreventOverscroll } from '@/hooks/usePreventOverscroll'
 import { useSession } from '@/hooks/useSession'
 
 export function UserActionFormLiveEventDeeplinkWrapper({
   slug,
 }: Pick<UserActionFormLiveEventProps, 'slug'>) {
+  usePreventOverscroll()
+
   const urls = useIntlUrls()
   const router = useRouter()
   const session = useSession()

--- a/src/components/app/userActionFormNFTMint/homepageDialogDeeplinkNFTMintWrapper.tsx
+++ b/src/components/app/userActionFormNFTMint/homepageDialogDeeplinkNFTMintWrapper.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { UserActionFormNFTMint } from '@/components/app/userActionFormNFTMint'
+import { usePreventOverscroll } from '@/hooks/usePreventOverscroll'
+
+export function HomepageDialogDeeplinkNFTMintWrapper() {
+  usePreventOverscroll()
+
+  return <UserActionFormNFTMint trackMount />
+}

--- a/src/components/app/userActionFormVoterRegistration/homepageDialogDeeplinkWrapper.tsx
+++ b/src/components/app/userActionFormVoterRegistration/homepageDialogDeeplinkWrapper.tsx
@@ -7,8 +7,11 @@ import { UserActionFormVoterRegistration } from '@/components/app/userActionForm
 import { ANALYTICS_NAME_USER_ACTION_FORM_VOTER_REGISTRATION } from '@/components/app/userActionFormVoterRegistration/constants'
 import { trackDialogOpen } from '@/components/ui/dialog/trackDialogOpen'
 import { useIntlUrls } from '@/hooks/useIntlUrls'
+import { usePreventOverscroll } from '@/hooks/usePreventOverscroll'
 
 export function UserActionFormVoterRegistrationDeeplinkWrapper() {
+  usePreventOverscroll()
+
   const urls = useIntlUrls()
   const router = useRouter()
   useEffect(() => {

--- a/src/hooks/usePreventOverscroll.ts
+++ b/src/hooks/usePreventOverscroll.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+
+export function usePreventOverscroll() {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (pathname?.includes('/action/')) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'scroll'
+    }
+  }, [pathname])
+}

--- a/src/hooks/usePreventOverscroll.ts
+++ b/src/hooks/usePreventOverscroll.ts
@@ -1,14 +1,11 @@
 import { useEffect } from 'react'
-import { usePathname } from 'next/navigation'
 
 export function usePreventOverscroll() {
-  const pathname = usePathname()
-
   useEffect(() => {
-    if (pathname?.includes('/action/')) {
-      document.body.style.overflow = 'hidden'
-    } else {
+    document.body.style.overflow = 'hidden'
+
+    return () => {
       document.body.style.overflow = 'scroll'
     }
-  }, [pathname])
+  }, [])
 }


### PR DESCRIPTION
closes #787

## What changed? Why?

- Even though there is a CSS property called overscroll that should prevent the background scrolling behavior, it didn't work in any scenario that I tested. 

P.S.: I also didn't remove the homepage content from the background because on desktop the user can see what is behind the modal because it is not full height/width

## How has it been tested?

- [X] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
