### PR TITLE
Scripts to export project data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -128,3 +128,6 @@ NEXT_PUBLIC_VERCEL_URL=
 # BuilderIO
 BUILDER_IO_PUBLIC_KEY='123'
 BUILDER_IO_PRIVATE_KEY='123'
+
+# Github repository read access token
+GITHUB_TOKEN=''

--- a/src/bin/reports/generateCommitReportByPerson.ts
+++ b/src/bin/reports/generateCommitReportByPerson.ts
@@ -1,4 +1,4 @@
-import { differenceInDays, differenceInHours, differenceInMinutes, format } from 'date-fns'
+import { format } from 'date-fns'
 import { debounce } from 'lodash-es'
 import path from 'path'
 import xlsx from 'xlsx'
@@ -130,11 +130,9 @@ async function generateProjectData() {
   await getGithubCommitData(commits, 'swc-web')
   await getGithubCommitData(commits, 'swc-internal')
 
-  console.log(commits.length)
+  await generateCommitReportByPerson(commits)
 
-  // await generateCommitReportByPerson(commits)
-
-  // console.log('Generated commit report by person successfully!')
+  console.log('Generated commit report by person successfully!')
 }
 
 void runBin(generateProjectData)

--- a/src/bin/reports/generateCommitReportByPerson.ts
+++ b/src/bin/reports/generateCommitReportByPerson.ts
@@ -1,0 +1,183 @@
+import { differenceInDays, differenceInHours, differenceInMinutes, format } from 'date-fns'
+import { debounce } from 'lodash-es'
+import path from 'path'
+import xlsx from 'xlsx'
+
+import { runBin } from '@/bin/runBin'
+import { fetchReq } from '@/utils/shared/fetchReq'
+
+const GITHUB_API_URL = 'https://api.github.com/graphql'
+
+interface Commit {
+  message: string
+  author: {
+    name: string
+  }
+  additions: number
+  deletions: number
+  committedDate: string
+  changedFilesIfAvailable: number
+  associatedPullRequests: {
+    nodes: Array<{
+      title: string
+    }>
+  }
+  url: string
+  repository: {
+    name: string
+  }
+}
+
+interface GithubCommitDataResponse {
+  data: {
+    repository: {
+      ref: {
+        target: {
+          history: {
+            nodes: Array<Commit>
+            pageInfo: {
+              hasNextPage: boolean
+              endCursor?: string
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+export const GITHUB_COMMIT_DATA_FROM_MAIN_BRANCH_QUERY = /* GraphQL */ `
+  query ($owner: String!, $name: String!, $after: String) {
+    repository(owner: $owner, name: $name) {
+      ref(qualifiedName: "main") {
+        target {
+          ... on Commit {
+            history(first: 100, after: $after) {
+              nodes {
+                message
+                author {
+                  name
+                }
+                associatedPullRequests(first: 1) {
+                  nodes {
+                    title
+                  }
+                }
+                additions
+                deletions
+                changedFilesIfAvailable
+                url
+                committedDate
+                repository {
+                  name
+                }
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+async function getGithubCommitData(commits: Commit[], repositoryName: string, after?: string) {
+  // This is required because there is a rate limit in Github API. https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-secondary-rate-limits
+  const MAX_REQUESTS_PER_MINUTE = 100
+  const REQUEST_INTERVAL = (60 * 1000) / MAX_REQUESTS_PER_MINUTE
+
+  const response = await fetchReq(GITHUB_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.GITHUB_TOKEN ?? ''}`,
+    },
+    body: JSON.stringify({
+      query: GITHUB_COMMIT_DATA_FROM_MAIN_BRANCH_QUERY,
+      variables: {
+        owner: 'Stand-With-Crypto',
+        name: repositoryName,
+        after,
+      },
+    }),
+  })
+
+  const { data } = (await response.json()) as GithubCommitDataResponse
+  const repository = data.repository
+  const commitsFromMainBranch = repository?.ref?.target?.history ?? {
+    nodes: [],
+    pageInfo: { hasNextPage: false },
+  }
+
+  commits.push(...commitsFromMainBranch.nodes)
+
+  if (commitsFromMainBranch.pageInfo.hasNextPage) {
+    debounce(
+      () =>
+        void getGithubCommitData(commits, repositoryName, commitsFromMainBranch.pageInfo.endCursor),
+      REQUEST_INTERVAL,
+    )
+  }
+}
+
+async function generateProjectData() {
+  console.log('Generating commit report by person. Please wait...')
+
+  const commits: Commit[] = []
+
+  await getGithubCommitData(commits, 'swc-web')
+  await getGithubCommitData(commits, 'swc-internal')
+
+  console.log(commits.length)
+
+  // await generateCommitReportByPerson(commits)
+
+  // console.log('Generated commit report by person successfully!')
+}
+
+void runBin(generateProjectData)
+
+async function generateCommitReportByPerson(commits: Commit[]) {
+  const commitsByPerson = commits.reduce(
+    (acc, commit) => {
+      if (!acc[commit.author.name]) {
+        acc[commit.author.name] = []
+      }
+
+      acc[commit.author.name].push(commit)
+
+      return acc
+    },
+    {} as Record<string, Commit[]>,
+  )
+
+  const workbook = xlsx.utils.book_new()
+
+  Object.entries(commitsByPerson).forEach(([author, _commits]) => {
+    const commitsOrderedDesc = _commits.sort(
+      (a, b) => new Date(b.committedDate).getTime() - new Date(a.committedDate).getTime(),
+    )
+
+    const worksheet = xlsx.utils.json_to_sheet(
+      commitsOrderedDesc.map((item: Commit) => {
+        return {
+          ['Author']: item.author.name,
+          ['Additions']: item.additions,
+          ['Deletions']: item.deletions,
+          ['Committed Date']: format(new Date(item.committedDate), 'yyyy-MM-dd'),
+          ['Changed Files']: item.changedFilesIfAvailable,
+          ['Repo']: item.repository.name,
+          ['Commit Message']: item.message,
+          ['Pull Request']: item.associatedPullRequests.nodes[0]?.title ?? '---',
+          ['Url']: item.url,
+        }
+      }),
+    )
+
+    xlsx.utils.book_append_sheet(workbook, worksheet, `${author} - ${_commits.length} commits`)
+  })
+
+  await xlsx.writeFile(workbook, path.join(__dirname, 'commitsReportByPerson.xlsx'))
+}

--- a/src/bin/reports/generateProjectData.ts
+++ b/src/bin/reports/generateProjectData.ts
@@ -1,0 +1,231 @@
+import { differenceInDays, differenceInHours, differenceInMinutes, format } from 'date-fns'
+import path from 'path'
+import xlsx from 'xlsx'
+
+import { runBin } from '@/bin/runBin'
+import { fetchReq } from '@/utils/shared/fetchReq'
+
+const GITHUB_API_URL = 'https://api.github.com/graphql'
+
+interface GithubProjectDataResponse {
+  data: {
+    repository: {
+      issues: {
+        nodes: Array<{
+          state: string
+          url: string
+          updatedAt: string
+          closedAt: string
+          createdAt: string
+          assignees: {
+            nodes: {
+              name: string
+              login: string
+            }[]
+          }
+          title: string
+          projectItems?: {
+            nodes?: [
+              {
+                effort?: {
+                  value: string
+                }
+                impact?: {
+                  value: string
+                }
+                issueType?: {
+                  value: string
+                }
+              },
+            ]
+          }
+        }>
+      }
+    }
+  }
+}
+
+type GithubProjectDataIssues = GithubProjectDataResponse['data']['repository']['issues']['nodes']
+
+export const GITHUB_PROJECT_DATA_QUERY = /* GraphQL */ `
+  query ($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
+      issues(first: 100, after: null) {
+        nodes {
+          title
+          state
+          url
+          updatedAt
+          closedAt
+          createdAt
+          assignees(first: 5, last: null) {
+            nodes {
+              name
+              login
+            }
+          }
+          projectItems(first: 100) {
+            nodes {
+              effort: fieldValueByName(name: "Effort") {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  value: name
+                }
+              }
+              impact: fieldValueByName(name: "Impact") {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  value: name
+                }
+              }
+              issueType: fieldValueByName(name: "Issue Type") {
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  value: name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+async function generateProjectData() {
+  const variables = {
+    owner: 'Stand-With-Crypto',
+    name: 'swc-web',
+  }
+
+  const response = await fetchReq(GITHUB_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.GITHUB_TOKEN ?? ''}`,
+    },
+    body: JSON.stringify({
+      query: GITHUB_PROJECT_DATA_QUERY,
+      variables,
+    }),
+  })
+
+  const { data } = (await response.json()) as GithubProjectDataResponse
+  const repository = data.repository
+  const issues = repository.issues.nodes
+
+  await generateProjectDataOverview(issues)
+  await generateProjectDataByAssignee(issues)
+}
+
+void runBin(generateProjectData)
+
+async function generateProjectDataOverview(issues: GithubProjectDataIssues) {
+  const workbook = xlsx.utils.book_new()
+
+  const closedIssues = issues.filter(issue => issue.state === 'CLOSED')
+  const closedIssuesByMonth = closedIssues.reduce(
+    (acc, issue) => {
+      const closedAtKey = format(new Date(issue.closedAt), 'yyyy-MM (MMMM)')
+
+      if (!acc[closedAtKey]) {
+        acc[closedAtKey] = []
+      }
+
+      acc[closedAtKey].push(issue)
+
+      return acc
+    },
+    {} as Record<string, GithubProjectDataIssues>,
+  )
+  const closedIssuesByMonthOrderedDesc = Object.entries(closedIssuesByMonth).sort(([a], [b]) => {
+    return new Date(b).getTime() - new Date(a).getTime()
+  })
+
+  closedIssuesByMonthOrderedDesc.forEach(([month, _issues]) => {
+    const worksheet = xlsx.utils.json_to_sheet(
+      _issues.map((item: GithubProjectDataIssues[0]) => {
+        const days = differenceInDays(new Date(item.closedAt), new Date(item.createdAt))
+        const hours = differenceInHours(new Date(item.closedAt), new Date(item.createdAt)) % 24
+        const minutes = differenceInMinutes(new Date(item.closedAt), new Date(item.createdAt)) % 60
+
+        const timePassed = []
+        if (days > 0) timePassed.push(`${days} days`)
+        if (hours > 0) timePassed.push(`${hours} hours`)
+        if (minutes > 0) timePassed.push(`${minutes} minutes`)
+
+        return {
+          ['Issue Title']: item.title,
+          ['Assignee']: item.assignees.nodes[0]?.name ?? item.assignees.nodes[0]?.login ?? '---',
+          ['Effort']: item?.projectItems?.nodes?.[0]?.effort?.value ?? '---',
+          ['Impact']: item?.projectItems?.nodes?.[0]?.impact?.value ?? '---',
+          ['Issue Type']: item?.projectItems?.nodes?.[0]?.issueType?.value ?? '---',
+          ['Url']: item.url,
+          ['Created']: format(new Date(item.createdAt), 'yyyy-MM-dd'),
+          ['Closed']: format(new Date(item.closedAt), 'yyyy-MM-dd'),
+          ['Time to Close']: timePassed.join(', '),
+          state: item.state === 'CLOSED' ? 'Closed' : 'Open',
+        }
+      }),
+    )
+
+    xlsx.utils.book_append_sheet(workbook, worksheet, month)
+  })
+
+  await xlsx.writeFile(workbook, path.join(__dirname, 'projectReportByMonth.xlsx'))
+}
+
+async function generateProjectDataByAssignee(issues: GithubProjectDataIssues) {
+  const workbook = xlsx.utils.book_new()
+
+  const closedIssues = issues.filter(issue => issue.state === 'CLOSED')
+
+  const issuesByAssignee = closedIssues.reduce(
+    (acc, issue) => {
+      const assignee = issue.assignees.nodes[0]
+      if (!assignee) return acc
+
+      if (!acc[assignee.login]) {
+        acc[assignee.login] = []
+      }
+
+      acc[assignee.login].push(issue)
+
+      return acc
+    },
+    {} as Record<string, GithubProjectDataResponse['data']['repository']['issues']['nodes']>,
+  )
+
+  Object.entries(issuesByAssignee).forEach(([assignee, _issues]) => {
+    const issuesOrderedDesc = _issues.sort((a, b) => {
+      return new Date(b.closedAt).getTime() - new Date(a.closedAt).getTime()
+    })
+
+    const worksheet = xlsx.utils.json_to_sheet(
+      issuesOrderedDesc.map((item: GithubProjectDataIssues[0]) => {
+        const days = differenceInDays(new Date(item.closedAt), new Date(item.createdAt))
+        const hours = differenceInHours(new Date(item.closedAt), new Date(item.createdAt)) % 24
+        const minutes = differenceInMinutes(new Date(item.closedAt), new Date(item.createdAt)) % 60
+
+        const timePassed = []
+        if (days > 0) timePassed.push(`${days} days`)
+        if (hours > 0) timePassed.push(`${hours} hours`)
+        if (minutes > 0) timePassed.push(`${minutes} minutes`)
+
+        return {
+          ['Issue Title']: item.title,
+          ['Assignee']: item.assignees.nodes[0]?.name ?? item.assignees.nodes[0]?.login ?? '---',
+          ['Effort']: item?.projectItems?.nodes?.[0]?.effort?.value ?? '---',
+          ['Impact']: item?.projectItems?.nodes?.[0]?.impact?.value ?? '---',
+          ['Issue Type']: item?.projectItems?.nodes?.[0]?.issueType?.value ?? '---',
+          ['Url']: item.url,
+          ['Created']: format(new Date(item.createdAt), 'yyyy-MM-dd'),
+          ['Closed']: format(new Date(item.closedAt), 'yyyy-MM-dd'),
+          ['Time to Close']: timePassed.join(', '),
+          state: item.state === 'CLOSED' ? 'Closed' : 'Open',
+        }
+      }),
+    )
+
+    xlsx.utils.book_append_sheet(workbook, worksheet, assignee)
+  })
+
+  await xlsx.writeFile(workbook, path.join(__dirname, 'projectReportByAssignee.xlsx'))
+}


### PR DESCRIPTION
closes [#49
](https://github.com/Stand-With-Crypto/swc-internal/issues/49)

## What changed? Why?
Created two new scripts to export project data 

## Notes to reviewers

You need to create a new env variable named GITHUB_TOKEN with the classic token created with the correct read privileges. You can create a new token accessing this [link](https://github.com/settings/tokens), selecting `Tokens (Classic)` and then selecting read access to `repo` and `project`, like so:

<img width="775" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/25483313/cc532d31-3356-4e15-aca8-7ef25b80d7bc">
<img width="777" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/25483313/be2657cc-a011-4b56-b859-84d4091fde44">


## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
