### PR TITLE
Prevent Outlook error spikes

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -75,7 +75,6 @@ Sentry.init({
     // `Can't find variable: bytecode`,
     'ResizeObserver loop limit exceeded',
     'ResizeObserver loop completed with undelivered notifications',
-    /Non-Error promise rejection captured with value: Object Not Found/,
   ],
   beforeSend: (event, hint) => {
     // prevent local errors from triggering sentry

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -75,6 +75,7 @@ Sentry.init({
     // `Can't find variable: bytecode`,
     'ResizeObserver loop limit exceeded',
     'ResizeObserver loop completed with undelivered notifications',
+    /Non-Error promise rejection captured with value: Object Not Found/,
   ],
   beforeSend: (event, hint) => {
     // prevent local errors from triggering sentry

--- a/src/hooks/useHandlePageError.ts
+++ b/src/hooks/useHandlePageError.ts
@@ -17,14 +17,15 @@ export function useHandlePageError({
     const isIntentionalError = window.location.pathname.includes('debug-sentry')
     logger.info(`${humanReadablePageName} Error Page rendered with:`, error)
     Sentry.captureException(error, { tags: { domain } })
-
-    if (checkIfErrorIsCausedByOutlook(error)) return
-
     const message = isIntentionalError
       ? `Testing Sentry Triggered ${humanReadablePageName} Error Page`
       : `${humanReadablePageName} Error Page Displayed`
     Sentry.captureMessage(message, { fingerprint: [`fingerprint-${message}`] })
-    trackClientAnalytic('Error Page Visible', { Category: humanReadablePageName })
+    const isAnOutlookBotError = checkIfErrorIsCausedByOutlook(error)
+    trackClientAnalytic('Error Page Visible', {
+      Category: humanReadablePageName,
+      ...(isAnOutlookBotError && { Cause: 'Outlook' }),
+    })
   }, [domain, error, humanReadablePageName])
 }
 
@@ -35,17 +36,17 @@ export function useHandlePageError({
 const OUTLOOK_BOT_ERROR_MESSAGE =
   'Non-Error promise rejection captured with value: Object Not Found'
 function checkIfErrorIsCausedByOutlook(error: Error & { digest?: string }) {
-  if (error?.message.includes(OUTLOOK_BOT_ERROR_MESSAGE)) return true
-  if (error?.name.includes(OUTLOOK_BOT_ERROR_MESSAGE)) return true
-  if (error?.digest && error?.digest.includes(OUTLOOK_BOT_ERROR_MESSAGE)) return true
+  if (error?.message?.includes(OUTLOOK_BOT_ERROR_MESSAGE)) return true
+  if (error?.name?.includes(OUTLOOK_BOT_ERROR_MESSAGE)) return true
+  if (error?.digest && error?.digest?.includes(OUTLOOK_BOT_ERROR_MESSAGE)) return true
   if (
     error?.cause &&
     typeof error?.cause === 'string' &&
-    error?.cause.includes(OUTLOOK_BOT_ERROR_MESSAGE)
+    error?.cause?.includes(OUTLOOK_BOT_ERROR_MESSAGE)
   ) {
     return true
   }
-  if (error?.stack && error?.stack.includes(OUTLOOK_BOT_ERROR_MESSAGE)) return true
+  if (error?.stack && error?.stack?.includes(OUTLOOK_BOT_ERROR_MESSAGE)) return true
 
   return false
 }

--- a/src/hooks/useHandlePageError.ts
+++ b/src/hooks/useHandlePageError.ts
@@ -17,10 +17,47 @@ export function useHandlePageError({
     const isIntentionalError = window.location.pathname.includes('debug-sentry')
     logger.info(`${humanReadablePageName} Error Page rendered with:`, error)
     Sentry.captureException(error, { tags: { domain } })
+
+    if (checkIfErrorIsCausedByOutlook(error)) return
+
     const message = isIntentionalError
       ? `Testing Sentry Triggered ${humanReadablePageName} Error Page`
       : `${humanReadablePageName} Error Page Displayed`
     Sentry.captureMessage(message, { fingerprint: [`fingerprint-${message}`] })
     trackClientAnalytic('Error Page Visible', { Category: humanReadablePageName })
   }, [domain, error, humanReadablePageName])
+}
+
+// we are not sure what causes outlook users to trigger an anti-fingerprint error when accessing
+// SWC using the parsed safe link from outlook. This is a fix to prevent errors spikes
+// from showing up in Sentry and Mixpanel when new email campaigns are sent out.
+// You can find more information about this issue here: https://github.com/Stand-With-Crypto/swc-web/issues/848
+const OUTLOOK_BOT_ERROR_MESSAGE =
+  'Non-Error promise rejection captured with value: Object Not Found'
+function checkIfErrorIsCausedByOutlook(error: Error & { digest?: string }) {
+  if (error?.message.includes(OUTLOOK_BOT_ERROR_MESSAGE)) {
+    return true
+  }
+
+  if (error?.name.includes(OUTLOOK_BOT_ERROR_MESSAGE)) {
+    return true
+  }
+
+  if (error?.digest && error?.digest.includes(OUTLOOK_BOT_ERROR_MESSAGE)) {
+    return true
+  }
+
+  if (
+    error?.cause &&
+    typeof error?.cause === 'string' &&
+    error?.cause.includes(OUTLOOK_BOT_ERROR_MESSAGE)
+  ) {
+    return true
+  }
+
+  if (error?.stack && error?.stack.includes(OUTLOOK_BOT_ERROR_MESSAGE)) {
+    return true
+  }
+
+  return false
 }

--- a/src/hooks/useHandlePageError.ts
+++ b/src/hooks/useHandlePageError.ts
@@ -21,10 +21,9 @@ export function useHandlePageError({
       ? `Testing Sentry Triggered ${humanReadablePageName} Error Page`
       : `${humanReadablePageName} Error Page Displayed`
     Sentry.captureMessage(message, { fingerprint: [`fingerprint-${message}`] })
-    const isAnOutlookBotError = checkIfErrorIsCausedByOutlook(error)
     trackClientAnalytic('Error Page Visible', {
       Category: humanReadablePageName,
-      ...(isAnOutlookBotError && { Cause: 'Outlook' }),
+      ...(checkIfErrorIsCausedByOutlook(error) && { Cause: 'Outlook' }),
     })
   }, [domain, error, humanReadablePageName])
 }

--- a/src/hooks/useHandlePageError.ts
+++ b/src/hooks/useHandlePageError.ts
@@ -35,18 +35,9 @@ export function useHandlePageError({
 const OUTLOOK_BOT_ERROR_MESSAGE =
   'Non-Error promise rejection captured with value: Object Not Found'
 function checkIfErrorIsCausedByOutlook(error: Error & { digest?: string }) {
-  if (error?.message.includes(OUTLOOK_BOT_ERROR_MESSAGE)) {
-    return true
-  }
-
-  if (error?.name.includes(OUTLOOK_BOT_ERROR_MESSAGE)) {
-    return true
-  }
-
-  if (error?.digest && error?.digest.includes(OUTLOOK_BOT_ERROR_MESSAGE)) {
-    return true
-  }
-
+  if (error?.message.includes(OUTLOOK_BOT_ERROR_MESSAGE)) return true
+  if (error?.name.includes(OUTLOOK_BOT_ERROR_MESSAGE)) return true
+  if (error?.digest && error?.digest.includes(OUTLOOK_BOT_ERROR_MESSAGE)) return true
   if (
     error?.cause &&
     typeof error?.cause === 'string' &&
@@ -54,10 +45,7 @@ function checkIfErrorIsCausedByOutlook(error: Error & { digest?: string }) {
   ) {
     return true
   }
-
-  if (error?.stack && error?.stack.includes(OUTLOOK_BOT_ERROR_MESSAGE)) {
-    return true
-  }
+  if (error?.stack && error?.stack.includes(OUTLOOK_BOT_ERROR_MESSAGE)) return true
 
   return false
 }


### PR DESCRIPTION
closes #848 

## What changed? Why?

This PR tries to add a conditional to don't log the errors caused by outlook bots from showing up in sentry and mixpanel.

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
