### PR TITLE
feat: add donations breakdown

### DIFF
--- a/src/components/app/pageDonate/sumDonationsCounter.tsx
+++ b/src/components/app/pageDonate/sumDonationsCounter.tsx
@@ -38,7 +38,10 @@ function useLiveSumDonations({ locale, initialData }: SumDonationsCounterProps) 
         .then(data => data as SumDonations),
     {
       refreshInterval: 5 * 1000,
-      fallbackData: { amountUsd: roundDownNumberToAnimateIn(initialData.amountUsd, 10000) },
+      fallbackData: {
+        amountUsd: roundDownNumberToAnimateIn(initialData.amountUsd, 10000),
+        fairshakeAmountUsd: roundDownNumberToAnimateIn(initialData.fairshakeAmountUsd, 10000),
+      },
     },
   )
 }

--- a/src/data/aggregations/getSumDonations.ts
+++ b/src/data/aggregations/getSumDonations.ts
@@ -4,8 +4,10 @@ import { sum } from 'lodash-es'
 
 import { prismaClient } from '@/utils/server/prismaClient'
 
+const FAIRSHAKE_DONATIONS_AMOUNT_USD = 85_718_453
+
 const MANUALLY_TRACKED_DONATIONS = [
-  85_718_453, // Fairshake donations
+  FAIRSHAKE_DONATIONS_AMOUNT_USD,
   1_000_000, // 2024-05-13 MoonPay donation
 ]
 
@@ -18,6 +20,7 @@ export const getSumDonations = async () => {
   return {
     amountUsd:
       (amountUsd._sum.totalDonationAmountUsd?.toNumber() || 0) + sum(MANUALLY_TRACKED_DONATIONS),
+    fairshakeAmountUsd: FAIRSHAKE_DONATIONS_AMOUNT_USD,
   }
 }
 


### PR DESCRIPTION
closes #946 

## What changed? Why?

This adds the donations breakdown to SwC and FairShake
<img width="464" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/155585835/67c542b9-a617-45bd-b606-2ad4cec34ee0">

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
