### PR TITLE
Changes DTSI API Webhook revalidation logic

### DIFF
--- a/src/app/api/internal/dtsi-updated-slugs-webhook/route.ts
+++ b/src/app/api/internal/dtsi-updated-slugs-webhook/route.ts
@@ -1,14 +1,15 @@
 import { flatten } from 'lodash-es'
-import { revalidatePath } from 'next/cache'
+import { revalidatePath, revalidateTag } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 
 import { ORDERED_SUPPORTED_LOCALES } from '@/intl/locales'
 import { getLogger } from '@/utils/shared/logger'
 import { requiredOutsideLocalEnv } from '@/utils/shared/requiredEnv'
-import { apiUrls, getIntlUrls } from '@/utils/shared/urls'
+import { getIntlUrls } from '@/utils/shared/urls'
 
 const logger = getLogger('/api/internal/dtsi-updated-slugs-webhook')
+const DTSI_AllPeopleQueryTag = 'DTSI_AllPeopleQuery'
 
 const zodPayload = z.object({
   type: z.literal('people-with-updates'),
@@ -44,12 +45,15 @@ export async function POST(request: NextRequest) {
       return [
         urls.home(),
         urls.politiciansHomepage(),
-        apiUrls.dtsiAllPeople(),
         ...validatedFields.personSlugs.map(slug => urls.politicianDetails(slug)),
       ]
     }),
   )
   pathsToUpdate.forEach(page => revalidatePath(page))
   logger.info('updated pages', pathsToUpdate)
+
+  revalidateTag(DTSI_AllPeopleQueryTag)
+  logger.info('updated fetch tags', DTSI_AllPeopleQueryTag)
+
   return NextResponse.json({ pathsToUpdate })
 }

--- a/src/app/api/internal/dtsi-updated-slugs-webhook/route.ts
+++ b/src/app/api/internal/dtsi-updated-slugs-webhook/route.ts
@@ -3,13 +3,13 @@ import { revalidatePath, revalidateTag } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 
+import { DTSI_AllPeopleQueryTag } from '@/data/dtsi/queries/queryDTSIAllPeople'
 import { ORDERED_SUPPORTED_LOCALES } from '@/intl/locales'
 import { getLogger } from '@/utils/shared/logger'
 import { requiredOutsideLocalEnv } from '@/utils/shared/requiredEnv'
 import { getIntlUrls } from '@/utils/shared/urls'
 
 const logger = getLogger('/api/internal/dtsi-updated-slugs-webhook')
-const DTSI_AllPeopleQueryTag = 'DTSI_AllPeopleQuery'
 
 const zodPayload = z.object({
   type: z.literal('people-with-updates'),

--- a/src/data/dtsi/fetchDTSI.ts
+++ b/src/data/dtsi/fetchDTSI.ts
@@ -18,7 +18,11 @@ const DO_THEY_SUPPORT_IT_API_KEY = process.env.DO_THEY_SUPPORT_IT_API_KEY!
 export const IS_MOCKING_DTSI_DATA =
   IS_DEVELOPING_OFFLINE || (!DO_THEY_SUPPORT_IT_API_KEY && NEXT_PUBLIC_ENVIRONMENT === 'local')
 
-export const fetchDTSI = async <R, V = object>(query: string, variables?: V) => {
+export const fetchDTSI = async <R, V = object>(
+  query: string,
+  variables?: V,
+  nextTags?: string[],
+) => {
   if (IS_MOCKING_DTSI_DATA) {
     // because this file will import faker, we want to avoid loading it in our serverless environments
     return import('@/mocks/dtsi/queryDTSIMockSchema').then(x =>
@@ -53,6 +57,7 @@ export const fetchDTSI = async <R, V = object>(query: string, variables?: V) => 
             query,
             variables,
           }),
+          ...(nextTags && { next: { tags: nextTags } }),
         },
         {
           withScope: scope => {

--- a/src/data/dtsi/queries/queryDTSIAllPeople.ts
+++ b/src/data/dtsi/queries/queryDTSIAllPeople.ts
@@ -4,6 +4,8 @@ import { fetchDTSI } from '@/data/dtsi/fetchDTSI'
 import { fragmentDTSIPersonCard } from '@/data/dtsi/fragments/fragmentDTSIPersonCard'
 import { DTSI_AllPeopleQuery, DTSI_AllPeopleQueryVariables } from '@/data/dtsi/generated'
 
+export const DTSI_AllPeopleQueryTag = 'DTSI_AllPeopleQuery'
+
 export const query = /* GraphQL */ `
   query AllPeople($limit: Int!) {
     people(
@@ -35,7 +37,7 @@ export const queryDTSIAllPeople = async ({ limit }: { limit: number } = { limit:
     {
       limit,
     },
-    ['DTSI_AllPeopleQuery'],
+    [DTSI_AllPeopleQueryTag],
   )
   if (results.people.length === 1500) {
     Sentry.captureMessage(

--- a/src/data/dtsi/queries/queryDTSIAllPeople.ts
+++ b/src/data/dtsi/queries/queryDTSIAllPeople.ts
@@ -30,9 +30,13 @@ export const queryDTSIAllPeople = async ({ limit }: { limit: number } = { limit:
   if (limit > 1500) {
     throw new Error('We should not be requesting more than 1500 people at a time')
   }
-  const results = await fetchDTSI<DTSI_AllPeopleQuery, DTSI_AllPeopleQueryVariables>(query, {
-    limit,
-  })
+  const results = await fetchDTSI<DTSI_AllPeopleQuery, DTSI_AllPeopleQueryVariables>(
+    query,
+    {
+      limit,
+    },
+    ['DTSI_AllPeopleQuery'],
+  )
   if (results.people.length === 1500) {
     Sentry.captureMessage(
       'Previous limit set in queryDTSIAllPeople has been reached, we should consider re-evaluating our architecture',


### PR DESCRIPTION
closes #811 

## What changed? Why?

Didn't find any documentation on NextJS that supports the assumption that we can call revalidatePath for api routes. Because of that, all people DTSI request wasn't updated when the Webhook was called. I checked on NextJS 15 release doc to check if anything like this could be supported in the future, but I didn't find anything.

To be able to handle this cache situation, I decided to use a NextJS feature of revalidating tags for fetch requests. This way, I can revalidate the all people DTSI request based on a tag. It is very similar on how React Query tags work.

Documentation on [revalidateTag](https://nextjs.org/docs/app/api-reference/functions/revalidateTag)