### PR TITLE
Changes caching logic from route to fetch req in all dtsi api route

### DIFF
--- a/src/app/api/public/dtsi/all-people/route.ts
+++ b/src/app/api/public/dtsi/all-people/route.ts
@@ -3,10 +3,9 @@ import 'server-only'
 import { NextResponse } from 'next/server'
 
 import { queryDTSIAllPeople } from '@/data/dtsi/queries/queryDTSIAllPeople'
-import { SECONDS_DURATION } from '@/utils/shared/seconds'
 
 export const dynamic = 'error'
-export const revalidate = SECONDS_DURATION['10_MINUTES']
+export const revalidate = 0
 
 export async function GET() {
   const data = await queryDTSIAllPeople()

--- a/src/data/dtsi/fetchDTSI.ts
+++ b/src/data/dtsi/fetchDTSI.ts
@@ -57,8 +57,10 @@ export const fetchDTSI = async <R, V = object>(
             query,
             variables,
           }),
-          ...(nextConfig?.nextTags && { next: { tags: nextConfig?.nextTags } }),
-          ...(nextConfig?.nextRevalidate && { next: { revalidate: nextConfig?.nextRevalidate } }),
+          next: {
+            ...(nextConfig?.nextTags && { tags: nextConfig?.nextTags }),
+            ...(nextConfig?.nextRevalidate && { revalidate: nextConfig?.nextRevalidate }),
+          },
         },
         {
           withScope: scope => {

--- a/src/data/dtsi/fetchDTSI.ts
+++ b/src/data/dtsi/fetchDTSI.ts
@@ -21,7 +21,7 @@ export const IS_MOCKING_DTSI_DATA =
 export const fetchDTSI = async <R, V = object>(
   query: string,
   variables?: V,
-  nextTags?: string[],
+  nextConfig?: { nextTags?: string[]; nextRevalidate?: number },
 ) => {
   if (IS_MOCKING_DTSI_DATA) {
     // because this file will import faker, we want to avoid loading it in our serverless environments
@@ -57,7 +57,8 @@ export const fetchDTSI = async <R, V = object>(
             query,
             variables,
           }),
-          ...(nextTags && { next: { tags: nextTags } }),
+          ...(nextConfig?.nextTags && { next: { tags: nextConfig?.nextTags } }),
+          ...(nextConfig?.nextRevalidate && { next: { revalidate: nextConfig?.nextRevalidate } }),
         },
         {
           withScope: scope => {

--- a/src/data/dtsi/queries/queryDTSIAllPeople.ts
+++ b/src/data/dtsi/queries/queryDTSIAllPeople.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/nextjs'
 import { fetchDTSI } from '@/data/dtsi/fetchDTSI'
 import { fragmentDTSIPersonCard } from '@/data/dtsi/fragments/fragmentDTSIPersonCard'
 import { DTSI_AllPeopleQuery, DTSI_AllPeopleQueryVariables } from '@/data/dtsi/generated'
+import { SECONDS_DURATION } from '@/utils/shared/seconds'
 
 export const DTSI_AllPeopleQueryTag = 'DTSI_AllPeopleQuery'
 
@@ -37,7 +38,10 @@ export const queryDTSIAllPeople = async ({ limit }: { limit: number } = { limit:
     {
       limit,
     },
-    [DTSI_AllPeopleQueryTag],
+    {
+      nextTags: [DTSI_AllPeopleQueryTag],
+      nextRevalidate: SECONDS_DURATION['10_MINUTES'],
+    },
   )
   if (results.people.length === 1500) {
     Sentry.captureMessage(


### PR DESCRIPTION
## What changed? Why?

This PR changes how we are handling cache in all dtsi route handler.

I was investigating on how caching was handle on the api route: /public/dtsi/all-people and I saw that we are defining the route cache as 10 minutes. This would prevent the revalidateTag logic from working because even though the fetch request was being invalidated, the route would keep returning the cache result for 10 minutes.

As we are able to cache the fetch request based on this doc: https://nextjs.org/docs/app/api-reference/functions/fetch, I decided to change the caching for the api route to be completely dynamic and always hitting the fetch function, but as we moved the 10 minutes revalidate prop into the fetch request, it should keep the same "caching" behavior as the route is just going to call the fetch req that is going to be cached and revalidated every 10 minutes.

The idea behind this change is that we'll be able to use revalidateTag to revalidate the fetch request and also keep the revalidation every 10 minutes as well, maintaining the previous behavior and allowing for on-demand fetch revalidation.

## How has it been tested?

I created a new next js app using the app router to test if the fetch cache would work as expected.

Created the following api route to load the data(this is called inside that client home page):
<img width="689" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/25483313/8e2c821f-ceef-485f-957c-f9b63d001d30">

this route calls a helper function to fetch the api response. This was not required, but I wanted to make it as similar to how it is happening in SWC as possible:
<img width="609" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/25483313/2fc14a55-ec18-4a11-9e2c-b2f1eabe6a85">

The above function sets the next.tags prop and also sets the revalidate as 10 minutes( 60 sec * 10)

This function calls this api route to get random data, but with the timestamp on when it was requested:
<img width="481" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/25483313/34d7cd40-35a2-4140-9a0c-c2464aa49abc">

I also created a new api route to revalidate the fetch request to test the on-demand revalidation:
<img width="485" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/25483313/03de4527-9f10-43c8-b021-a36c6e8b30ca">


---

I built the app and opened the same page on two different browsers(chrome and brave), and the response was the same for both of them, even though I accessed the page after a few minutes on brave browser:

<img width="1679" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/25483313/5efb692e-3c39-40de-94d2-d460f510cbe4">

I'll keep getting the same response for both no matter how many reloads I trigger on each browser until 10 minutes is passed.

<img width="763" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/25483313/5bd05d6b-8b89-4e32-a7a9-eacec17e83fd">

But if I trigger the revalidateTag, the response is going to be updated for all users on page reload:
<img width="541" alt="image" src="https://github.com/Stand-With-Crypto/swc-web/assets/25483313/5a47011c-965f-49b6-abaa-6b2c5176a814">


