### PR TITLE
Adds Nextjs Loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "next-i18n-router": "^5.0.2",
         "next-sitemap": "^4.2.3",
         "next-themes": "^0.2.1",
-        "nextjs-toploader": "^1.6.6",
+        "nextjs-toploader": "^1.6.12",
         "obscenity": "^0.2.0",
         "p-limit": "^5.0.0",
         "p-retry": "^6.2.0",
@@ -12557,11 +12557,6 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
-    },
-    "node_modules/@types/nprogress": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@types/nprogress/-/nprogress-0.2.3.tgz",
-      "integrity": "sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -28402,13 +28397,15 @@
       }
     },
     "node_modules/nextjs-toploader": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/nextjs-toploader/-/nextjs-toploader-1.6.6.tgz",
-      "integrity": "sha512-LKow/aV28/DLhj4yH1E8ydF/I5QDNsb5NqlbsXBaIVFrmZ9/OGHyxPLdumvPE2IOYoQdvJ4XWoaCA1v7aivYBg==",
+      "version": "1.6.12",
+      "resolved": "https://registry.npmjs.org/nextjs-toploader/-/nextjs-toploader-1.6.12.tgz",
+      "integrity": "sha512-nbun5lvVjlKnxLQlahzZ55nELVEduqoEXT03KCHnsEYJnFpI/3BaIzpMyq/v8C7UGU2NfxQmjq6ldZ310rsDqA==",
       "dependencies": {
-        "@types/nprogress": "^0.2.2",
         "nprogress": "^0.2.0",
         "prop-types": "^15.8.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/TheSGJ"
       },
       "peerDependencies": {
         "next": ">= 6.0.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "next-i18n-router": "^5.0.2",
     "next-sitemap": "^4.2.3",
     "next-themes": "^0.2.1",
-    "nextjs-toploader": "^1.6.6",
+    "nextjs-toploader": "^1.6.12",
     "obscenity": "^0.2.0",
     "p-limit": "^5.0.0",
     "p-retry": "^6.2.0",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -73,8 +73,8 @@ export default function Layout({ children, params }: PageProps & { children: Rea
       <body className={fontClassName}>
         <OverrideGlobalLocalStorage />
         <NextTopLoader
-          color="#6200FF"
-          shadow="0 0 10px #6200FF,0 0 5px #6200FF"
+          color="hsl(var(--primary-cta))"
+          shadow="0 0 10px hsl(var(--primary-cta)),0 0 5px hsl(var(--primary-cta))"
           showSpinner={false}
         />
         <TopLevelClientLogic locale={locale}>

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -2,6 +2,7 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 import { capitalize } from 'lodash-es'
 import type { Metadata, Viewport } from 'next'
 import { notFound } from 'next/navigation'
+import NextTopLoader from 'nextjs-toploader'
 
 import { TopLevelClientLogic } from '@/app/[locale]/topLevelClientLogic'
 import { CookieConsent } from '@/components/app/cookieConsent'
@@ -71,8 +72,11 @@ export default function Layout({ children, params }: PageProps & { children: Rea
     <html lang={locale}>
       <body className={fontClassName}>
         <OverrideGlobalLocalStorage />
-        {/* LATER-TASK add back once https://github.com/TheSGJ/nextjs-toploader/issues/66 is resolved */}
-        {/* <NextTopLoader /> */}
+        <NextTopLoader
+          color="#6200FF"
+          shadow="0 0 10px #6200FF,0 0 5px #6200FF"
+          showSpinner={false}
+        />
         <TopLevelClientLogic locale={locale}>
           <FullHeight.Container>
             <Navbar locale={locale} />


### PR DESCRIPTION
closes #91

## What changed? Why?

This PR adds the NextJS Loader lib to SWC after this [issue](https://github.com/TheSGJ/nextjs-toploader/issues/66) has been resolved.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
