### PR TITLE
feat: removes async code to remove layout shift

### DIFF
--- a/src/components/app/pagePoliticianDetails/questionnaireAccordion.tsx
+++ b/src/components/app/pagePoliticianDetails/questionnaireAccordion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import {
   Accordion,
@@ -23,8 +23,8 @@ interface QuestionnaireAccordionProps {
 const QUESTIONNAIRE_HASH_KEY = 'questionnaire'
 
 export function QuestionnaireAccordion({ questionnaire }: QuestionnaireAccordionProps) {
+  const [accordionValue, setAccordionValue] = useState('')
   const urlHash = useUrlHash()
-  const accordionDefaultValue = urlHash === QUESTIONNAIRE_HASH_KEY ? QUESTIONNAIRE_HASH_KEY : ''
   const questionnaireRef = useRef<HTMLDivElement>(null)
 
   const answersAmount = useMemo(() => {
@@ -42,9 +42,13 @@ export function QuestionnaireAccordion({ questionnaire }: QuestionnaireAccordion
   }, [questionnaire.data])
 
   useEffect(() => {
-    if (!questionnaireRef.current || !accordionDefaultValue) return
+    if (!questionnaireRef.current || !urlHash) return
     questionnaireRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [questionnaireRef, accordionDefaultValue])
+  }, [questionnaireRef, urlHash])
+
+  useEffect(() => {
+    setAccordionValue(urlHash === QUESTIONNAIRE_HASH_KEY ? QUESTIONNAIRE_HASH_KEY : '')
+  }, [urlHash])
 
   if (answersAmount === -1) return null
 
@@ -54,7 +58,7 @@ export function QuestionnaireAccordion({ questionnaire }: QuestionnaireAccordion
         Candidate questionnaire
       </PageTitle>
 
-      <Accordion collapsible defaultValue={accordionDefaultValue} type="single">
+      <Accordion collapsible onValueChange={setAccordionValue} type="single" value={accordionValue}>
         <AccordionItem value="questionnaire">
           <AccordionTrigger>Responses ({answersAmount})</AccordionTrigger>
 

--- a/src/components/app/pagePoliticianDetails/questionnaireAccordion.tsx
+++ b/src/components/app/pagePoliticianDetails/questionnaireAccordion.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect, useMemo, useRef } from 'react'
-import { isNil } from 'lodash-es'
 
 import {
   Accordion,
@@ -24,9 +23,8 @@ interface QuestionnaireAccordionProps {
 const QUESTIONNAIRE_HASH_KEY = 'questionnaire'
 
 export function QuestionnaireAccordion({ questionnaire }: QuestionnaireAccordionProps) {
-  const { urlHash } = useUrlHash()
-  const accordionDefaultValue =
-    urlHash === QUESTIONNAIRE_HASH_KEY ? QUESTIONNAIRE_HASH_KEY : isNil(urlHash) ? null : ''
+  const urlHash = useUrlHash()
+  const accordionDefaultValue = urlHash === QUESTIONNAIRE_HASH_KEY ? QUESTIONNAIRE_HASH_KEY : ''
   const questionnaireRef = useRef<HTMLDivElement>(null)
 
   const answersAmount = useMemo(() => {
@@ -48,10 +46,10 @@ export function QuestionnaireAccordion({ questionnaire }: QuestionnaireAccordion
     questionnaireRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [questionnaireRef, accordionDefaultValue])
 
-  if (!questionnaire || isNil(accordionDefaultValue) || answersAmount === -1) return null
+  if (answersAmount === -1) return null
 
   return (
-    <div className="mb-10 flex scroll-mt-20 flex-col" id="questionnaire" ref={questionnaireRef}>
+    <div className="mb-10 flex scroll-mt-20 flex-col" ref={questionnaireRef}>
       <PageTitle as="h2" className="mb-4 text-center text-lg md:text-xl lg:text-2xl" size="sm">
         Candidate questionnaire
       </PageTitle>

--- a/src/hooks/useUrlHash.ts
+++ b/src/hooks/useUrlHash.ts
@@ -1,16 +1,5 @@
-import { useEffect, useState } from 'react'
+'use client'
 
 export function useUrlHash() {
-  const [urlHash, setUrlHash] = useState<string | null>()
-
-  useEffect(() => {
-    const hash =
-      typeof window !== 'undefined'
-        ? decodeURIComponent(window.location.hash.replace('#', ''))
-        : null
-
-    setUrlHash(hash)
-  }, [])
-
-  return { urlHash }
+  return decodeURIComponent(window.location.hash.replace('#', ''))
 }

--- a/src/hooks/useUrlHash.ts
+++ b/src/hooks/useUrlHash.ts
@@ -3,5 +3,5 @@
 export function useUrlHash() {
   return typeof window !== 'undefined'
     ? decodeURIComponent(window.location.hash.replace('#', ''))
-    : ''
+    : null
 }

--- a/src/hooks/useUrlHash.ts
+++ b/src/hooks/useUrlHash.ts
@@ -1,5 +1,5 @@
 'use client'
 
 export function useUrlHash() {
-  return decodeURIComponent(window.location.hash.replace('#', ''))
+  return window ? decodeURIComponent(window.location.hash.replace('#', '')) : ''
 }

--- a/src/hooks/useUrlHash.ts
+++ b/src/hooks/useUrlHash.ts
@@ -1,5 +1,7 @@
 'use client'
 
 export function useUrlHash() {
-  return window ? decodeURIComponent(window.location.hash.replace('#', '')) : ''
+  return typeof window !== 'undefined'
+    ? decodeURIComponent(window.location.hash.replace('#', ''))
+    : ''
 }


### PR DESCRIPTION
closes #864 

## What changed? Why?

This PR removes all async conditions evaluation from questionnaire component to remove possible layout shifts.

<img width="363" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/165944245/e545ca24-587b-4444-a54c-e62f725f79a4">


## How has it been tested?

- [X] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
