### PR TITLE
Email message not updating correctly between action modal re-renders

### DIFF
--- a/src/components/app/dtsiCongresspersonAssociatedWithFormAddress.tsx
+++ b/src/components/app/dtsiCongresspersonAssociatedWithFormAddress.tsx
@@ -21,16 +21,13 @@ import { zodGooglePlacesAutocompletePrediction } from '@/validation/fields/zodGo
 
 export function DTSICongresspersonAssociatedWithFormAddress({
   address,
-  onChangeDTSISlug,
-  currentDTSISlugValue,
+  onChangeAddress,
   politicianCategory,
   dtsiPeopleFromAddressResponse,
 }: {
   politicianCategory: YourPoliticianCategory
   address?: z.infer<typeof zodGooglePlacesAutocompletePrediction>
-  currentDTSISlugValue: string[]
-  onChangeDTSISlug: (args: {
-    dtsiSlugs: string[]
+  onChangeAddress: (args: {
     location?: {
       districtNumber: number
       stateCode: string
@@ -39,26 +36,13 @@ export function DTSICongresspersonAssociatedWithFormAddress({
   dtsiPeopleFromAddressResponse: ReturnType<typeof useGetDTSIPeopleFromAddress>
 }) {
   useEffect(() => {
-    if (
-      dtsiPeopleFromAddressResponse?.data &&
-      'dtsiPeople' in dtsiPeopleFromAddressResponse.data &&
-      dtsiPeopleFromAddressResponse?.data?.dtsiPeople?.some(
-        (person, index) => person.slug !== currentDTSISlugValue[index],
-      )
-    ) {
-      const { districtNumber, stateCode, dtsiPeople } = dtsiPeopleFromAddressResponse.data
-      const dtsiSlugs = dtsiPeople.map(person => person.slug)
-      onChangeDTSISlug({ dtsiSlugs, location: { districtNumber, stateCode } })
-    } else if (
-      currentDTSISlugValue.length &&
-      (!dtsiPeopleFromAddressResponse?.data ||
-        'notFoundReason' in dtsiPeopleFromAddressResponse.data)
-    ) {
-      onChangeDTSISlug({ dtsiSlugs: [] })
+    if (dtsiPeopleFromAddressResponse?.data && 'dtsiPeople' in dtsiPeopleFromAddressResponse.data) {
+      const { districtNumber, stateCode } = dtsiPeopleFromAddressResponse.data
+      onChangeAddress({ location: { districtNumber, stateCode } })
     }
-    // onChangeDTSISlug shouldnt be passed as a dependency
+    // onChangeAddress shouldnt be passed as a dependency
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentDTSISlugValue, dtsiPeopleFromAddressResponse?.data])
+  }, [dtsiPeopleFromAddressResponse?.data])
 
   const categoryDisplayName = getYourPoliticianCategoryDisplayName(politicianCategory)
   if (!address || dtsiPeopleFromAddressResponse?.isLoading) {

--- a/src/components/app/userActionFormEmailCongressperson/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/index.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useMemo, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { UserActionType } from '@prisma/client'
@@ -159,7 +159,7 @@ export function UserActionFormEmailCongressperson({
   const router = useRouter()
   const urls = useIntlUrls()
   const hasModifiedMessage = useRef(false)
-  const userDefaultValues = useMemo(() => getDefaultValues({ user, dtsiSlugs: [] }), [user])
+  const userDefaultValues = getDefaultValues({ user, dtsiSlugs: [] })
   const form = useForm<FormValues>({
     resolver: zodResolver(zodUserActionFormEmailCongresspersonFields),
     defaultValues: {
@@ -183,10 +183,11 @@ export function UserActionFormEmailCongressperson({
     addressField?.description,
   )
 
-  const dtsiPeople =
-    dtsiPeopleFromAddressResponse?.data && 'dtsiPeople' in dtsiPeopleFromAddressResponse.data
+  const dtsiPeople = useMemo(() => {
+    return dtsiPeopleFromAddressResponse?.data && 'dtsiPeople' in dtsiPeopleFromAddressResponse.data
       ? dtsiPeopleFromAddressResponse.data.dtsiPeople
       : []
+  }, [dtsiPeopleFromAddressResponse?.data])
 
   const { data: congresspersonBillVote } = useCongresspersonFIT21BillVote(dtsiPeople?.[0]?.slug, {
     onSuccess: data => {
@@ -221,6 +222,17 @@ export function UserActionFormEmailCongressperson({
       form.setFocus('firstName')
     }
   }, [form, isDesktop])
+
+  useEffect(() => {
+    if (dtsiPeople.length === 0) form.setValue('dtsiSlugs', [])
+
+    const currentSlugs = form.getValues('dtsiSlugs')
+
+    if (!dtsiPeople?.some((person, index) => person.slug !== currentSlugs[index])) return
+
+    const newDtsiSlugs = dtsiPeople.map(person => person.slug)
+    form.setValue('dtsiSlugs', newDtsiSlugs)
+  }, [dtsiPeople, form])
 
   return (
     <Form {...form}>
@@ -336,28 +348,16 @@ export function UserActionFormEmailCongressperson({
                 control={form.control}
                 name="address"
                 render={addressProps => (
-                  <FormField
-                    control={form.control}
-                    name="dtsiSlugs"
-                    render={dtsiSlugProps => (
-                      <div className="w-full">
-                        <DTSICongresspersonAssociatedWithFormAddress
-                          address={addressProps.field.value}
-                          currentDTSISlugValue={dtsiSlugProps.field.value}
-                          dtsiPeopleFromAddressResponse={dtsiPeopleFromAddressResponse}
-                          onChangeDTSISlug={({
-                            dtsiSlugs: newDtsiSlugs,
-                            location: newLocation,
-                          }) => {
-                            dtsiSlugProps.field.onChange(newDtsiSlugs)
-                            setLocation(newLocation)
-                          }}
-                          politicianCategory={politicianCategory}
-                        />
-                        {/* <FormErrorMessage /> */}
-                      </div>
-                    )}
-                  />
+                  <div className="w-full">
+                    <DTSICongresspersonAssociatedWithFormAddress
+                      address={addressProps.field.value}
+                      dtsiPeopleFromAddressResponse={dtsiPeopleFromAddressResponse}
+                      onChangeAddress={({ location: newLocation }) => {
+                        setLocation(newLocation)
+                      }}
+                      politicianCategory={politicianCategory}
+                    />
+                  </div>
                 )}
               />
               <FormField

--- a/src/components/app/userActionFormEmailCongressperson/skeleton.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/skeleton.tsx
@@ -62,9 +62,8 @@ export function UserActionFormEmailCongresspersonSkeleton({
             </div>
             <div className="w-full">
               <DTSICongresspersonAssociatedWithFormAddress
-                currentDTSISlugValue={[]}
                 dtsiPeopleFromAddressResponse={{} as ReturnType<typeof useGetDTSIPeopleFromAddress>}
-                onChangeDTSISlug={noop}
+                onChangeAddress={noop}
                 politicianCategory={politicianCategory}
               />
             </div>


### PR DESCRIPTION
closes #960 

## What changed? Why?

This PR fixes a bug where the dtsiSlugs field value was not being updated correctly when the users closes and then reopens the email flow modal.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
