### PR TITLE
Do not auto-focus inputs for actions on mobile

### DIFF
--- a/src/components/app/userActionFormEmailCongressperson/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/index.tsx
@@ -35,6 +35,7 @@ import { PageTitle } from '@/components/ui/pageTitleText'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Textarea } from '@/components/ui/textarea'
 import { useIntlUrls } from '@/hooks/useIntlUrls'
+import { useIsDesktop } from '@/hooks/useIsDesktop'
 import { convertAddressToAnalyticsProperties } from '@/utils/shared/sharedAnalytics'
 import { UserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns'
 import {
@@ -106,6 +107,7 @@ export function UserActionFormEmailCongressperson({
   initialValues?: FormFields
   politicianCategory?: YourPoliticianCategory
 }) {
+  const isDesktop = useIsDesktop()
   const router = useRouter()
   const urls = useIntlUrls()
   const hasModifiedMessage = useRef(false)
@@ -124,8 +126,8 @@ export function UserActionFormEmailCongressperson({
   })
 
   React.useEffect(() => {
-    form.setFocus('firstName')
-  }, [form])
+    if (isDesktop) form.setFocus('firstName')
+  }, [form, isDesktop])
 
   return (
     <Form {...form}>

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -71,7 +71,7 @@ export function Combobox<T>({
     return (
       <Dialog analytics={wrappedAnalytics} onOpenChange={setOpen} open={open}>
         <DialogTrigger asChild>{formatPopoverTrigger({ value, open })}</DialogTrigger>
-        <DialogContent className="min-h-[260px] p-0 pt-10">
+        <DialogContent className="min-h-[260px] p-0 pt-10" forceAutoFocus>
           <StatusList
             setOpen={setOpen}
             {...{

--- a/src/components/ui/dialog/index.tsx
+++ b/src/components/ui/dialog/index.tsx
@@ -12,6 +12,7 @@ import {
   dialogFooterCTAStyles,
   dialogOverlayStyles,
 } from '@/components/ui/dialog/styles'
+import { useIsMobile } from '@/hooks/useIsMobile'
 import { cn } from '@/utils/web/cn'
 import { PrimitiveComponentAnalytics } from '@/utils/web/primitiveComponentAnalytics'
 
@@ -48,31 +49,43 @@ interface DialogContentProps
   extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
   padding?: boolean
   closeClassName?: string
+  forceAutoFocus?: boolean
 }
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
 >(
   (
-    { className, children, padding = true, onOpenAutoFocus, closeClassName = '', ...props },
+    {
+      className,
+      children,
+      padding = true,
+      forceAutoFocus = false,
+      onOpenAutoFocus,
+      closeClassName = '',
+      ...props
+    },
     ref,
-  ) => (
-    <DialogPortal>
-      <DialogOverlay />
-      <DialogPrimitive.Content
-        className={cn(dialogContentStyles, padding && dialogContentPaddingStyles, className)}
-        onOpenAutoFocus={onOpenAutoFocus ? e => onOpenAutoFocus(e) : e => e.preventDefault()}
-        ref={ref}
-        {...props}
-      >
-        {children}
-        <DialogPrimitive.Close className={cn(dialogCloseStyles, closeClassName)} tabIndex={-1}>
-          <X size={20} />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
-      </DialogPrimitive.Content>
-    </DialogPortal>
-  ),
+  ) => {
+    const isMobile = useIsMobile()
+    return (
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+          className={cn(dialogContentStyles, padding && dialogContentPaddingStyles, className)}
+          onOpenAutoFocus={isMobile && !forceAutoFocus ? e => e.preventDefault() : onOpenAutoFocus}
+          ref={ref}
+          {...props}
+        >
+          {children}
+          <DialogPrimitive.Close className={cn(dialogCloseStyles, closeClassName)} tabIndex={-1}>
+            <X size={20} />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    )
+  },
 )
 DialogContent.displayName = DialogPrimitive.Content.displayName
 

--- a/src/components/ui/dialog/index.tsx
+++ b/src/components/ui/dialog/index.tsx
@@ -52,22 +52,28 @@ interface DialogContentProps
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
->(({ className, children, padding = true, closeClassName = '', ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      className={cn(dialogContentStyles, padding && dialogContentPaddingStyles, className)}
-      ref={ref}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className={cn(dialogCloseStyles, closeClassName)} tabIndex={-1}>
-        <X size={20} />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-))
+>(
+  (
+    { className, children, padding = true, onOpenAutoFocus, closeClassName = '', ...props },
+    ref,
+  ) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        className={cn(dialogContentStyles, padding && dialogContentPaddingStyles, className)}
+        onOpenAutoFocus={onOpenAutoFocus ? e => onOpenAutoFocus(e) : e => e.preventDefault()}
+        ref={ref}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className={cn(dialogCloseStyles, closeClassName)} tabIndex={-1}>
+          <X size={20} />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  ),
+)
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->
#818 

fixes

## What changed? Why?

- Disabled radix-ui Dialog's default behavior of auto-focusing on its first focusable child when opened.
- Focus on input only on Desktop devices.

## Notes to reviewers

This behavior was impacting different flows, but just one of them was focusing on a input (`UserActionFormEmailCongressperson`).

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
