### PR TITLE
Trigger capitol canary on sms opt in

### DIFF
--- a/src/actions/actionUpdateUserHasOptedInSMS.ts
+++ b/src/actions/actionUpdateUserHasOptedInSMS.ts
@@ -1,10 +1,18 @@
 'use server'
 import 'server-only'
 
+import { Address, User, UserCryptoAddress } from '@prisma/client'
 import { z } from 'zod'
 
 import { getClientUser } from '@/clientModels/clientUser/clientUser'
+import { CAPITOL_CANARY_UPSERT_ADVOCATE_INNGEST_EVENT_NAME } from '@/inngest/functions/capitolCanary/upsertAdvocateInCapitolCanary'
+import { inngest } from '@/inngest/inngest'
 import { appRouterGetAuthUser } from '@/utils/server/authentication/appRouterGetAuthUser'
+import {
+  CapitolCanaryCampaignName,
+  getCapitolCanaryCampaignID,
+} from '@/utils/server/capitolCanary/campaigns'
+import { UpsertAdvocateInCapitolCanaryPayloadRequirements } from '@/utils/server/capitolCanary/payloadRequirements'
 import { prismaClient } from '@/utils/server/prismaClient'
 import { throwIfRateLimited } from '@/utils/server/ratelimit/throwIfRateLimited'
 import { getServerPeopleAnalytics } from '@/utils/server/serverAnalytics'
@@ -60,7 +68,29 @@ async function _actionUpdateUserHasOptedInToSMS(data: UpdateUserHasOptedInToSMSP
     },
   })
 
+  await handleCapitolCanarySMSUpdate(updatedUser)
+
   return {
     user: getClientUser(updatedUser),
   }
+}
+
+async function handleCapitolCanarySMSUpdate(
+  updatedUser: User & { address: Address | null } & {
+    primaryUserCryptoAddress: UserCryptoAddress | null
+  },
+) {
+  const payload: UpsertAdvocateInCapitolCanaryPayloadRequirements = {
+    campaignId: getCapitolCanaryCampaignID(CapitolCanaryCampaignName.DEFAULT_SUBSCRIBER),
+    user: updatedUser,
+    opts: {
+      isSmsOptin: updatedUser.hasOptedInToSms,
+      // shouldSendSmsOptinConfirmation: true,
+    },
+  }
+
+  await inngest.send({
+    name: CAPITOL_CANARY_UPSERT_ADVOCATE_INNGEST_EVENT_NAME,
+    data: payload,
+  })
 }


### PR DESCRIPTION
## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## Notes to reviewers

Not sure if the `shouldSendSmsOptinConfirmation: true` should be sent. cc @travisbloom-cb 


## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
