### PR TITLE
fix(email): change message for max length message

### DIFF
--- a/src/validation/forms/zodEmailYourCongressperson.ts
+++ b/src/validation/forms/zodEmailYourCongressperson.ts
@@ -9,6 +9,8 @@ export const zodEmailYourCongressperson = object({
   phoneNumber: string()
     .min(10, 'Please enter a valid phone number')
     .max(10, 'Please enter a valid phone number'),
-  address: string().min(1, 'Please enter your address').max(300, 'Please enter your address'),
-  message: string().min(1, 'Please enter a message').max(1000, 'Please enter a message'),
+  address: string().min(1, 'Please enter your address').max(300, 'Address too long'),
+  message: string()
+    .min(1, 'Please enter a message')
+    .max(1000, 'Your message should not exceed 1000 characters'),
 }).merge(zodFirstAndLastNames)

--- a/src/validation/forms/zodEmailYourCongressperson.ts
+++ b/src/validation/forms/zodEmailYourCongressperson.ts
@@ -12,5 +12,5 @@ export const zodEmailYourCongressperson = object({
   address: string().min(1, 'Please enter your address').max(300, 'Address too long'),
   message: string()
     .min(1, 'Please enter a message')
-    .max(1000, 'Your message should not exceed 1000 characters'),
+    .max(2000, 'Your message should not exceed 2000 characters'),
 }).merge(zodFirstAndLastNames)

--- a/src/validation/forms/zodUserActionFormEmailCongressperson.ts
+++ b/src/validation/forms/zodUserActionFormEmailCongressperson.ts
@@ -11,7 +11,7 @@ const base = object({
   emailAddress: string().trim().email('Please enter a valid email address').toLowerCase(),
   message: string()
     .min(1, 'Please enter a message')
-    .max(1000, 'Your message should not exceed 1000 characters'),
+    .max(2000, 'Your message should not exceed 2000 characters'),
   dtsiSlugs: array(zodDTSISlug).min(1),
   campaignName: nativeEnum(UserActionEmailCampaignName),
   politicianCategory: zodYourPoliticianCategory,

--- a/src/validation/forms/zodUserActionFormEmailCongressperson.ts
+++ b/src/validation/forms/zodUserActionFormEmailCongressperson.ts
@@ -9,7 +9,9 @@ import { zodYourPoliticianCategory } from '@/validation/fields/zodYourPolitician
 
 const base = object({
   emailAddress: string().trim().email('Please enter a valid email address').toLowerCase(),
-  message: string().min(1, 'Please enter a message').max(1000, 'Please enter a message'),
+  message: string()
+    .min(1, 'Please enter a message')
+    .max(1000, 'Your message should not exceed 1000 characters'),
   dtsiSlugs: array(zodDTSISlug).min(1),
   campaignName: nativeEnum(UserActionEmailCampaignName),
   politicianCategory: zodYourPoliticianCategory,


### PR DESCRIPTION
## What changed? Why?

We made the validation error message more clear for max length email messages. Reported by this tweet:

https://twitter.com/jastirn/status/1790459417701323012

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
