### PR TITLE
style: fixing email modal height

### DIFF
--- a/src/components/app/userActionFormEmailCongressperson/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/index.tsx
@@ -130,7 +130,7 @@ export function UserActionFormEmailCongressperson({
   return (
     <Form {...form}>
       <form
-        className="flex h-full min-h-[calc(100dvh-4px)] flex-col"
+        className="flex h-full flex-col"
         onSubmit={form.handleSubmit(async values => {
           const address = await convertGooglePlaceAutoPredictionToAddressSchema(
             values.address,
@@ -316,7 +316,7 @@ export function UserActionFormEmailCongressperson({
           </div>
         </ScrollArea>
         <div
-          className="z-10 mt-auto flex flex-1 flex-col items-center justify-end border border-t p-6 sm:flex-row md:px-12"
+          className="z-10 mt-auto flex flex-col items-center justify-end border border-t p-6 sm:flex-row md:px-12"
           style={{ boxShadow: 'rgba(0, 0, 0, 0.2) 0px 1px 6px 0px' }}
         >
           <Button


### PR DESCRIPTION
## What changed? Why?

Returning email modal to be full height only on mobile. Tested the homepage modal and action flow on desktop and mobile and everything is working as expected.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
