### PR TITLE
Updates address default value condition

### DIFF
--- a/src/clientModels/clientAddress.ts
+++ b/src/clientModels/clientAddress.ts
@@ -2,12 +2,12 @@ import { Address } from '@prisma/client'
 
 import { ClientModel, getClientModel } from '@/clientModels/utils'
 
-export type ClientAddress = ClientModel<Pick<Address, 'id' | 'formattedDescription'>> & {
+export type ClientAddress = ClientModel<Pick<Address, 'id' | 'formattedDescription' | 'route'>> & {
   googlePlaceId: string
 }
 
 export const getClientAddress = (record: Address): ClientAddress | null => {
-  const { id, googlePlaceId, formattedDescription } = record
+  const { id, googlePlaceId, formattedDescription, route } = record
   // all addresses should have google places, but we want to gracefully fail if google starts hard-capping us for some reason
   if (!googlePlaceId) {
     return null
@@ -16,5 +16,6 @@ export const getClientAddress = (record: Address): ClientAddress | null => {
     id,
     googlePlaceId,
     formattedDescription,
+    route,
   })
 }

--- a/src/components/app/userActionFormCallCongressperson/index.tsx
+++ b/src/components/app/userActionFormCallCongressperson/index.tsx
@@ -55,7 +55,7 @@ export function UserActionFormCallCongressperson({
 
   const initialAddress = initialValues?.address
     ? initialValues.address
-    : user?.address
+    : user?.address?.route
       ? { place_id: user.address.googlePlaceId, description: user.address.formattedDescription }
       : undefined
   const { data: resolvedCongressPersonData, isLoading: isLoadingInitialCongresspersonData } =

--- a/src/components/app/userActionFormEmailCongressperson/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/index.tsx
@@ -75,7 +75,7 @@ const getDefaultValues = ({
       lastName: user.lastName,
       emailAddress: user.primaryUserEmailAddress?.emailAddress || '',
       message: getDefaultText({ dtsiSlugs, firstName, lastName }),
-      address: user.address
+      address: user.address?.route
         ? {
             description: user.address.formattedDescription,
             place_id: user.address.googlePlaceId,


### PR DESCRIPTION
## What changed? Why?

This PR updates address default value condition to check if a route property is present in user.address. The objective is to reduce errors related to address not found on google api.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
