### PR TITLE
test: add cypress login command

### DIFF
--- a/cypress/e2e/07-action-voter-registration.cy.ts
+++ b/cypress/e2e/07-action-voter-registration.cy.ts
@@ -76,7 +76,6 @@ describe('action - voter registration', () => {
 
       cy.contains("Claim “I'm a Voter” NFT")
 
-      cy.intercept('/api/auth/login').as('authLogin')
       cy.intercept('/api/identified-user/claimed-opt-in-nft').as('hasOptInNft')
 
       cy.get('button[type="button"]').contains('Claim NFT').click()
@@ -90,16 +89,7 @@ describe('action - voter registration', () => {
         },
       )
 
-      cy.get('button[type="button"]').contains('Join To Claim NFT').click()
-
-      cy.get('button[data-test="continue-as-guest-button"]').click()
-
-      cy.get('input[data-test="new-password"][type="password"]').type(mockWallet.password)
-      cy.get('input[data-test="confirm-password"][type="password"]').type(mockWallet.password)
-
-      cy.contains('Create new wallet').click()
-
-      cy.wait('@authLogin')
+      cy.waitForLogin({ trigger: cy.get('button[type="button"]').contains('Join To Claim NFT') })
 
       cy.contains(/Finish my profile/g).click()
 

--- a/cypress/e2e/11-action-mint-your-supporter-nft.cy.ts
+++ b/cypress/e2e/11-action-mint-your-supporter-nft.cy.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { mockRandomUser, mockWallet } from 'cypress/fixture/mocks'
+import { mockRandomUser } from 'cypress/fixture/mocks'
 
 describe('action - mint your supporter NFT', () => {
   it('should go through signing in and nft minting', () => {
@@ -10,25 +10,7 @@ describe('action - mint your supporter NFT', () => {
 
     cy.get('[role="dialog"]')
 
-    cy.get('button[data-testid="signin-button"]').click()
-
-    cy.get('button[data-test="continue-as-guest-button"]').click()
-
-    cy.intercept('/api/auth/login').as('authLogin')
-
-    cy.get('input[data-test="new-password"][type="password"]')
-
-      .type(mockWallet.password)
-    cy.get('input[data-test="confirm-password"][type="password"]')
-
-      .type(mockWallet.password)
-
-    cy.contains('Create new wallet').click()
-
-    cy.wait('@authLogin')
-
-    // wait for page blink
-    cy.wait(1000)
+    cy.waitForLogin({ trigger: cy.get('button[data-testid="signin-button"]') })
 
     cy.contains(/Finish your profile|Create an account. Get an NFT./g).should('be.visible')
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 
 import { Prisma } from '@prisma/client'
+import { mockWallet } from 'cypress/fixture/mocks'
 
 // ***********************************************
 // This example commands.ts shows you how to
@@ -109,13 +110,42 @@ Cypress.Commands.add('typeIntoInput', ({ selector, text }) => {
   cy.get(selector).should('be.visible').clear().wait(500).type(text)
 })
 
+/**
+ * This command is used to wait for the login page to load and then fill in the login form
+ * @param trigger - The trigger to click to open the login form
+ * @example cy.waitForLogin({ trigger: cy.get('button[data-test="login-button"]') })
+ * @returns void
+ */
+Cypress.Commands.add('waitForLogin', ({ trigger }) => {
+  trigger.click()
+
+  cy.wait(500)
+
+  cy.get('button[data-test="continue-as-guest-button"]').click()
+
+  cy.intercept('/api/auth/login').as('authLogin')
+
+  cy.get('input[data-test="new-password"][type="password"]')
+
+    .type(mockWallet.password)
+  cy.get('input[data-test="confirm-password"][type="password"]')
+
+    .type(mockWallet.password)
+
+  cy.contains('Create new wallet').click()
+
+  cy.wait('@authLogin')
+
+  cy.wait(500)
+})
+
 export {}
 
 declare global {
   namespace Cypress {
     interface Chainable {
       selectFromComboBox(config: {
-        trigger: Chainable<JQuery<Node>>
+        trigger: Cypress.Chainable<JQuery<HTMLElement>>
         searchText: string
         typingRequired?: boolean
       }): Chainable<void>
@@ -124,6 +154,7 @@ declare global {
       clearDb(): Chainable<void>
       seedDb(): Chainable<void>
       typeIntoInput(config: { selector: string; text: string }): Chainable<void>
+      waitForLogin(config: { trigger: Cypress.Chainable<JQuery<HTMLElement>> }): Chainable<void>
 
       //   drag(subject: string, options?: Partial<TypeOptions>): Chainable<Element>
       //   dismiss(subject: string, options?: Partial<TypeOptions>): Chainable<Element>


### PR DESCRIPTION
#951

closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

adds a login command in cypress to ease the usage throughout other user actions

ex.: `cy.waitForLogin({ trigger: cy.get('button[type="button"]').contains('Join To Claim NFT') })`

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
