### PR TITLE
Deal with error spikes caused by SWC email campaigns

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -115,8 +115,7 @@ Sentry.init({
 
     // force group error names
     try {
-      const error = hint.originalException as Error
-      const errorMessage = error?.message
+      const errorMessage = getErrorMessage(hint.originalException)
       console.log('error message to match against COMMON_ERROR_MESSAGES_TO_GROUP', errorMessage)
       if (errorMessage) {
         COMMON_ERROR_MESSAGES_TO_GROUP.forEach(message => {
@@ -135,3 +134,15 @@ Sentry.init({
     return event
   },
 })
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (error instanceof PromiseRejectionEvent) {
+    return JSON.stringify(error.reason)
+  }
+
+  return JSON.stringify(error)
+}

--- a/src/hooks/useHandlePageError.ts
+++ b/src/hooks/useHandlePageError.ts
@@ -4,6 +4,24 @@ import * as Sentry from '@sentry/nextjs'
 import { logger } from '@/utils/shared/logger'
 import { trackClientAnalytic } from '@/utils/web/clientAnalytics'
 
+const CHUNK_FAILED_MESSAGE = /Loading chunk [\d]+ failed/
+
+function getErrorMessage({
+  isIntentionalError,
+  humanReadablePageName,
+}: {
+  isIntentionalError: boolean
+  humanReadablePageName: string
+}) {
+  let message = `${humanReadablePageName} Error Page Displayed`
+
+  if (isIntentionalError) {
+    message = `Testing Sentry Triggered - ${message}`
+  }
+
+  return message
+}
+
 export function useHandlePageError({
   domain,
   humanReadablePageName,
@@ -16,27 +34,26 @@ export function useHandlePageError({
   useEffect(() => {
     const isIntentionalError = window.location.pathname.includes('debug-sentry')
     const errorSentryId = Sentry.captureException(error, { tags: { domain } })
+    const isChunkLoadError = CHUNK_FAILED_MESSAGE.test(error.message)
 
-    const message = isIntentionalError
-      ? `Testing Sentry Triggered ${humanReadablePageName} Error Page`
-      : `${humanReadablePageName} Error Page Displayed`
+    const message = getErrorMessage({ isIntentionalError, humanReadablePageName })
+
     const messageSentryId = Sentry.captureMessage(message, {
       fingerprint: [`fingerprint-${message}`],
       extra: {
         windowSearchParams: window.location.search,
         isIntentionalError,
+        isChunkLoadError,
         domain,
         errorSentryId,
         errorDigest: error?.digest,
       },
     })
-    logger.info(
-      `${humanReadablePageName} Error Page Displayed - SentryId: ${messageSentryId} - `,
-      error,
-    )
+    logger.info(`${message} - SentryId: ${messageSentryId}`, error)
     trackClientAnalytic('Error Page Visible', {
       Category: humanReadablePageName,
       sentryId: messageSentryId,
+      Cause: isChunkLoadError ? 'ChunkLoadError' : undefined,
     })
   }, [domain, error, humanReadablePageName])
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -63,13 +63,4 @@ export function register() {
       },
     })
   }
-
-  process.on('unhandledRejection', (reason: string, promise: Promise<any>) => {
-    Sentry.captureException('Unhandled Rejection', {
-      extra: {
-        promise,
-        reason,
-      },
-    })
-  })
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -63,4 +63,13 @@ export function register() {
       },
     })
   }
+
+  process.on('unhandledRejection', (reason: string, promise: Promise<any>) => {
+    Sentry.captureException('Unhandled Rejection', {
+      extra: {
+        promise,
+        reason,
+      },
+    })
+  })
 }


### PR DESCRIPTION
closes #848 

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

- Correctly handle sentry events other than Errors
- Add filtering paramenter do global error page events caused by `ChunkLoadError`

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
