### PR TITLE
increase font-size for politician og-images, and fix spacing bug on profile form

### DIFF
--- a/src/components/app/pagePoliticianDetails/generateOgImage.tsx
+++ b/src/components/app/pagePoliticianDetails/generateOgImage.tsx
@@ -101,8 +101,8 @@ export async function generateOgImage({ params }: { params: { dtsiSlug: string }
                   borderRadius: '50%',
                   overflow: 'hidden',
                   objectFit: 'cover',
-                  width: '200px',
-                  height: '200px',
+                  width: '300px',
+                  height: '300px',
                 }}
               />
               <img
@@ -112,7 +112,7 @@ export async function generateOgImage({ params }: { params: { dtsiSlug: string }
                   position: 'absolute',
                   bottom: 0,
                   right: 0,
-                  width: '60px',
+                  width: '90px',
                 }}
               />
             </div>
@@ -125,8 +125,8 @@ export async function generateOgImage({ params }: { params: { dtsiSlug: string }
                   backgroundColor: 'white',
                   overflow: 'hidden',
                   objectFit: 'cover',
-                  width: '200px',
-                  height: '200px',
+                  width: '300px',
+                  height: '300px',
                   justifyContent: 'center',
                   alignItems: 'center',
                 }}
@@ -151,17 +151,15 @@ export async function generateOgImage({ params }: { params: { dtsiSlug: string }
                   position: 'absolute',
                   bottom: 0,
                   right: 0,
-                  width: '60px',
+                  width: '90px',
                 }}
               />
             </div>
           )}
-          <div tw="flex-col text-xl mb-2 mt-8 flex text-gray-400 justify-center items-center">
-            <span tw="text-white mx-2 text-[40px] leading-[48px] pb-4">
-              {dtsiPersonFullName(person)}
-            </span>
+          <div tw="flex-col text-xl mb-2 mt-8 flex justify-center items-center">
+            <span tw="text-white mx-2 text-6xl pb-4">{dtsiPersonFullName(person)}</span>
             <br />
-            {scoreLanguage}
+            <span tw="text-4xl text-gray-400">{scoreLanguage}</span>
           </div>
         </div>
         <div tw="text-gray-400 pt-9">standwithcrypto.org</div>

--- a/src/components/app/updateUserProfileForm/step1.tsx
+++ b/src/components/app/updateUserProfileForm/step1.tsx
@@ -251,7 +251,7 @@ export function UpdateUserProfileForm({
           </Collapsible>
           <FormGeneralErrorMessage control={form.control} />
         </div>
-        <div className="!mt-auto flex justify-center gap-6">
+        <div className="flex justify-center gap-6 max-md:!mt-auto md:mt-4">
           <Button
             className="w-full md:w-1/2"
             disabled={form.formState.isSubmitting}


### PR DESCRIPTION

## What changed? Why?
Before
![image](https://github.com/Stand-With-Crypto/swc-web/assets/153657370/25000014-a755-46e7-aa4b-04242328db44)
![image](https://github.com/Stand-With-Crypto/swc-web/assets/153657370/adb21c77-d9c8-4b7e-a7fc-c1ab955746a5)

After
![image](https://github.com/Stand-With-Crypto/swc-web/assets/153657370/fcfe8e9c-7756-4308-aff3-d028fbb34000)
![image](https://github.com/Stand-With-Crypto/swc-web/assets/153657370/fb021b4a-e654-4f5e-9773-7a1cd679a54b)

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
