### PR TITLE
Calculates next action using campaign

### DIFF
--- a/src/app/api/identified-user/performed-user-action-types/route.ts
+++ b/src/app/api/identified-user/performed-user-action-types/route.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 
-import { uniq } from 'lodash-es'
+import { uniqBy } from 'lodash-es'
 import { NextResponse } from 'next/server'
 
 import { getMaybeUserAndMethodOfMatchWithMaybeSession } from '@/utils/server/getMaybeUserAndMethodOfMatch'
@@ -18,8 +18,9 @@ async function apiResponseForUserPerformedUserActionTypes() {
     },
   })
 
-  const performedUserActionTypes = uniq(
+  const performedUserActionTypes = uniqBy(
     user?.userActions.map(({ actionType, campaignName }) => ({ actionType, campaignName })),
+    ({ actionType, campaignName }) => `${actionType}-${campaignName}`,
   )
   return { performedUserActionTypes }
 }

--- a/src/app/api/identified-user/performed-user-action-types/route.ts
+++ b/src/app/api/identified-user/performed-user-action-types/route.ts
@@ -12,13 +12,15 @@ async function apiResponseForUserPerformedUserActionTypes() {
     prisma: {
       include: {
         userActions: {
-          select: { id: true, actionType: true },
+          select: { id: true, actionType: true, campaignName: true },
         },
       },
     },
   })
 
-  const performedUserActionTypes = uniq(user?.userActions.map(({ actionType }) => actionType))
+  const performedUserActionTypes = uniq(
+    user?.userActions.map(({ actionType, campaignName }) => ({ actionType, campaignName })),
+  )
   return { performedUserActionTypes }
 }
 

--- a/src/components/app/recentActivityRow/variantRecentActivityRow.tsx
+++ b/src/components/app/recentActivityRow/variantRecentActivityRow.tsx
@@ -57,7 +57,9 @@ export const VariantRecentActivityRow = function VariantRecentActivityRow({
   const { userLocationDetails } = action.user
   const isStateAvailable = userLocationDetails?.administrativeAreaLevel1
   const { data } = useApiResponseForUserPerformedUserActionTypes()
-  const hasSignedUp = data?.performedUserActionTypes.includes(UserActionType.OPT_IN)
+  const hasSignedUp = data?.performedUserActionTypes.some(
+    performedAction => performedAction.actionType === UserActionType.OPT_IN,
+  )
   const newUserStateOrJoin = isStateAvailable
     ? `from ${userLocationDetails.administrativeAreaLevel1} joined`
     : 'joined'

--- a/src/components/app/userActionFormSuccessScreen/getNextAction.tsx
+++ b/src/components/app/userActionFormSuccessScreen/getNextAction.tsx
@@ -4,14 +4,21 @@ import { UserActionType } from '@prisma/client'
 
 import { GetUserPerformedUserActionTypesResponse } from '@/app/api/identified-user/performed-user-action-types/route'
 import { USER_ACTION_ROW_CTA_INFO } from '@/components/app/userActionRowCTA/constants'
+import { USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP } from '@/utils/shared/userActionCampaigns'
 import { USER_ACTION_TYPE_CTA_PRIORITY_ORDER } from '@/utils/web/userActionUtils'
 
 export function getNextAction(
   performedUserActionTypes: GetUserPerformedUserActionTypesResponse['performedUserActionTypes'],
 ) {
   const action = USER_ACTION_TYPE_CTA_PRIORITY_ORDER.filter(x => x !== UserActionType.OPT_IN).find(
-    actionType => !performedUserActionTypes.includes(actionType),
+    userAction =>
+      !performedUserActionTypes.some(
+        performedAction =>
+          performedAction.actionType === userAction &&
+          performedAction.campaignName === USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP[userAction],
+      ),
   )
+
   if (action) {
     const { WrapperComponent: _WrapperComponent, ...rest } = USER_ACTION_ROW_CTA_INFO[action]
     return rest

--- a/src/components/app/userActionFormSuccessScreen/userActionFormSuccessScreenMainCTA.tsx
+++ b/src/components/app/userActionFormSuccessScreen/userActionFormSuccessScreenMainCTA.tsx
@@ -92,8 +92,8 @@ export function UserActionFormSuccessScreenMainCTA({
   )
 
   const { user, performedUserActionTypes } = data
-  const hasOptedInToMembership = performedUserActionTypes.find(
-    action => action === UserActionType.OPT_IN,
+  const hasOptedInToMembership = performedUserActionTypes.some(
+    performedAction => performedAction.actionType === UserActionType.OPT_IN,
   )
 
   if (nftWhenAuthenticated && session.isLoggedIn && !session.isLoggedInThirdweb) {

--- a/src/components/app/userActionRowCTA/userActionRowCTAsAnimatedListWithApi.tsx
+++ b/src/components/app/userActionRowCTA/userActionRowCTAsAnimatedListWithApi.tsx
@@ -12,10 +12,13 @@ export function UserActionRowCTAsAnimatedListWithApi({
   excludeUserActionTypes,
 }: UserActionRowCTAsListWithApiProps) {
   const { data } = useApiResponseForUserPerformedUserActionTypes()
+  const performedUserActions = data?.performedUserActionTypes.map(
+    performedAction => performedAction.actionType,
+  )
   return (
     <UserActionRowCTAsAnimatedList
       excludeUserActionTypes={excludeUserActionTypes}
-      performedUserActionTypes={data?.performedUserActionTypes}
+      performedUserActionTypes={performedUserActions}
     />
   )
 }

--- a/src/components/app/userActionRowCTA/userActionRowCTAsListWithApi.tsx
+++ b/src/components/app/userActionRowCTA/userActionRowCTAsListWithApi.tsx
@@ -12,10 +12,13 @@ export function UserActionRowCTAsListWithApi({
   excludeUserActionTypes,
 }: UserActionRowCTAsListWithApiProps) {
   const { data } = useApiResponseForUserPerformedUserActionTypes()
+  const performedUserActions = data?.performedUserActionTypes.map(
+    performedAction => performedAction.actionType,
+  )
   return (
     <UserActionRowCTAsList
       excludeUserActionTypes={excludeUserActionTypes}
-      performedUserActionTypes={data?.performedUserActionTypes}
+      performedUserActionTypes={performedUserActions}
     />
   )
 }


### PR DESCRIPTION
closes #875 

## What changed? Why?

This PR changes how we calculate the next action suggestion based on performed user actions. Now we are also checking if the user has completed X action from the current campaign.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
