### PR TITLE
Changes text align to left in address input field

### DIFF
--- a/src/components/ui/googlePlacesSelect/index.tsx
+++ b/src/components/ui/googlePlacesSelect/index.tsx
@@ -61,7 +61,7 @@ export const GooglePlacesSelect = React.forwardRef<
           className={cn(
             'text-muted-foreground',
             triggerProps.value && 'text-gray-500',
-            'h-auto cursor-pointer whitespace-normal',
+            'h-auto cursor-pointer whitespace-normal text-left',
             triggerProps.open && 'outline-none ring-2 ring-ring ring-offset-2',
             className,
           )}


### PR DESCRIPTION
closes #973 

## What changed? Why?

Changes text align for google places api input to be left aligned.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
