### PR TITLE
iOS keyboard offsetting the address input dialog

### DIFF
--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -55,7 +55,6 @@ export function Combobox<T>({
   const parentRef = React.useRef<HTMLButtonElement>(null)
   const isMobile = useIsMobile({ defaultState: false })
   const size = useResizeObserver(parentRef)
-  usePreventMobileKeyboardOffset(open)
   const wrappedAnalytics = React.useCallback(
     (newOpen: boolean) =>
       trackPrimitiveComponentAnalytics(
@@ -135,6 +134,8 @@ function StatusList<T>({
   | 'getOptionKey'
   | 'isLoading'
 >) {
+  usePreventMobileKeyboardOffset()
+
   return (
     <Command shouldFilter={false}>
       <CommandInput

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -12,6 +12,7 @@ import {
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useIsMobile } from '@/hooks/useIsMobile'
+import { usePreventMobileKeyboardOffset } from '@/hooks/usePreventMobileKeyboardOffset'
 import { useResizeObserver } from '@/hooks/useResizeObserver'
 import { trackClientAnalytic } from '@/utils/web/clientAnalytics'
 import { cn } from '@/utils/web/cn'
@@ -54,6 +55,7 @@ export function Combobox<T>({
   const parentRef = React.useRef<HTMLButtonElement>(null)
   const isMobile = useIsMobile({ defaultState: false })
   const size = useResizeObserver(parentRef)
+  usePreventMobileKeyboardOffset(open)
   const wrappedAnalytics = React.useCallback(
     (newOpen: boolean) =>
       trackPrimitiveComponentAnalytics(

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -52,6 +52,7 @@ export function Combobox<T>({
   setOpen,
   ...inputProps
 }: ComboBoxProps<T>) {
+  usePreventMobileKeyboardOffset(open)
   const parentRef = React.useRef<HTMLButtonElement>(null)
   const isMobile = useIsMobile({ defaultState: false })
   const size = useResizeObserver(parentRef)
@@ -134,8 +135,6 @@ function StatusList<T>({
   | 'getOptionKey'
   | 'isLoading'
 >) {
-  usePreventMobileKeyboardOffset()
-
   return (
     <Command shouldFilter={false}>
       <CommandInput

--- a/src/hooks/usePreventMobileKeyboardOffset.ts
+++ b/src/hooks/usePreventMobileKeyboardOffset.ts
@@ -3,7 +3,7 @@ import * as React from 'react'
 
 import { useIsMobile } from '@/hooks/useIsMobile'
 
-const OFFSET_SCROLLY_TO_ACTUAL_HEIGHT = 148
+const DIFF_SCROLL_Y_TO_ACTUAL_HEIGHT = 148
 
 function getScrollHeight() {
   if (typeof sessionStorage === 'undefined') return null
@@ -20,7 +20,7 @@ function resetScrollPosition() {
   const scrollHeight = getScrollHeight()
   if (!scrollHeight) return
 
-  window.scrollTo(0, Number(scrollHeight) - OFFSET_SCROLLY_TO_ACTUAL_HEIGHT)
+  window.scrollTo(0, Number(scrollHeight) - DIFF_SCROLL_Y_TO_ACTUAL_HEIGHT)
   sessionStorage.removeItem('scrollHeight')
   return
 }

--- a/src/hooks/usePreventMobileKeyboardOffset.ts
+++ b/src/hooks/usePreventMobileKeyboardOffset.ts
@@ -3,32 +3,36 @@ import * as React from 'react'
 
 import { useIsMobile } from '@/hooks/useIsMobile'
 
-export function usePreventMobileKeyboardOffset(enabled: boolean) {
+const OFFSET_SCROLLY_TO_ACTUAL_HEIGHT = 148
+
+function getScrollHeight() {
+  if (typeof sessionStorage === 'undefined') return null
+  return sessionStorage.getItem('scrollHeight')
+}
+
+function setScrollHeight() {
+  sessionStorage.setItem('scrollHeight', String(window.scrollY))
+  window.scrollTo(0, 0)
+  return
+}
+
+function resetScrollPosition() {
+  const scrollHeight = getScrollHeight()
+  if (!scrollHeight) return
+
+  window.scrollTo(0, Number(scrollHeight) - OFFSET_SCROLLY_TO_ACTUAL_HEIGHT)
+  sessionStorage.removeItem('scrollHeight')
+  return
+}
+
+export function usePreventMobileKeyboardOffset() {
   const isMobile = useIsMobile()
 
-  const scrollHeight =
-    typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('scrollHeight') : null
-
-  const handleKeyboardOffset = React.useCallback(() => {
-    if (!isMobile) return
-
-    if (enabled) {
-      sessionStorage.setItem('scrollHeight', String(window.scrollY))
-      window.scrollTo(0, 0)
-      return
-    }
-
-    if (!scrollHeight) return
-    window.scrollTo(0, Number(scrollHeight))
-    sessionStorage.removeItem('scrollHeight')
-    return
-  }, [isMobile, enabled, scrollHeight])
-
   React.useEffect(() => {
-    handleKeyboardOffset()
+    if (isMobile) setScrollHeight()
 
     return () => {
-      handleKeyboardOffset()
+      resetScrollPosition()
     }
-  }, [handleKeyboardOffset])
+  }, [isMobile])
 }

--- a/src/hooks/usePreventMobileKeyboardOffset.ts
+++ b/src/hooks/usePreventMobileKeyboardOffset.ts
@@ -3,6 +3,8 @@ import * as React from 'react'
 
 import { useIsMobile } from '@/hooks/useIsMobile'
 
+// This constant is the difference between the scrollY position saved and the actual height of the page
+// If we use just the scrollY position saved, the page will actually scroll more than it should.
 const DIFF_SCROLL_Y_TO_ACTUAL_HEIGHT = 148
 
 function getScrollHeight() {
@@ -25,6 +27,20 @@ function resetScrollPosition() {
   return
 }
 
+// This hook "fixes" a known issue on iOS devices where when you open a modal with the keyboard
+// opened, the keyboard will push the entire page up.
+
+// This happens because if the keyboard is already open the component will no resize to fit the
+// screen height when using 100dvh but instead it behaves like 100vh, causing the keyboard to
+//  offset the page to the top.
+
+// To fix this, this hook will save the current scrollY position when it is rendered and scroll
+// the entire page to the top. Once the hook is unmounted, it will scroll the page back to the
+// original position.
+
+// References:
+// https://stackoverflow.com/questions/13820088/how-to-prevent-keyboard-push-up-webview-at-ios-app-using-phonegap
+// https://stackoverflow.com/questions/38619762/how-to-prevent-ios-keyboard-from-pushing-the-view-off-screen-with-css-or-js
 export function usePreventMobileKeyboardOffset() {
   const isMobile = useIsMobile()
 

--- a/src/hooks/usePreventMobileKeyboardOffset.ts
+++ b/src/hooks/usePreventMobileKeyboardOffset.ts
@@ -1,0 +1,32 @@
+import * as React from 'react'
+
+import { useIsMobile } from '@/hooks/useIsMobile'
+
+export function usePreventMobileKeyboardOffset(enabled: boolean) {
+  const isMobile = useIsMobile()
+
+  const scrollHeight = sessionStorage.getItem('scrollHeight')
+
+  const handleKeyboardOffset = React.useCallback(() => {
+    if (!isMobile) return
+
+    if (enabled) {
+      sessionStorage.setItem('scrollHeight', String(window.scrollY))
+      window.scrollTo(0, 0)
+      return
+    }
+
+    if (!scrollHeight) return
+    window.scrollTo(0, Number(scrollHeight))
+    sessionStorage.removeItem('scrollHeight')
+    return
+  }, [isMobile, enabled, scrollHeight])
+
+  React.useEffect(() => {
+    handleKeyboardOffset()
+
+    return () => {
+      handleKeyboardOffset()
+    }
+  }, [handleKeyboardOffset])
+}

--- a/src/hooks/usePreventMobileKeyboardOffset.ts
+++ b/src/hooks/usePreventMobileKeyboardOffset.ts
@@ -1,3 +1,4 @@
+'use client'
 import * as React from 'react'
 
 import { useIsMobile } from '@/hooks/useIsMobile'
@@ -5,7 +6,8 @@ import { useIsMobile } from '@/hooks/useIsMobile'
 export function usePreventMobileKeyboardOffset(enabled: boolean) {
   const isMobile = useIsMobile()
 
-  const scrollHeight = sessionStorage.getItem('scrollHeight')
+  const scrollHeight =
+    typeof sessionStorage !== 'undefined' ? sessionStorage.getItem('scrollHeight') : null
 
   const handleKeyboardOffset = React.useCallback(() => {
     if (!isMobile) return

--- a/src/hooks/usePreventMobileKeyboardOffset.ts
+++ b/src/hooks/usePreventMobileKeyboardOffset.ts
@@ -3,10 +3,6 @@ import * as React from 'react'
 
 import { useIsMobile } from '@/hooks/useIsMobile'
 
-// This constant is the difference between the scrollY position saved and the actual height of the page
-// If we use just the scrollY position saved, the page will actually scroll more than it should.
-const DIFF_SCROLL_Y_TO_ACTUAL_HEIGHT = 148
-
 function getScrollHeight() {
   if (typeof sessionStorage === 'undefined') return null
   return sessionStorage.getItem('scrollHeight')
@@ -14,7 +10,6 @@ function getScrollHeight() {
 
 function setScrollHeight() {
   sessionStorage.setItem('scrollHeight', String(window.scrollY))
-  window.scrollTo(0, 0)
   return
 }
 
@@ -22,7 +17,7 @@ function resetScrollPosition() {
   const scrollHeight = getScrollHeight()
   if (!scrollHeight) return
 
-  window.scrollTo(0, Number(scrollHeight) - DIFF_SCROLL_Y_TO_ACTUAL_HEIGHT)
+  window.scrollTo(0, Number(scrollHeight))
   sessionStorage.removeItem('scrollHeight')
   return
 }
@@ -41,14 +36,17 @@ function resetScrollPosition() {
 // References:
 // https://stackoverflow.com/questions/13820088/how-to-prevent-keyboard-push-up-webview-at-ios-app-using-phonegap
 // https://stackoverflow.com/questions/38619762/how-to-prevent-ios-keyboard-from-pushing-the-view-off-screen-with-css-or-js
-export function usePreventMobileKeyboardOffset() {
+// https://blog.opendigerati.com/the-eccentric-ways-of-ios-safari-with-the-keyboard-b5aa3f34228d
+// https://stackoverflow.com/questions/56351216/ios-safari-unwanted-scroll-when-keyboard-is-opened-and-body-scroll-is-disabled
+export function usePreventMobileKeyboardOffset(shouldScrollTop: boolean) {
   const isMobile = useIsMobile()
 
   React.useEffect(() => {
     if (isMobile) setScrollHeight()
+    if (shouldScrollTop) window.scrollTo(0, 0)
 
     return () => {
       resetScrollPosition()
     }
-  }, [isMobile])
+  }, [isMobile, shouldScrollTop])
 }


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->
[#37](https://github.com/Stand-With-Crypto/swc-internal/issues/37)

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

This is a known issue regarding the keyboard in iOS devices because the component is not resized to fit the screen height when using `100dvh` but instead it behaves like `100vh` and the keyboard offsets the content to top. The only way I found to fix this problem is making the entire screen scroll to top, so I had to save the current scroll height, scroll the entire page to the top and then scroll the page back to the previous scroll value after the modal is closed.

### Before | After

https://github.com/Stand-With-Crypto/swc-web/assets/167922524/234ac6c2-7ce3-425f-b051-81b1798a3cc5


https://github.com/Stand-With-Crypto/swc-web/assets/167922524/d41a6962-a880-4be4-af2c-1fbb54bc2b4a


## How has it been tested?

## Notes to reviewers

I used sessionStorage instead of a state because with state the scroll back to place had a delay that caused a flick on the screen, with sessionStorage this doesn't happen and the scroll is done instantly.

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
