### PR TITLE
Investigates if the cause property will show up in MixPanel

### DIFF
--- a/src/hooks/useHandlePageError.ts
+++ b/src/hooks/useHandlePageError.ts
@@ -28,34 +28,7 @@ export function useHandlePageError({
     Sentry.captureMessage(message, { fingerprint: [`fingerprint-${message}`] })
     trackClientAnalytic('Error Page Visible', {
       Category: humanReadablePageName,
-      ...(checkIfErrorIsCausedByOutlook(error, isFromNewsletter) && { Cause: 'Outlook' }),
+      ...(isFromNewsletter && { Cause: 'Outlook' }),
     })
   }, [domain, error, humanReadablePageName, isFromNewsletter])
-}
-
-// we are not sure what causes outlook users to trigger an anti-fingerprint error when accessing
-// SWC using the parsed safe link from outlook. This fix was added to track the error
-// You can find more information about this issue here: https://github.com/Stand-With-Crypto/swc-web/issues/848
-const OUTLOOK_BOT_ERROR_MESSAGE = 'Non-Error promise rejection captured with value: '
-
-function checkIfErrorIsCausedByOutlook(error: any, isFromNewsletter: boolean) {
-  if (!isFromNewsletter) return false
-
-  // The conditional logic below was inspired by this suggestion https://github.com/getsentry/sentry-javascript/issues/3440#issuecomment-828834651 as an attempt to try to catch the outlook error
-  if (
-    typeof error !== 'undefined' &&
-    typeof error?.exception !== 'undefined' &&
-    typeof error?.exception?.values !== 'undefined' &&
-    error?.exception?.values?.length === 1
-  ) {
-    const exception = error.exception.values[0]
-    if (
-      exception.type === 'UnhandledRejection' &&
-      exception.value?.includes(OUTLOOK_BOT_ERROR_MESSAGE)
-    ) {
-      return true
-    }
-  }
-
-  return false
 }


### PR DESCRIPTION
## What changed? Why?

The objective is to ensure that the Cause property will be added if the error occurs from newsletter. This will set all email related errors to have this Cause property, but the idea is to make sure that this property will be added when the condition is met. This way, we can guarantee that the problem is how we are trying to handle the error and not something related to MixPanel.

## Notes to reviewers

This PR code is temporary. We will try new ways to catch the bug on next PRs