### PR TITLE
Minimize Google Civic Api usage

### DIFF
--- a/src/components/app/clientCurrentUserDTSIPersonCardOrCTA.tsx
+++ b/src/components/app/clientCurrentUserDTSIPersonCardOrCTA.tsx
@@ -49,8 +49,8 @@ const POLITICIAN_CATEGORY: YourPoliticianCategory = 'senate-and-house'
 function _ClientCurrentUserDTSIPersonCardOrCTA({ locale }: { locale: SupportedLocale }) {
   const { setAddress, address } = useMutableCurrentUserAddress()
   const res = useGetDTSIPeopleFromAddress(
-    address === 'loading' ? '' : address?.description || '',
     POLITICIAN_CATEGORY,
+    address === 'loading' ? null : address?.description,
   )
   if (!address || address === 'loading' || !res.data) {
     return (

--- a/src/components/app/dtsiCongresspersonAssociatedWithFormAddress.tsx
+++ b/src/components/app/dtsiCongresspersonAssociatedWithFormAddress.tsx
@@ -36,7 +36,7 @@ export function DTSICongresspersonAssociatedWithFormAddress({
     }
   }) => void
 }) {
-  const res = useGetDTSIPeopleFromAddress(address?.description || '', politicianCategory)
+  const res = useGetDTSIPeopleFromAddress(politicianCategory, address?.description)
   useEffect(() => {
     if (
       res.data &&

--- a/src/components/app/pageLocationStateSpecific/userLocationRaceInfo.tsx
+++ b/src/components/app/pageLocationStateSpecific/userLocationRaceInfo.tsx
@@ -58,7 +58,7 @@ function _UserLocationRaceInfo({
   locale,
 }: UserLocationRaceInfoProps) {
   const { setAddress, address } = useMutableCurrentUserAddress()
-  const res = useGetDistrictFromAddress(address === 'loading' ? '' : address?.description || '', {
+  const res = useGetDistrictFromAddress(address === 'loading' ? null : address?.description, {
     stateCode,
   })
   const shouldShowSubtitle = !address || !res.data

--- a/src/components/app/pageLocationUnitedStates/userAddressVoterGuideInput.tsx
+++ b/src/components/app/pageLocationUnitedStates/userAddressVoterGuideInput.tsx
@@ -50,8 +50,8 @@ const POLITICIAN_CATEGORY: YourPoliticianCategory = 'senate-and-house'
 function _UserAddressVoterGuideInputSection({ locale }: UserAddressVoterGuideInput) {
   const { setAddress, address } = useMutableCurrentUserAddress()
   const res = useGetDTSIPeopleFromAddress(
-    address === 'loading' ? '' : address?.description || '',
     POLITICIAN_CATEGORY,
+    address === 'loading' ? null : address?.description,
   )
   const shouldShowSubtitle = !address || !res.data
 

--- a/src/components/app/userActionFormCallCongressperson/sections/address/index.tsx
+++ b/src/components/app/userActionFormCallCongressperson/sections/address/index.tsx
@@ -212,8 +212,8 @@ export function useCongresspersonData({
       }
 
       const dtsiResponse = await getDTSIPeopleFromAddress(
-        address.description,
         CALL_FLOW_POLITICIANS_CATEGORY,
+        address.description,
       )
       if ('notFoundReason' in dtsiResponse) {
         return { notFoundReason: dtsiResponse.notFoundReason }

--- a/src/hooks/useGetDTSIPeopleFromAddress.ts
+++ b/src/hooks/useGetDTSIPeopleFromAddress.ts
@@ -17,6 +17,10 @@ export interface DTSIPeopleFromCongressionalDistrict
   dtsiPeople: DTSIPeopleByCongressionalDistrictQueryResult
 }
 
+export type UseGetDTSIPeopleFromAddressResponse = Awaited<
+  ReturnType<typeof getDTSIPeopleFromAddress>
+>
+
 async function getDTSIPeopleFromCongressionalDistrict(
   result: CongressionalDistrictFromAddress,
   category: YourPoliticianCategory,
@@ -56,19 +60,20 @@ async function getDTSIPeopleFromCongressionalDistrict(
   return { ...result, dtsiPeople: filteredData }
 }
 
-export async function getDTSIPeopleFromAddress(address: string, category: YourPoliticianCategory) {
+export async function getDTSIPeopleFromAddress(
+  category: YourPoliticianCategory,
+  address?: string | null,
+) {
   const result = await getCongressionalDistrictFromAddress(address)
 
   return getDTSIPeopleFromCongressionalDistrict(result, category)
 }
-
-export type UseGetDTSIPeopleFromAddressResponse = Awaited<
-  ReturnType<typeof getDTSIPeopleFromAddress>
->
-
-export function useGetDTSIPeopleFromAddress(address: string, category: YourPoliticianCategory) {
+export function useGetDTSIPeopleFromAddress(
+  category: YourPoliticianCategory,
+  address?: string | null,
+) {
   return useSWR(address ? `useGetDTSIPeopleFromAddress-${address}` : null, () =>
-    getDTSIPeopleFromAddress(address, category),
+    getDTSIPeopleFromAddress(category, address),
   )
 }
 export function formatGetDTSIPeopleFromAddressNotFoundReason(

--- a/src/hooks/useGetDistrictFromAddress.ts
+++ b/src/hooks/useGetDistrictFromAddress.ts
@@ -6,7 +6,7 @@ import {
 } from '@/utils/shared/getCongressionalDistrictFromAddress'
 
 export function useGetDistrictFromAddress(
-  address: string,
+  address?: string | null,
   params?: GetCongressionalDistrictFromAddressParams,
 ) {
   return useSWR(

--- a/src/utils/shared/getCongressionalDistrictFromAddress.ts
+++ b/src/utils/shared/getCongressionalDistrictFromAddress.ts
@@ -78,9 +78,10 @@ export type GetCongressionalDistrictFromAddressParams = {
 }
 
 export async function getCongressionalDistrictFromAddress(
-  address: string,
-  { stateCode: passedStateCode }: GetCongressionalDistrictFromAddressParams = {},
+  address?: string | null,
+  params?: GetCongressionalDistrictFromAddressParams,
 ) {
+  if (!address?.length) return { notFoundReason: 'USER_WITHOUT_ADDRESS' as const }
   const result = await getGoogleCivicDataFromAddress(address).catch(() => null)
   if (!result) {
     return { notFoundReason: 'CIVIC_API_DOWN' as const }
@@ -104,6 +105,8 @@ export async function getCongressionalDistrictFromAddress(
       googleCivicData: result,
     } as GetCongressionalDistrictFromAddressSuccess
   }
+
+  const { stateCode: passedStateCode } = params ?? {}
 
   if (passedStateCode && passedStateCode !== stateCode) {
     return { notFoundReason: 'NOT_SAME_STATE' as const }
@@ -137,6 +140,8 @@ export function formatGetCongressionalDistrictFromAddressNotFoundReason(
   }
 
   switch (data.notFoundReason) {
+    case 'USER_WITHOUT_ADDRESS':
+      return 'Please fill out your address.'
     case 'NOT_USA_ADDRESS':
       return 'Please enter a US-based address.'
     case 'NOT_SAME_STATE':


### PR DESCRIPTION
closes #899 

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

When user does not have an address we were still making the request to the API because we passed an empty string and did not prevent the request from being made in these cases. This PR prevents this from happening and makes more clear that addresses can be `null` or `undefined`.

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
