### PR TITLE
Changes all dtsi api route caching logic

### DIFF
--- a/src/app/api/public/dtsi/all-people/route.ts
+++ b/src/app/api/public/dtsi/all-people/route.ts
@@ -3,10 +3,9 @@ import 'server-only'
 import { NextResponse } from 'next/server'
 
 import { queryDTSIAllPeople } from '@/data/dtsi/queries/queryDTSIAllPeople'
-import { SECONDS_DURATION } from '@/utils/shared/seconds'
 
 export const dynamic = 'error'
-export const revalidate = SECONDS_DURATION['10_MINUTES']
+export const revalidate = 0
 
 export async function GET() {
   const data = await queryDTSIAllPeople()

--- a/src/data/dtsi/fetchDTSI.ts
+++ b/src/data/dtsi/fetchDTSI.ts
@@ -21,7 +21,7 @@ export const IS_MOCKING_DTSI_DATA =
 export const fetchDTSI = async <R, V = object>(
   query: string,
   variables?: V,
-  nextTags?: string[],
+  nextConfig?: { nextTags?: string[]; nextRevalidate?: number },
 ) => {
   if (IS_MOCKING_DTSI_DATA) {
     // because this file will import faker, we want to avoid loading it in our serverless environments
@@ -57,7 +57,10 @@ export const fetchDTSI = async <R, V = object>(
             query,
             variables,
           }),
-          ...(nextTags && { next: { tags: nextTags } }),
+          next: {
+            ...(nextConfig?.nextTags && { tags: nextConfig?.nextTags }),
+            ...(nextConfig?.nextRevalidate && { revalidate: nextConfig?.nextRevalidate }),
+          },
         },
         {
           withScope: scope => {

--- a/src/data/dtsi/queries/queryDTSIAllPeople.ts
+++ b/src/data/dtsi/queries/queryDTSIAllPeople.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/nextjs'
 import { fetchDTSI } from '@/data/dtsi/fetchDTSI'
 import { fragmentDTSIPersonCard } from '@/data/dtsi/fragments/fragmentDTSIPersonCard'
 import { DTSI_AllPeopleQuery, DTSI_AllPeopleQueryVariables } from '@/data/dtsi/generated'
+import { SECONDS_DURATION } from '@/utils/shared/seconds'
 
 export const DTSI_AllPeopleQueryTag = 'DTSI_AllPeopleQuery'
 
@@ -37,7 +38,10 @@ export const queryDTSIAllPeople = async ({ limit }: { limit: number } = { limit:
     {
       limit,
     },
-    [DTSI_AllPeopleQueryTag],
+    {
+      nextTags: [DTSI_AllPeopleQueryTag],
+      nextRevalidate: SECONDS_DURATION['10_MINUTES'],
+    },
   )
   if (results.people.length === 1500) {
     Sentry.captureMessage(


### PR DESCRIPTION
## What changed? Why?

This PR restores the last attempt on caching the all dtsi api route logic

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
