### PR TITLE
Showcase previous completed campaigns in profile page

### DIFF
--- a/src/components/app/pageUserProfile/index.tsx
+++ b/src/components/app/pageUserProfile/index.tsx
@@ -5,6 +5,7 @@ import { redirect, RedirectType } from 'next/navigation'
 import { LoginDialogWrapper } from '@/components/app/authentication/loginDialogWrapper'
 import { NFTDisplay } from '@/components/app/nftHub/nftDisplay'
 import { PageUserProfileUser } from '@/components/app/pageUserProfile/getAuthenticatedData'
+import { PreviousCampaignsList } from '@/components/app/pageUserProfile/previousCampaignsList'
 import { UpdateUserProfileFormDialog } from '@/components/app/updateUserProfileForm/dialog'
 import { OPEN_UPDATE_USER_PROFILE_FORM_QUERY_PARAM_KEY } from '@/components/app/updateUserProfileForm/queryParamConfig'
 import { UserActionRowCTAsList } from '@/components/app/userActionRowCTA/userActionRowCTAsList'
@@ -21,6 +22,10 @@ import { getSearchParam, setCallbackQueryString } from '@/utils/server/searchPar
 import { SupportedFiatCurrencyCodes } from '@/utils/shared/currency'
 import { getUserActionsProgress } from '@/utils/shared/getUserActionsProgress'
 import { USER_ACTION_DEEPLINK_MAP } from '@/utils/shared/urlsDeeplinkUserActions'
+import {
+  USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP,
+  USER_ACTIONS_WITH_ADDITIONAL_CAMPAIGN,
+} from '@/utils/shared/userActionCampaigns'
 import { hasCompleteUserProfile } from '@/utils/web/hasCompleteUserProfile'
 import { getSensitiveDataUserDisplayName } from '@/utils/web/userUtils'
 
@@ -61,6 +66,13 @@ export function PageUserProfile({ params, searchParams, user }: PageUserProfile)
       userHasEmbeddedWallet: user.hasEmbeddedWallet,
       performedUserActionTypes,
     })
+
+  const userActionsFromPreviousCampaigns =
+    userActions.filter(
+      action =>
+        action.campaignName !== USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP[action.actionType] &&
+        !USER_ACTIONS_WITH_ADDITIONAL_CAMPAIGN[action.actionType]?.includes(action.campaignName),
+    ) ?? []
 
   return (
     <div className="standard-spacing-from-navbar container space-y-10 lg:space-y-16">
@@ -148,7 +160,8 @@ export function PageUserProfile({ params, searchParams, user }: PageUserProfile)
           Your advocacy progress
         </PageTitle>
         <PageSubTitle className="mb-5">
-          You've completed {numActionsCompleted} out of {numActionsAvailable} actions. Keep going!
+          You've completed {numActionsCompleted} out of {numActionsAvailable} active campaigns. Keep
+          going!
         </PageSubTitle>
         <div className="mx-auto mb-10 max-w-xl">
           <Progress value={progressValue} />
@@ -158,6 +171,20 @@ export function PageUserProfile({ params, searchParams, user }: PageUserProfile)
           performedUserActionTypes={performedUserActionTypes}
         />
       </section>
+      {userActionsFromPreviousCampaigns.length > 0 && (
+        <section>
+          <PageTitle className="mb-4" size="sm">
+            Previous campaigns
+          </PageTitle>
+          <PageSubTitle className="mb-5">
+            Nice work. You completed {userActionsFromPreviousCampaigns.length} previous{' '}
+            {userActionsFromPreviousCampaigns.length > 1 ? 'campaigns' : 'campaign'}.
+          </PageSubTitle>
+
+          <PreviousCampaignsList userActions={userActionsFromPreviousCampaigns} />
+        </section>
+      )}
+
       <section>
         <PageTitle className="mb-4" size="sm">
           Your NFTs

--- a/src/components/app/pageUserProfile/previousCampaignsList.tsx
+++ b/src/components/app/pageUserProfile/previousCampaignsList.tsx
@@ -1,0 +1,83 @@
+import { UserActionType } from '@prisma/client'
+
+import { SensitiveDataClientUserAction } from '@/clientModels/clientUserAction/sensitiveDataClientUserAction'
+import { NextImage } from '@/components/ui/image'
+import {
+  UserActionCallCampaignName,
+  UserActionCampaigns,
+  UserActionEmailCampaignName,
+  UserActionTweetAtPersonCampaignName,
+} from '@/utils/shared/userActionCampaigns'
+
+type DisabledUserActionCampaigns = {
+  [K in keyof UserActionCampaigns]?: {
+    [Key in UserActionCampaigns[K]]?: {
+      title: string
+      subtitle: string
+    }
+  }
+}
+
+const DISABLED_USER_ACTION_CAMPAIGNS: DisabledUserActionCampaigns = {
+  [UserActionType.EMAIL]: {
+    [UserActionEmailCampaignName.FIT21_2024_04]: {
+      title: 'FIT21 Email Campaign',
+      subtitle: 'You emailed your representative and asked them to vote YES on FIT21.',
+    },
+    [UserActionEmailCampaignName.CNN_PRESIDENTIAL_DEBATE_2024]: {
+      title: 'CNN Presidential Debate 2024',
+      subtitle: "You emailed CNN and asked them to include the candidates' stance on crypto.",
+    },
+  },
+  [UserActionType.TWEET_AT_PERSON]: {
+    [UserActionTweetAtPersonCampaignName['2024_05_22_PIZZA_DAY']]: {
+      title: 'Pizza Day 2024',
+      subtitle: 'You tweeted your representative for pizza day.',
+    },
+  },
+  [UserActionType.CALL]: {
+    [UserActionCallCampaignName.FIT21_2024_04]: {
+      title: 'FIT21 Call Campaign',
+      subtitle: 'You called your representative and asked them to vote YES on FIT21.',
+    },
+  },
+}
+
+interface PreviousCampaignsListProps {
+  userActions: SensitiveDataClientUserAction[]
+}
+
+export function PreviousCampaignsList({ userActions }: PreviousCampaignsListProps) {
+  return (
+    <div>
+      {userActions.map(action => (
+        <CampaignCard action={action} key={action.id} />
+      ))}
+    </div>
+  )
+}
+
+function CampaignCard({ action }: { action: SensitiveDataClientUserAction }) {
+  const campaignsFromActionType = DISABLED_USER_ACTION_CAMPAIGNS[action.actionType]
+
+  if (!campaignsFromActionType) return null
+
+  const { title, subtitle } =
+    campaignsFromActionType[action.campaignName as keyof typeof campaignsFromActionType] || {}
+
+  if (!title || !subtitle) {
+    throw new Error(
+      `No title or subtitle found for campaign: ${action.campaignName}, in DISABLED_USER_ACTION_CAMPAIGNS`,
+    )
+  }
+
+  return (
+    <div className="flex w-full items-center gap-6 rounded-3xl bg-secondary p-4 text-left lg:px-8 lg:py-11">
+      <NextImage alt={'Action complete'} height={24} src={'/misc/checkedCircle.svg'} width={24} />
+      <div className="flex flex-col">
+        <div className="mb-1 text-base font-bold lg:text-2xl">{title}</div>
+        <div className="text-sm text-gray-500 lg:text-xl">{subtitle}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/utils/web/userActionUtils.ts
+++ b/src/utils/web/userActionUtils.ts
@@ -18,7 +18,7 @@ export const USER_ACTION_TYPE_CTA_PRIORITY_ORDER: ReadonlyArray<ActiveClientUser
 ]
 
 // Remember to update USER_ACTION_ROW_CTA_INFO_FROM_CAMPAIGN so that the correct campaign CTA is displayed.
-// Failing to add the correct campaign will result in the corresponding CTA not being displayed.
+// Failing to add the correct campaign will result in error.
 // Also remember to remove the campaign from USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN if it is not needed anymore.
 // Keeping a campaign here will result in an increase of the number of total actions in profile page.
 export const USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN: ReadonlyArray<{


### PR DESCRIPTION
closes #1000 

## What changed? Why?

This PR adds a new section to the profile page to showcase the previously completed campaigns

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
