### PR TITLE
ensure key bills are displayed ordered at the top of the bills page

### DIFF
--- a/src/components/app/pageBills/index.tsx
+++ b/src/components/app/pageBills/index.tsx
@@ -1,9 +1,10 @@
+import { partition, sortBy } from 'lodash-es'
+
 import { CryptoSupportHighlight } from '@/components/app/cryptoSupportHighlight'
 import { DTSIBill, DTSIBillCard } from '@/components/app/dtsiBillCard'
 import { PageSubTitle } from '@/components/ui/pageSubTitle'
 import { PageTitle } from '@/components/ui/pageTitleText'
 import { SupportedLocale } from '@/intl/locales'
-import { partition, sortBy } from 'lodash-es'
 
 interface PageBillsProps {
   title: string
@@ -28,15 +29,15 @@ export function PageBills(props: PageBillsProps) {
       </section>
 
       {[
-        { bills: sortedKeyBills, title: 'Key Bills' },
-        { bills: otherBills, title: 'Other Crypto Bills' },
-      ].map(({ bills, title }) => (
-        <section key={title}>
-          <PageTitle size="sm" as="h3" className="mb-5">
-            {title}
+        { results: sortedKeyBills, sectionTitle: 'Key Bills' },
+        { results: otherBills, sectionTitle: 'Other Crypto Bills' },
+      ].map(({ results, sectionTitle }) => (
+        <section key={sectionTitle}>
+          <PageTitle as="h3" className="mb-5" size="sm">
+            {sectionTitle}
           </PageTitle>
           <div className="flex flex-col gap-4 lg:gap-8">
-            {bills.map(bill => (
+            {results.map(bill => (
               <DTSIBillCard bill={bill} key={bill.id} locale={locale}>
                 <CryptoSupportHighlight
                   className="flex-shrink-0 rounded-full text-base"

--- a/src/components/app/pageBills/index.tsx
+++ b/src/components/app/pageBills/index.tsx
@@ -3,6 +3,7 @@ import { DTSIBill, DTSIBillCard } from '@/components/app/dtsiBillCard'
 import { PageSubTitle } from '@/components/ui/pageSubTitle'
 import { PageTitle } from '@/components/ui/pageTitleText'
 import { SupportedLocale } from '@/intl/locales'
+import { partition, sortBy } from 'lodash-es'
 
 interface PageBillsProps {
   title: string
@@ -11,8 +12,13 @@ interface PageBillsProps {
   locale: SupportedLocale
 }
 
+const KEY_BILLS = ['hr4763', 'hjres109']
+
 export function PageBills(props: PageBillsProps) {
   const { title, description, bills, locale } = props
+
+  const [keyBills, otherBills] = partition(bills, bill => KEY_BILLS.includes(bill.slug))
+  const sortedKeyBills = sortBy(keyBills, bill => KEY_BILLS.indexOf(bill.slug))
 
   return (
     <div className="standard-spacing-from-navbar container space-y-16">
@@ -21,18 +27,26 @@ export function PageBills(props: PageBillsProps) {
         <PageSubTitle>{description}</PageSubTitle>
       </section>
 
-      <section>
-        <div className="flex flex-col gap-4 lg:gap-8">
-          {bills.map(bill => (
-            <DTSIBillCard bill={bill} key={bill.id} locale={locale}>
-              <CryptoSupportHighlight
-                className="flex-shrink-0 rounded-full text-base"
-                stanceScore={bill.computedStanceScore}
-              />
-            </DTSIBillCard>
-          ))}
-        </div>
-      </section>
+      {[
+        { bills: sortedKeyBills, title: 'Key Bills' },
+        { bills: otherBills, title: 'Other Crypto Bills' },
+      ].map(({ bills, title }) => (
+        <section key={title}>
+          <PageTitle size="sm" as="h3" className="mb-5">
+            {title}
+          </PageTitle>
+          <div className="flex flex-col gap-4 lg:gap-8">
+            {bills.map(bill => (
+              <DTSIBillCard bill={bill} key={bill.id} locale={locale}>
+                <CryptoSupportHighlight
+                  className="flex-shrink-0 rounded-full text-base"
+                  stanceScore={bill.computedStanceScore}
+                />
+              </DTSIBillCard>
+            ))}
+          </div>
+        </section>
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
## What changed? Why?
ensure key bills are displayed ordered at the top of the bills page

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
