### PR TITLE
Adds padding to Dtsi Congressperson display to prevent absolute content from not showing

### DIFF
--- a/src/components/app/dtsiCongresspersonDisplay.tsx
+++ b/src/components/app/dtsiCongresspersonDisplay.tsx
@@ -41,7 +41,7 @@ export function DtsiCongresspersonDisplay({
   const people = maxPeopleDisplayed ? dtsiPeople.slice(0, maxPeopleDisplayed) : dtsiPeople
 
   return people.map(person => (
-    <div className="flex flex-row items-center gap-4 text-sm md:text-base" key={person.id}>
+    <div className="flex flex-row items-center gap-4 pb-2 text-sm md:text-base" key={person.id}>
       <div className="relative">
         <DTSIAvatar person={person} size={60} />
         <div className="absolute bottom-[-8px] right-[-8px]">


### PR DESCRIPTION
closes #832 

## What changed? Why?

Adds padding bottom to DtsiCongresspersonDisplay component to prevent the absolute positioned content from being cut off because of container padding.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
