### PR TITLE
feat: adds type validation for google places api results

### DIFF
--- a/cypress/e2e/4-action-email-your-congressperson.cy.ts
+++ b/cypress/e2e/4-action-email-your-congressperson.cy.ts
@@ -15,13 +15,6 @@ it('action - email your congressperson', () => {
   cy.contains('Please enter a valid email address')
   cy.contains('Please select a valid address')
 
-  // validate invalid address
-  cy.selectFromComboBox({
-    trigger: cy.get('input[placeholder="Your full address"]'),
-    searchText: 'new york',
-  })
-  cy.contains('Please enter a specific address that includes street-level information')
-
   // validate success
   cy.get('input[placeholder="Your first name"]').type('John')
   cy.get('input[placeholder="Your last name"]').type('Doe')

--- a/cypress/e2e/8-action-call-your-congressperson.cy.ts
+++ b/cypress/e2e/8-action-call-your-congressperson.cy.ts
@@ -19,17 +19,9 @@ it('action - call your congressperson', () => {
   // validate error messages display
   cy.selectFromComboBox({
     trigger: cy.get('input[placeholder="Your full address"]'),
-    searchText: 'berlin germany',
+    searchText: 'Berliner Bogen, Anckelmannsplatz, Hamburg, Germany',
   })
   cy.contains('Please enter a US-based address.').should('be.visible')
-
-  cy.selectFromComboBox({
-    trigger: cy.get('input[placeholder="Your full address"]'),
-    searchText: 'new york',
-  })
-  cy.contains('Please enter a specific address that includes street-level information').should(
-    'be.visible',
-  )
 
   // validate success
   cy.selectFromComboBox({

--- a/src/components/app/dtsiPersonHeroCard/dtsiPersonHeroCard.stories.tsx
+++ b/src/components/app/dtsiPersonHeroCard/dtsiPersonHeroCard.stories.tsx
@@ -6,6 +6,8 @@ import {
   DTSI_PersonPoliticalAffiliationCategory,
   DTSI_PersonRoleCategory,
   DTSI_PersonRoleStatus,
+  DTSI_TwitterAccountState,
+  DTSI_TwitterAccountType,
 } from '@/data/dtsi/generated'
 import { SupportedLocale } from '@/intl/locales'
 
@@ -39,6 +41,15 @@ const getDefaultProps = () => {
         status: DTSI_PersonRoleStatus.HELD,
         title: 'President',
       },
+      twitterAccounts: [
+        {
+          accountType: DTSI_TwitterAccountType.PROFESSIONAL,
+          id: '',
+          personId: '',
+          state: DTSI_TwitterAccountState.VISIBLE,
+          username: '',
+        },
+      ],
     },
   }
   return props

--- a/src/components/app/dtsiPersonHeroCard/dtsiPersonHeroCard.stories.tsx
+++ b/src/components/app/dtsiPersonHeroCard/dtsiPersonHeroCard.stories.tsx
@@ -6,8 +6,6 @@ import {
   DTSI_PersonPoliticalAffiliationCategory,
   DTSI_PersonRoleCategory,
   DTSI_PersonRoleStatus,
-  DTSI_TwitterAccountState,
-  DTSI_TwitterAccountType,
 } from '@/data/dtsi/generated'
 import { SupportedLocale } from '@/intl/locales'
 

--- a/src/components/app/dtsiPersonHeroCard/dtsiPersonHeroCard.stories.tsx
+++ b/src/components/app/dtsiPersonHeroCard/dtsiPersonHeroCard.stories.tsx
@@ -41,15 +41,6 @@ const getDefaultProps = () => {
         status: DTSI_PersonRoleStatus.HELD,
         title: 'President',
       },
-      twitterAccounts: [
-        {
-          accountType: DTSI_TwitterAccountType.PROFESSIONAL,
-          id: '',
-          personId: '',
-          state: DTSI_TwitterAccountState.VISIBLE,
-          username: '',
-        },
-      ],
     },
   }
   return props

--- a/src/components/ui/googlePlacesSelect/index.tsx
+++ b/src/components/ui/googlePlacesSelect/index.tsx
@@ -29,10 +29,10 @@ export const GooglePlacesSelect = React.forwardRef<
     setValue,
     init,
   } = usePlacesAutocomplete({
-    // note on why we aren't restricting to just addresses https://stackoverflow.com/a/65206036
     requestOptions: {
       locationBias: 'IP_BIAS',
       language: 'en',
+      types: ['street_address', 'premise', 'postal_code', 'subpremise'],
     },
   })
   const scriptStatus = useGoogleMapsScript()


### PR DESCRIPTION
closes #850 

## What changed? Why?

Added some type validations for google places api results to prevent returning vague addresses that would cause Capitol Canary to fail.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
