### PR TITLE
Changes google places select results to be more strict in US

### DIFF
--- a/src/components/app/userActionFormEmailCongressperson/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/index.tsx
@@ -336,6 +336,7 @@ export function UserActionFormEmailCongressperson({
                           {...field}
                           onChange={field.onChange}
                           placeholder="Your full address"
+                          shouldLimitUSAddresses
                           value={field.value}
                         />
                       </FormControl>

--- a/src/components/ui/googlePlacesSelect/index.tsx
+++ b/src/components/ui/googlePlacesSelect/index.tsx
@@ -55,15 +55,7 @@ export const GooglePlacesSelect = React.forwardRef<
   // Capitol Canary won't be able to successfully find the related congressperson based on the address provided
   // That's why we need to filter out the route type for US addresses on required action flows
   const usePlacesAutoCompleteResult = shouldLimitUSAddresses
-    ? data
-        ?.map(place =>
-          !place.description.includes('USA')
-            ? place
-            : !place.types.includes('route')
-              ? place
-              : null,
-        )
-        .filter(Boolean)
+    ? data?.filter(place => !place.description.includes('USA') && !place.types.includes('route'))
     : data
 
   const scriptStatus = useGoogleMapsScript()

--- a/src/components/ui/googlePlacesSelect/index.tsx
+++ b/src/components/ui/googlePlacesSelect/index.tsx
@@ -54,7 +54,7 @@ export const GooglePlacesSelect = React.forwardRef<
   // But for US, if we allow users to use an address with the route type,
   // Capitol Canary won't be able to successfully find the related congressperson based on the address provided
   // That's why we need to filter out the route type for US addresses on required action flows
-  const usePlacesAutoCompleteResult = shouldLimitUSAddresses
+  const placesAutoCompleteResult = shouldLimitUSAddresses
     ? data?.filter(place => !place.description.includes('USA') || !place.types.includes('route'))
     : data
 
@@ -95,7 +95,7 @@ export const GooglePlacesSelect = React.forwardRef<
       onChange={propsOnChange}
       onChangeInputValue={setValue}
       open={open}
-      options={usePlacesAutoCompleteResult}
+      options={placesAutoCompleteResult}
       placeholder="Type your address..."
       setOpen={setOpen}
       value={propsValue}

--- a/src/components/ui/googlePlacesSelect/index.tsx
+++ b/src/components/ui/googlePlacesSelect/index.tsx
@@ -15,6 +15,11 @@ export type GooglePlacesSelectProps = {
   showIcon?: boolean
   loading?: boolean
   disablePreventMobileKeyboardOffset?: boolean
+  /**
+   * If true, the component will filter out the route type for US addresses. This will prevent
+   * vague addresses from being selected in the US.
+   */
+  shouldLimitUSAddresses?: boolean
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'type'>
 
 export const GooglePlacesSelect = React.forwardRef<
@@ -28,6 +33,7 @@ export const GooglePlacesSelect = React.forwardRef<
     showIcon = true,
     loading,
     disablePreventMobileKeyboardOffset,
+    shouldLimitUSAddresses,
     ...inputProps
   } = props
   const [open, setOpen] = React.useState(false)
@@ -44,6 +50,22 @@ export const GooglePlacesSelect = React.forwardRef<
       types: ['street_address', 'premise', 'postal_code', 'subpremise', 'route'],
     },
   })
+  // For some countries, the route type is required to show addresses options correctly
+  // But for US, if we allow users to use an address with the route type,
+  // Capitol Canary won't be able to successfully find the related congressperson based on the address provided
+  // That's why we need to filter out the route type for US addresses on required action flows
+  const usePlacesAutoCompleteResult = shouldLimitUSAddresses
+    ? data
+        ?.map(place =>
+          !place.description.includes('USA')
+            ? place
+            : !place.types.includes('route')
+              ? place
+              : null,
+        )
+        .filter(Boolean)
+    : data
+
   const scriptStatus = useGoogleMapsScript()
 
   useEffect(() => {
@@ -81,7 +103,7 @@ export const GooglePlacesSelect = React.forwardRef<
       onChange={propsOnChange}
       onChangeInputValue={setValue}
       open={open}
-      options={data}
+      options={usePlacesAutoCompleteResult}
       placeholder="Type your address..."
       setOpen={setOpen}
       value={propsValue}

--- a/src/components/ui/googlePlacesSelect/index.tsx
+++ b/src/components/ui/googlePlacesSelect/index.tsx
@@ -55,7 +55,7 @@ export const GooglePlacesSelect = React.forwardRef<
   // Capitol Canary won't be able to successfully find the related congressperson based on the address provided
   // That's why we need to filter out the route type for US addresses on required action flows
   const usePlacesAutoCompleteResult = shouldLimitUSAddresses
-    ? data?.filter(place => !place.description.includes('USA') && !place.types.includes('route'))
+    ? data?.filter(place => !place.description.includes('USA') || !place.types.includes('route'))
     : data
 
   const scriptStatus = useGoogleMapsScript()


### PR DESCRIPTION
closes #947 

## What changed? Why?

This PR changes the google places api options based on the search results to prevent vague addresses to be used on email flow that would case Capitol Canary to fail when trying to find the related congressperson with the provided address.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
