### PR TITLE
Fix experiments always returning the control variant

### DIFF
--- a/src/utils/web/clientExperiments.ts
+++ b/src/utils/web/clientExperiments.ts
@@ -15,11 +15,8 @@ function getRandomExperimentVariant<K extends Experiments>(experiment: K): Exper
   let cumulativePercentage = 0
   const finalVariant = variantConfigs.find(variant => {
     cumulativePercentage += variant.percentage
-    console.log({ variant, cumulativePercentage, randomValue })
     return cumulativePercentage >= randomValue
   })
-
-  console.log({ finalVariant })
 
   if (!finalVariant) {
     const variant = variantConfigs[0].name as ExperimentVariant<K>

--- a/src/utils/web/clientExperiments.ts
+++ b/src/utils/web/clientExperiments.ts
@@ -15,8 +15,11 @@ function getRandomExperimentVariant<K extends Experiments>(experiment: K): Exper
   let cumulativePercentage = 0
   const finalVariant = variantConfigs.find(variant => {
     cumulativePercentage += variant.percentage
+    console.log({ variant, cumulativePercentage, randomValue })
     return cumulativePercentage >= randomValue
   })
+
+  console.log({ finalVariant })
 
   if (!finalVariant) {
     const variant = variantConfigs[0].name as ExperimentVariant<K>
@@ -26,8 +29,7 @@ function getRandomExperimentVariant<K extends Experiments>(experiment: K): Exper
       fallback: variant,
     })
   }
-  const variant = variantConfigs[0].name as ExperimentVariant<K>
-  return variant
+  return finalVariant.name as ExperimentVariant<K>
 }
 
 export function getAllExperiments(persisted: PersistedLocalUser | null) {


### PR DESCRIPTION
fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

When we randomly get an experiment variant based on their percentages we are correctly getting a random variant but when returning it, we always select the first variant that turns out to be the control variant. This PR fixes it.

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
