### PR TITLE
Removes address requirement from user action email model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -311,8 +311,8 @@ model UserActionEmail {
   senderEmail               String                     @map("sender_email")
   firstName                 String                     @map("first_name")
   lastName                  String                     @map("last_name")
-  address                   Address                    @relation(fields: [addressId], references: [id])
-  addressId                 String                     @map("address_id")
+  address                   Address?                   @relation(fields: [addressId], references: [id])
+  addressId                 String?                    @map("address_id")
   userActionEmailRecipients UserActionEmailRecipient[]
 
   @@index([id])

--- a/src/clientModels/clientUserAction/sensitiveDataClientUserAction.ts
+++ b/src/clientModels/clientUserAction/sensitiveDataClientUserAction.ts
@@ -24,7 +24,7 @@ If this ever changes, we may need to export the SensitiveDataClientUserActionEma
 type SensitiveDataClientUserActionDatabaseQuery = UserAction & {
   userActionEmail:
     | (UserActionEmail & {
-        address: Address
+        address: Address | null
         userActionEmailRecipients: UserActionEmailRecipient[]
       })
     | null
@@ -172,7 +172,7 @@ export const getSensitiveDataClientUserAction = ({
           senderEmail,
           firstName,
           lastName,
-          address: getClientAddress(address),
+          address: address ? getClientAddress(address) : null,
           userActionEmailRecipients: userActionEmailRecipients.map(x => ({
             id: x.id,
           })),


### PR DESCRIPTION
## What changed? Why?

This PR updates the prisma schema so that address is not required in UserActionEmail model.

## PlanetScale deploy request

PlaneScale deploy request: https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/24

## Notes to reviewers

Related to #980 

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
