### PR TITLE
feat: add phone number display to desktop call action

### DIFF
--- a/cypress/e2e/8-action-call-your-congressperson.cy.ts
+++ b/cypress/e2e/8-action-call-your-congressperson.cy.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 it('action - call your congressperson', () => {
+  cy.viewport('iphone-6')
   cy.visit('/')
 
   // validate CTA button


### PR DESCRIPTION
closes #887

## What changed? Why?

This adds a phone number display and removes the "call complete" guard from the desktop version of the call action.

Mobile shouldn't change

## UI Changes ##

### Before
![image](https://github.com/Stand-With-Crypto/swc-web/assets/155585835/b3f0b4d9-2725-4b89-b6a2-a7b695ae4355)

### After (ignore the representative avatar not loading, qwerks of local dev)
<img width="799" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/155585835/d196fdb9-3460-4ff7-ab3d-768fbaf5c57c">


## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
