### PR TITLE
Changes SWC CTA logic to include campaigns

### DIFF
--- a/src/app/[locale]/internal/user-action-deeplinks/page.tsx
+++ b/src/app/[locale]/internal/user-action-deeplinks/page.tsx
@@ -24,7 +24,6 @@ export default function UserActionDeepLinks() {
           actionType => USER_ACTION_DEEPLINK_MAP[actionType as UserActionTypesWithDeeplink],
         ).map(actionType => {
           const props = getUserActionCTAInfo(actionType)
-          if (!props) return null
 
           const { WrapperComponent: _, ...userAction } = props
 

--- a/src/app/[locale]/internal/user-action-deeplinks/page.tsx
+++ b/src/app/[locale]/internal/user-action-deeplinks/page.tsx
@@ -2,7 +2,7 @@
 import { useRouter } from 'next/navigation'
 
 import { UserActionRowCTAButton } from '@/components/app/userActionRowCTA'
-import { USER_ACTION_ROW_CTA_INFO } from '@/components/app/userActionRowCTA/constants'
+import { getUserActionCTAInfo } from '@/components/app/userActionRowCTA/constants'
 import { ExternalLink } from '@/components/ui/link'
 import { useLocale } from '@/hooks/useLocale'
 import { fullUrl } from '@/utils/shared/urls'
@@ -23,8 +23,11 @@ export default function UserActionDeepLinks() {
         {USER_ACTION_TYPE_CTA_PRIORITY_ORDER.filter(
           actionType => USER_ACTION_DEEPLINK_MAP[actionType as UserActionTypesWithDeeplink],
         ).map(actionType => {
-          const props = USER_ACTION_ROW_CTA_INFO[actionType]
+          const props = getUserActionCTAInfo(actionType)
+          if (!props) return null
+
           const { WrapperComponent: _, ...userAction } = props
+
           const url = USER_ACTION_DEEPLINK_MAP[
             userAction.actionType as UserActionTypesWithDeeplink
           ].getDeeplinkUrl({ locale })

--- a/src/clientModels/clientUserAction/sensitiveDataClientUserAction.ts
+++ b/src/clientModels/clientUserAction/sensitiveDataClientUserAction.ts
@@ -85,7 +85,7 @@ type SensitiveDataClientUserActionTweetAtPerson = {
 At the database schema level we can't enforce that a single action only has one "type" FK, but at the client level we can and should
 */
 export type SensitiveDataClientUserAction = ClientModel<
-  Pick<UserAction, 'id' | 'actionType'> & {
+  Pick<UserAction, 'id' | 'actionType' | 'campaignName'> & {
     nftMint: ClientNFTMint | null
     datetimeCreated: string
   } & (
@@ -119,11 +119,12 @@ export const getSensitiveDataClientUserAction = ({
 }: {
   record: SensitiveDataClientUserActionDatabaseQuery
 }): SensitiveDataClientUserAction => {
-  const { id, datetimeCreated, actionType, nftMint } = record
+  const { id, datetimeCreated, actionType, nftMint, campaignName } = record
   const sharedProps = {
     id,
     datetimeCreated: datetimeCreated.toISOString(),
     actionType,
+    campaignName,
     nftMint: nftMint
       ? {
           ...getClientNFTMint(nftMint),

--- a/src/components/app/nftHub/nftDisplay.tsx
+++ b/src/components/app/nftHub/nftDisplay.tsx
@@ -3,7 +3,7 @@ import { UserActionType } from '@prisma/client'
 import * as Sentry from '@sentry/nextjs'
 
 import { SensitiveDataClientUserAction } from '@/clientModels/clientUserAction/sensitiveDataClientUserAction'
-import { USER_ACTION_ROW_CTA_INFO } from '@/components/app/userActionRowCTA/constants'
+import { getUserActionCTAInfo } from '@/components/app/userActionRowCTA/constants'
 import { Button } from '@/components/ui/button'
 import { NextImage } from '@/components/ui/image'
 import { NFTSlug } from '@/utils/shared/nft'
@@ -21,7 +21,9 @@ type NFTImages = {
   key: string
 }
 
-const ButtonWrapper = USER_ACTION_ROW_CTA_INFO[UserActionType.NFT_MINT].WrapperComponent
+const CTAInfo = getUserActionCTAInfo(UserActionType.NFT_MINT)
+
+const ButtonWrapper = CTAInfo?.WrapperComponent
 
 export function NFTDisplay({ userActions }: NFTDisplayProps) {
   let optInNftButton = true
@@ -88,9 +90,11 @@ export function NFTDisplay({ userActions }: NFTDisplayProps) {
       </div>
       {optInNftButton ?? (
         <div className="m-4 flex justify-center">
-          <ButtonWrapper>
-            <Button>Mint Stand With Crypto Supporter NFT</Button>
-          </ButtonWrapper>
+          {ButtonWrapper !== undefined ? (
+            <ButtonWrapper>
+              <Button>Mint Stand With Crypto Supporter NFT</Button>
+            </ButtonWrapper>
+          ) : null}
         </div>
       )}
     </>

--- a/src/components/app/pageUserProfile/index.tsx
+++ b/src/components/app/pageUserProfile/index.tsx
@@ -21,6 +21,7 @@ import { getSearchParam, setCallbackQueryString } from '@/utils/server/searchPar
 import { SupportedFiatCurrencyCodes } from '@/utils/shared/currency'
 import { USER_ACTION_DEEPLINK_MAP } from '@/utils/shared/urlsDeeplinkUserActions'
 import { hasCompleteUserProfile } from '@/utils/web/hasCompleteUserProfile'
+import { USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN } from '@/utils/web/userActionUtils'
 import { getSensitiveDataUserDisplayName } from '@/utils/web/userUtils'
 
 import { UserReferralUrl } from './userReferralUrl'
@@ -67,14 +68,30 @@ export function PageUserProfile({ params, searchParams, user }: PageUserProfile)
     )
   }
   const { userActions } = user
-  const performedUserActionTypes = uniq(userActions.map(x => x.actionType))
+  const performedUserActionTypes = uniq(
+    userActions.map(x => ({ actionType: x.actionType, campaignName: x.campaignName })),
+  )
   const excludeUserActionTypes = user.hasEmbeddedWallet
     ? [UserActionType.NFT_MINT, ...USER_ACTIONS_EXCLUDED_FROM_CTA]
     : USER_ACTIONS_EXCLUDED_FROM_CTA
-  const numActionsCompleted = performedUserActionTypes.filter(
-    action => !excludeUserActionTypes.includes(action),
+  const numActionsCompleted = performedUserActionTypes
+    .filter(performedAction => {
+      return !excludeUserActionTypes.includes(performedAction.actionType)
+    })
+    .filter(
+      performedAction =>
+        !USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN.some(
+          item =>
+            item.campaign !== performedAction.campaignName &&
+            item.action === performedAction.actionType,
+        ),
+    ).length
+
+  const numActionsAvailable = Object.values(
+    USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN.filter(
+      item => !excludeUserActionTypes.includes(item.action),
+    ),
   ).length
-  const numActionsAvailable = Object.values(UserActionType).length - excludeUserActionTypes.length
 
   return (
     <div className="standard-spacing-from-navbar container space-y-10 lg:space-y-16">
@@ -120,7 +137,7 @@ export function PageUserProfile({ params, searchParams, user }: PageUserProfile)
           {[
             {
               label: 'Actions',
-              value: <FormattedNumber amount={userActions.length} locale={locale} />,
+              value: <FormattedNumber amount={numActionsCompleted} locale={locale} />,
             },
             {
               label: 'Donated',

--- a/src/components/app/userActionFormSuccessScreen/getNextAction.tsx
+++ b/src/components/app/userActionFormSuccessScreen/getNextAction.tsx
@@ -4,23 +4,24 @@ import { UserActionType } from '@prisma/client'
 
 import { GetUserPerformedUserActionTypesResponse } from '@/app/api/identified-user/performed-user-action-types/route'
 import { getUserActionCTAInfo } from '@/components/app/userActionRowCTA/constants'
-import { USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP } from '@/utils/shared/userActionCampaigns'
-import { USER_ACTION_TYPE_CTA_PRIORITY_ORDER } from '@/utils/web/userActionUtils'
+import { USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN } from '@/utils/web/userActionUtils'
 
 export function getNextAction(
   performedUserActionTypes: GetUserPerformedUserActionTypesResponse['performedUserActionTypes'],
 ) {
-  const action = USER_ACTION_TYPE_CTA_PRIORITY_ORDER.filter(x => x !== UserActionType.OPT_IN).find(
+  const nextAction = USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN.filter(
+    x => x.action !== UserActionType.OPT_IN,
+  ).find(
     userAction =>
       !performedUserActionTypes.some(
         performedAction =>
-          performedAction.actionType === userAction &&
-          performedAction.campaignName === USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP[userAction],
+          performedAction.actionType === userAction.action &&
+          performedAction.campaignName === userAction.campaign,
       ),
   )
 
-  if (action) {
-    const CTAInfo = getUserActionCTAInfo(action)
+  if (nextAction) {
+    const CTAInfo = getUserActionCTAInfo(nextAction.action, nextAction.campaign)
 
     if (!CTAInfo) return null
 

--- a/src/components/app/userActionFormSuccessScreen/getNextAction.tsx
+++ b/src/components/app/userActionFormSuccessScreen/getNextAction.tsx
@@ -3,7 +3,7 @@
 import { UserActionType } from '@prisma/client'
 
 import { GetUserPerformedUserActionTypesResponse } from '@/app/api/identified-user/performed-user-action-types/route'
-import { USER_ACTION_ROW_CTA_INFO } from '@/components/app/userActionRowCTA/constants'
+import { getUserActionCTAInfo } from '@/components/app/userActionRowCTA/constants'
 import { USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP } from '@/utils/shared/userActionCampaigns'
 import { USER_ACTION_TYPE_CTA_PRIORITY_ORDER } from '@/utils/web/userActionUtils'
 
@@ -20,7 +20,11 @@ export function getNextAction(
   )
 
   if (action) {
-    const { WrapperComponent: _WrapperComponent, ...rest } = USER_ACTION_ROW_CTA_INFO[action]
+    const CTAInfo = getUserActionCTAInfo(action)
+
+    if (!CTAInfo) return null
+
+    const { WrapperComponent: _WrapperComponent, ...rest } = CTAInfo
     return rest
   }
   return null

--- a/src/components/app/userActionFormSuccessScreen/getNextAction.tsx
+++ b/src/components/app/userActionFormSuccessScreen/getNextAction.tsx
@@ -23,8 +23,6 @@ export function getNextAction(
   if (nextAction) {
     const CTAInfo = getUserActionCTAInfo(nextAction.action, nextAction.campaign)
 
-    if (!CTAInfo) return null
-
     const { WrapperComponent: _WrapperComponent, ...rest } = CTAInfo
     return rest
   }

--- a/src/components/app/userActionFormSuccessScreen/userActionFormSuccessScreenNextAction.tsx
+++ b/src/components/app/userActionFormSuccessScreen/userActionFormSuccessScreenNextAction.tsx
@@ -42,8 +42,6 @@ export function UserActionFormSuccessScreenNextAction({
 
   const CTAInfo = getUserActionCTAInfo(nextAction.actionType)
 
-  if (!CTAInfo) return null
-
   return (
     <div className="mt-8">
       <div className="mb-2 font-bold">Up next</div>

--- a/src/components/app/userActionFormSuccessScreen/userActionFormSuccessScreenNextAction.tsx
+++ b/src/components/app/userActionFormSuccessScreen/userActionFormSuccessScreenNextAction.tsx
@@ -6,7 +6,7 @@ import {
   UserActionRowCTAButton,
   UserActionRowCTAButtonSkeleton,
 } from '@/components/app/userActionRowCTA'
-import { USER_ACTION_ROW_CTA_INFO } from '@/components/app/userActionRowCTA/constants'
+import { getUserActionCTAInfo } from '@/components/app/userActionRowCTA/constants'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useLocale } from '@/hooks/useLocale'
 import {
@@ -39,6 +39,11 @@ export function UserActionFormSuccessScreenNextAction({
   if (!nextAction) {
     return null
   }
+
+  const CTAInfo = getUserActionCTAInfo(nextAction.actionType)
+
+  if (!CTAInfo) return null
+
   return (
     <div className="mt-8">
       <div className="mb-2 font-bold">Up next</div>
@@ -63,7 +68,7 @@ export function UserActionFormSuccessScreenNextAction({
         <UserActionRowCTA
           state="hidden"
           {...nextAction}
-          WrapperComponent={USER_ACTION_ROW_CTA_INFO[nextAction.actionType].WrapperComponent}
+          WrapperComponent={CTAInfo.WrapperComponent}
         />
       )}
     </div>

--- a/src/components/app/userActionRowCTA/constants.tsx
+++ b/src/components/app/userActionRowCTA/constants.tsx
@@ -110,5 +110,5 @@ export function getUserActionCTAInfo(actionType: ActiveClientUserActionType, cam
     return USER_ACTION_ROW_CTA_INFO_FROM_CAMPAIGN[campaign]
   }
 
-  return null
+  throw new Error(`No CTA info found for campaign: ${campaign}`)
 }

--- a/src/components/app/userActionRowCTA/constants.tsx
+++ b/src/components/app/userActionRowCTA/constants.tsx
@@ -16,6 +16,7 @@ import { useLocale } from '@/hooks/useLocale'
 import { ActiveClientUserActionType } from '@/utils/shared/activeUserAction'
 import { TOTAL_CRYPTO_ADVOCATE_COUNT_DISPLAY_NAME } from '@/utils/shared/constants'
 import { getIntlUrls } from '@/utils/shared/urls'
+import { USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP } from '@/utils/shared/userActionCampaigns'
 import { getYourPoliticianCategoryShortDisplayName } from '@/utils/shared/yourPoliticianCategory'
 
 export const USER_ACTION_ROW_CTA_INFO: Record<
@@ -93,4 +94,21 @@ export const USER_ACTION_ROW_CTA_INFO: Record<
     canBeTriggeredMultipleTimes: true,
     WrapperComponent: UserActionFormNFTMintDialog,
   },
+}
+
+export const USER_ACTION_ROW_CTA_INFO_FROM_CAMPAIGN: Record<
+  string,
+  Omit<UserActionRowCTAProps, 'state'>
+> = {} // This is a temp placeholder. This will be updated with the actual CNN campaign data
+
+export function getUserActionCTAInfo(actionType: ActiveClientUserActionType, campaign?: string) {
+  if (!campaign || campaign === USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP[actionType]) {
+    return USER_ACTION_ROW_CTA_INFO[actionType]
+  }
+
+  if (USER_ACTION_ROW_CTA_INFO_FROM_CAMPAIGN[campaign]) {
+    return USER_ACTION_ROW_CTA_INFO_FROM_CAMPAIGN[campaign]
+  }
+
+  return null
 }

--- a/src/components/app/userActionRowCTA/userActionRowCTAsAnimatedList.tsx
+++ b/src/components/app/userActionRowCTA/userActionRowCTAsAnimatedList.tsx
@@ -35,9 +35,6 @@ export function UserActionRowCTAsAnimatedList({
     <div className={className}>
       {filteredActions.map((item, index) => {
         const props = getUserActionCTAInfo(item.action, item.campaign)
-
-        if (!props) return null
-
         return (
           <motion.div
             // we apply individual pb to the elements instead of space-y-7 to ensure that there's no jank in the animation as the height transitions in

--- a/src/components/app/userActionRowCTA/userActionRowCTAsAnimatedListWithApi.tsx
+++ b/src/components/app/userActionRowCTA/userActionRowCTAsAnimatedListWithApi.tsx
@@ -12,13 +12,11 @@ export function UserActionRowCTAsAnimatedListWithApi({
   excludeUserActionTypes,
 }: UserActionRowCTAsListWithApiProps) {
   const { data } = useApiResponseForUserPerformedUserActionTypes()
-  const performedUserActions = data?.performedUserActionTypes.map(
-    performedAction => performedAction.actionType,
-  )
+
   return (
     <UserActionRowCTAsAnimatedList
       excludeUserActionTypes={excludeUserActionTypes}
-      performedUserActionTypes={performedUserActions}
+      performedUserActionTypesResponse={data}
     />
   )
 }

--- a/src/components/app/userActionRowCTA/userActionRowCTAsList.tsx
+++ b/src/components/app/userActionRowCTA/userActionRowCTAsList.tsx
@@ -29,9 +29,6 @@ export function UserActionRowCTAsList({
     <div className={cn('space-y-4', className)}>
       {filteredActions.map(({ action, campaign }) => {
         const props = getUserActionCTAInfo(action, campaign)
-
-        if (!props) return null
-
         return (
           <UserActionRowCTA
             key={`${action}-${campaign}`}

--- a/src/components/app/userActionRowCTA/userActionRowCTAsList.tsx
+++ b/src/components/app/userActionRowCTA/userActionRowCTAsList.tsx
@@ -4,9 +4,9 @@ import { useMemo } from 'react'
 import { UserActionType } from '@prisma/client'
 
 import { UserActionRowCTA } from '@/components/app/userActionRowCTA'
-import { USER_ACTION_ROW_CTA_INFO } from '@/components/app/userActionRowCTA/constants'
+import { getUserActionCTAInfo } from '@/components/app/userActionRowCTA/constants'
 import { cn } from '@/utils/web/cn'
-import { USER_ACTION_TYPE_CTA_PRIORITY_ORDER } from '@/utils/web/userActionUtils'
+import { USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN } from '@/utils/web/userActionUtils'
 
 export function UserActionRowCTAsList({
   performedUserActionTypes,
@@ -14,29 +14,35 @@ export function UserActionRowCTAsList({
   className,
 }: {
   className?: string
-  performedUserActionTypes?: UserActionType[]
+  performedUserActionTypes?: Array<{ actionType: UserActionType; campaignName: string }>
   excludeUserActionTypes?: UserActionType[]
 }) {
-  const filteredActions = useMemo(
-    () =>
-      !excludeUserActionTypes
-        ? USER_ACTION_TYPE_CTA_PRIORITY_ORDER
-        : USER_ACTION_TYPE_CTA_PRIORITY_ORDER.filter(
-            actionType => !excludeUserActionTypes.includes(actionType),
-          ),
-    [excludeUserActionTypes],
-  )
+  const filteredActions = useMemo(() => {
+    return !excludeUserActionTypes
+      ? USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN
+      : USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN.filter(
+          ({ action }) => !excludeUserActionTypes.includes(action),
+        )
+  }, [excludeUserActionTypes])
+
   return (
     <div className={cn('space-y-4', className)}>
-      {filteredActions.map(actionType => {
-        const props = USER_ACTION_ROW_CTA_INFO[actionType]
+      {filteredActions.map(({ action, campaign }) => {
+        const props = getUserActionCTAInfo(action, campaign)
+
+        if (!props) return null
+
         return (
           <UserActionRowCTA
-            key={actionType}
+            key={`${action}-${campaign}`}
             state={
               !performedUserActionTypes
                 ? 'unknown'
-                : performedUserActionTypes.includes(actionType)
+                : performedUserActionTypes.some(
+                      performedAction =>
+                        performedAction.actionType === action &&
+                        performedAction.campaignName === campaign,
+                    )
                   ? 'complete'
                   : 'incomplete'
             }

--- a/src/components/app/userActionRowCTA/userActionRowCTAsListWithApi.tsx
+++ b/src/components/app/userActionRowCTA/userActionRowCTAsListWithApi.tsx
@@ -12,13 +12,15 @@ export function UserActionRowCTAsListWithApi({
   excludeUserActionTypes,
 }: UserActionRowCTAsListWithApiProps) {
   const { data } = useApiResponseForUserPerformedUserActionTypes()
-  const performedUserActions = data?.performedUserActionTypes.map(
-    performedAction => performedAction.actionType,
-  )
+  const performedUserActionTypesResponse = data?.performedUserActionTypes?.map(item => ({
+    actionType: item.actionType,
+    campaignName: item.campaignName,
+  }))
+
   return (
     <UserActionRowCTAsList
       excludeUserActionTypes={excludeUserActionTypes}
-      performedUserActionTypes={performedUserActions}
+      performedUserActionTypes={performedUserActionTypesResponse}
     />
   )
 }

--- a/src/utils/shared/checkIfUserActionWithCampaignIsComplete.ts
+++ b/src/utils/shared/checkIfUserActionWithCampaignIsComplete.ts
@@ -1,0 +1,22 @@
+import { UserActionType } from '@prisma/client'
+
+import {
+  USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP,
+  USER_ACTIONS_WITH_ADDITIONAL_CAMPAIGN,
+  UserActionCampaigns,
+} from '@/utils/shared/userActionCampaigns'
+
+interface CheckIfUserActionWithCampaignIsCompleteProps {
+  action: UserActionType
+  campaign: UserActionCampaigns
+}
+
+export function checkIfUserActionWithCampaignIsComplete({
+  action,
+  campaign,
+}: CheckIfUserActionWithCampaignIsCompleteProps) {
+  const defaultCampaign = USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP[action]
+  const additionalCampaigns = USER_ACTIONS_WITH_ADDITIONAL_CAMPAIGN[action] ?? []
+  const combinedCampaigns = [...additionalCampaigns, defaultCampaign]
+  return combinedCampaigns.includes(campaign)
+}

--- a/src/utils/shared/userActionCampaigns.ts
+++ b/src/utils/shared/userActionCampaigns.ts
@@ -46,6 +46,17 @@ export enum UserActionTweetAtPersonCampaignName {
   '2024_05_22_PIZZA_DAY' = '2024_05_22_PIZZA_DAY',
 }
 
+export type UserActionCampaigns =
+  | UserActionEmailCampaignName
+  | UserActionCallCampaignName
+  | UserActionDonationCampaignName
+  | UserActionOptInCampaignName
+  | UserActionTweetCampaignName
+  | UserActionNftMintCampaignName
+  | UserActionVoterRegistrationCampaignName
+  | UserActionLiveEventCampaignName
+  | UserActionTweetAtPersonCampaignName
+
 export const USER_ACTION_TO_CAMPAIGN_NAME_MAP = {
   [UserActionType.EMAIL]: UserActionEmailCampaignName,
   [UserActionType.CALL]: UserActionCallCampaignName,
@@ -69,3 +80,11 @@ export const USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP = {
   [UserActionType.LIVE_EVENT]: UserActionLiveEventCampaignName['2024_03_04_LA'],
   [UserActionType.TWEET_AT_PERSON]: UserActionTweetAtPersonCampaignName.DEFAULT,
 } satisfies Record<ActiveClientUserActionWithCampaignType, string>
+
+type UserActionAdditionalCampaigns = {
+  [key in UserActionType]: string[]
+}
+
+export const USER_ACTIONS_WITH_ADDITIONAL_CAMPAIGN: Partial<UserActionAdditionalCampaigns> = {
+  [UserActionType.EMAIL]: [UserActionEmailCampaignName.DEFAULT], // This will be changed to CNN campaign later
+}

--- a/src/utils/web/userActionUtils.ts
+++ b/src/utils/web/userActionUtils.ts
@@ -1,6 +1,7 @@
 import { UserActionType } from '@prisma/client'
 
 import { ActiveClientUserActionType } from '@/utils/shared/activeUserAction'
+import { USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP } from '@/utils/shared/userActionCampaigns'
 
 export const USER_ACTION_TYPE_CTA_PRIORITY_ORDER: ReadonlyArray<ActiveClientUserActionType> = [
   UserActionType.EMAIL,
@@ -10,4 +11,25 @@ export const USER_ACTION_TYPE_CTA_PRIORITY_ORDER: ReadonlyArray<ActiveClientUser
   UserActionType.DONATION,
   UserActionType.TWEET,
   UserActionType.NFT_MINT,
+]
+
+// Remember to update USER_ACTION_ROW_CTA_INFO_FROM_CAMPAIGN so that the correct campaign CTA is displayed.
+// Failing to add the correct campaign will result in the corresponding CTA not being displayed.
+// Also remember to remove the campaign from USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN if it is not needed anymore.
+// Keeping a campaign here will result in an increase of the number of total actions in profile page.
+export const USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN: ReadonlyArray<{
+  action: ActiveClientUserActionType
+  campaign: string
+}> = [
+  { action: UserActionType.EMAIL, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.EMAIL },
+  { action: UserActionType.OPT_IN, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.OPT_IN },
+  // { action: UserActionType.EMAIL, campaign: UserActionEmailCampaignName.CNN_EMAIL }, this will be used in a next PR
+  {
+    action: UserActionType.VOTER_REGISTRATION,
+    campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.VOTER_REGISTRATION,
+  },
+  { action: UserActionType.CALL, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.CALL },
+  { action: UserActionType.DONATION, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.DONATION },
+  { action: UserActionType.TWEET, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.TWEET },
+  { action: UserActionType.NFT_MINT, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.NFT_MINT },
 ]


### PR DESCRIPTION
## What changed? Why?

This PR changes how we get the CTA cards and every logic related to that so that we will be able to have more than one CTA from the same action type but with different campaign. For example: we can have the CTA to email the congressperson and another CTA to email CNN about the presidential debate. The idea is to be able to show two or more CTAs with the same action type, but with different campaigns.

## Notes to reviewers

This PR is related to the task #959 and it will have a fast follow that will have everything related to creating the email CNN flow.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
