### PR TITLE
gracefully fail when user gets sent to broken url

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -265,6 +265,11 @@ const nextConfig = {
           '/action/tweet-at-person/2024_05_22_PIZZA_DAY?utm_source=pizzadao&utm_medium=live-event&utm_campaign=pizza-day-2024',
         permanent: false,
       },
+      {
+        source: '/&modal=call-your-representative&:rest*',
+        destination: '/action/call?unexpectedUrl=true',
+        permanent: false,
+      },
     ]
   },
 }

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -57,6 +57,12 @@ const InitialOrchestration = () => {
       })
     }
   }, [authUser.user, searchParamsUserId])
+  const unexpectedUrl = searchParams?.get('unexpectedUrl')
+  useEffect(() => {
+    if (unexpectedUrl) {
+      Sentry.captureMessage('unexpectedUrl')
+    }
+  }, [unexpectedUrl])
   useEffect(() => {
     if (!pathname) {
       return


### PR DESCRIPTION

## What changed? Why?

There are lingering broken URLs users are getting sent to. We want to gracefully fail when they land on SWC.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
