### PR TITLE
Adds cache header for images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -178,6 +178,7 @@ const V1_ACTION_REDIRECTS = ACTION_REDIRECTS.map(({ destination, queryKey, query
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
+    minimumCacheTTL: 60 * 60 * 24 * 7, // 7 days
     unoptimized: false,
     remotePatterns: [
       {
@@ -192,7 +193,7 @@ const nextConfig = {
     return [
       {
         source: '/(.*)',
-        headers: [...securityHeaders, { key: 'Cache-Control', value: 's-maxage=604800' }], // 7 days
+        headers: securityHeaders,
       },
     ]
   },

--- a/next.config.js
+++ b/next.config.js
@@ -192,7 +192,7 @@ const nextConfig = {
     return [
       {
         source: '/(.*)',
-        headers: securityHeaders,
+        headers: [...securityHeaders, { key: 'Cache-Control', value: 's-maxage=604800' }], // 7 days
       },
     ]
   },


### PR DESCRIPTION
closes #934 

## What changed? Why?

This PR adds a new header to control cache following the nextjs documentation for image [optimization](https://nextjs.org/docs/app/api-reference/components/image#caching-behavior)

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
