### PR TITLE
New attempt to try to catch outlook error

### DIFF
--- a/src/hooks/useHandlePageError.ts
+++ b/src/hooks/useHandlePageError.ts
@@ -34,18 +34,18 @@ export function useHandlePageError({
 }
 
 // we are not sure what causes outlook users to trigger an anti-fingerprint error when accessing
-// SWC using the parsed safe link from outlook. This is a fix to prevent errors spikes
-// from showing up in Sentry and Mixpanel when new email campaigns are sent out.
+// SWC using the parsed safe link from outlook. This is fix to track the error
 // You can find more information about this issue here: https://github.com/Stand-With-Crypto/swc-web/issues/848
 const OUTLOOK_BOT_ERROR_MESSAGE = 'Non-Error promise rejection captured with value: '
 
 function checkIfErrorIsCausedByOutlook(error: any, isFromNewsletter: boolean) {
   if (!isFromNewsletter) return false
 
+  // The conditional logic below was inspired by this suggestion https://github.com/getsentry/sentry-javascript/issues/3440#issuecomment-828834651 as an attempt to try to catch the outlook error
   if (
-    error !== undefined &&
-    error?.exception !== undefined &&
-    error?.exception?.values !== undefined &&
+    typeof error !== 'undefined' &&
+    typeof error?.exception !== 'undefined' &&
+    typeof error?.exception?.values !== 'undefined' &&
     error?.exception?.values?.length === 1
   ) {
     const exception = error.exception.values[0]

--- a/src/hooks/useHandlePageError.ts
+++ b/src/hooks/useHandlePageError.ts
@@ -34,7 +34,7 @@ export function useHandlePageError({
 }
 
 // we are not sure what causes outlook users to trigger an anti-fingerprint error when accessing
-// SWC using the parsed safe link from outlook. This is fix to track the error
+// SWC using the parsed safe link from outlook. This fix was added to track the error
 // You can find more information about this issue here: https://github.com/Stand-With-Crypto/swc-web/issues/848
 const OUTLOOK_BOT_ERROR_MESSAGE = 'Non-Error promise rejection captured with value: '
 

--- a/src/hooks/useHandlePageError.ts
+++ b/src/hooks/useHandlePageError.ts
@@ -21,6 +21,7 @@ export function useHandlePageError({
     const isIntentionalError = window.location.pathname.includes('debug-sentry')
     logger.info(`${humanReadablePageName} Error Page rendered with:`, error)
     Sentry.captureException(error, { tags: { domain } })
+
     const message = isIntentionalError
       ? `Testing Sentry Triggered ${humanReadablePageName} Error Page`
       : `${humanReadablePageName} Error Page Displayed`
@@ -36,36 +37,21 @@ export function useHandlePageError({
 // SWC using the parsed safe link from outlook. This is a fix to prevent errors spikes
 // from showing up in Sentry and Mixpanel when new email campaigns are sent out.
 // You can find more information about this issue here: https://github.com/Stand-With-Crypto/swc-web/issues/848
-const OUTLOOK_BOT_ERROR_MESSAGE = [
-  'Object Not Found Matching Id:',
-  'antifingerprint not defined yet',
-]
-function checkIfErrorIsCausedByOutlook(
-  error: Error & { digest?: string },
-  isFromNewsletter: boolean,
-) {
+const OUTLOOK_BOT_ERROR_MESSAGE = 'Non-Error promise rejection captured with value: '
+
+function checkIfErrorIsCausedByOutlook(error: any, isFromNewsletter: boolean) {
   if (!isFromNewsletter) return false
 
   if (
-    typeof error !== typeof Error &&
-    OUTLOOK_BOT_ERROR_MESSAGE.some(errorMsg => error?.toString()?.includes(errorMsg))
+    error !== undefined &&
+    error?.exception !== undefined &&
+    error?.exception?.values !== undefined &&
+    error?.exception?.values?.length === 1
   ) {
-    return true
-  }
-
-  if (OUTLOOK_BOT_ERROR_MESSAGE.some(errorMsg => error?.message?.includes(errorMsg))) return true
-  if (OUTLOOK_BOT_ERROR_MESSAGE.some(errorMsg => error?.name?.includes(errorMsg))) return true
-  if (
-    error?.digest &&
-    OUTLOOK_BOT_ERROR_MESSAGE.some(errorMsg => error?.digest?.includes(errorMsg))
-  ) {
-    return true
-  }
-  if (
-    error?.stack &&
-    OUTLOOK_BOT_ERROR_MESSAGE.some(errorMsg => error?.stack?.includes(errorMsg))
-  ) {
-    return true
+    const exception = error.exception.values[0]
+    if (exception.type === 'UnhandledRejection' && exception.value === OUTLOOK_BOT_ERROR_MESSAGE) {
+      return true
+    }
   }
 
   return false

--- a/src/hooks/useHandlePageError.ts
+++ b/src/hooks/useHandlePageError.ts
@@ -49,7 +49,10 @@ function checkIfErrorIsCausedByOutlook(error: any, isFromNewsletter: boolean) {
     error?.exception?.values?.length === 1
   ) {
     const exception = error.exception.values[0]
-    if (exception.type === 'UnhandledRejection' && exception.value === OUTLOOK_BOT_ERROR_MESSAGE) {
+    if (
+      exception.type === 'UnhandledRejection' &&
+      exception.value.includes(OUTLOOK_BOT_ERROR_MESSAGE)
+    ) {
       return true
     }
   }

--- a/src/hooks/useHandlePageError.ts
+++ b/src/hooks/useHandlePageError.ts
@@ -51,7 +51,7 @@ function checkIfErrorIsCausedByOutlook(error: any, isFromNewsletter: boolean) {
     const exception = error.exception.values[0]
     if (
       exception.type === 'UnhandledRejection' &&
-      exception.value.includes(OUTLOOK_BOT_ERROR_MESSAGE)
+      exception.value?.includes(OUTLOOK_BOT_ERROR_MESSAGE)
     ) {
       return true
     }


### PR DESCRIPTION
## What changed? Why?

This PR is a new attempt to try to catch the outlook error using [this](https://github.com/getsentry/sentry-javascript/issues/3440#issuecomment-828834651) suggestion as reference.

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
