### PR TITLE
fix: change session check to useSession on nft mint

### DIFF
--- a/src/components/app/userActionFormNFTMint/sections/checkout/index.tsx
+++ b/src/components/app/userActionFormNFTMint/sections/checkout/index.tsx
@@ -28,7 +28,7 @@ import { PageTitle } from '@/components/ui/pageTitleText'
 import { Skeleton } from '@/components/ui/skeleton'
 import { UseSectionsReturn } from '@/hooks/useSections'
 import { MintStatus } from '@/hooks/useSendMintNFTTransaction'
-import { useThirdwebAddress } from '@/hooks/useThirdwebAddress'
+import { useSession } from '@/hooks/useSession'
 import { SupportedCryptoCurrencyCodes } from '@/utils/shared/currency'
 import { NFTSlug } from '@/utils/shared/nft'
 import { NFT_CLIENT_METADATA } from '@/utils/web/nft'
@@ -69,7 +69,7 @@ export function UserActionFormNFTMintCheckout({
 }: UserActionFormNFTMintCheckoutProps) {
   const { contract } = useContract(MINT_NFT_CONTRACT_ADDRESS)
   const contractMetadata = NFT_CLIENT_METADATA[NFTSlug.STAND_WITH_CRYPTO_SUPPORTER]
-  const address = useThirdwebAddress()
+  const session = useSession()
 
   const checkoutError = useCheckoutError({
     totalFee: totalFee,
@@ -78,7 +78,7 @@ export function UserActionFormNFTMintCheckout({
   const maybeOverriddenCheckoutError = debug ? null : checkoutError
   const connectionStatus = useConnectionStatus()
 
-  if (!address) {
+  if (!session.isLoggedInThirdweb) {
     return <UserActionFormNFTMintCheckoutSkeleton />
   }
 


### PR DESCRIPTION
## What changed? Why?

This changes how we check if the user has a connected wallet in the checkout step of the nft mint action. Why? Seems like `useAddress` has some inconsistency where it is not returning for valid addresses.

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
