### PR TITLE
fix: encode address on google api call

### DIFF
--- a/src/utils/server/getGooglePlaceIdFromAddress.ts
+++ b/src/utils/server/getGooglePlaceIdFromAddress.ts
@@ -10,7 +10,7 @@ const GOOGLE_PLACES_BACKEND_API_KEY = requiredEnv(
 
 export async function getGooglePlaceIdFromAddress(address: string) {
   const response = await fetchReq(
-    `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${address}&language=en&key=${GOOGLE_PLACES_BACKEND_API_KEY}`,
+    `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${encodeURIComponent(address)}&language=en&key=${GOOGLE_PLACES_BACKEND_API_KEY}`,
     {
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
closes #632 

fixes PROD-SWC-WEB-1HJ

## What changed? Why?

This encodes the `address` query param in the google places api call. Why? That was causing problems with addresses that contained a `#` sign
<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
