### PR TITLE
feat: addes a new emailAddress field for UserActionEmailRecipient

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -324,6 +324,7 @@ model UserActionEmailRecipient {
   id                String          @id @default(uuid())
   userActionEmailId String          @map("user_action_email_id")
   userActionEmail   UserActionEmail @relation(fields: [userActionEmailId], references: [id])
+  emailAddress      String?         @map("email_address")
   // unfortunately some of our legacy data doesn't include this info so it needs to be optional
   dtsiSlug          String?         @map("dtsi_slug")
 

--- a/src/mocks/models/mockUserActionEmailRecipient.ts
+++ b/src/mocks/models/mockUserActionEmailRecipient.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker'
 import { Prisma, UserActionEmailRecipient } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
@@ -15,5 +16,6 @@ export function mockUserActionEmailRecipient(): UserActionEmailRecipient {
     ...mockCreateUserActionEmailRecipientInput(),
     id: fakerFields.id(),
     userActionEmailId: fakerFields.id(),
+    emailAddress: faker.internet.email(),
   }
 }


### PR DESCRIPTION
## What changed? Why?

This PR adds a new optional emailAddress field for the UserActionEmailRecipient model for the #959 task.

## PlanetScale deploy request

[Deploy Request](https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/22)

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
