### PR TITLE
Fix: Leaderboard page build performance

### DIFF
--- a/src/app/[locale]/community/leaderboard/[[...page]]/page.tsx
+++ b/src/app/[locale]/community/leaderboard/[[...page]]/page.tsx
@@ -60,6 +60,7 @@ export default async function CommunityLeaderboardPage({ params }: Props) {
   const sumDonationsByUser = await getSumDonationsByUser({
     limit: itemsPerPage,
     offset,
+    pageNum,
   })
 
   const dataProps: PageLeaderboardInferredProps = {

--- a/src/clientModels/clientUser/clientLeaderboardUser.ts
+++ b/src/clientModels/clientUser/clientLeaderboardUser.ts
@@ -17,7 +17,10 @@ export type ClientLeaderboardUser = ClientModel<
     }
 >
 
-export type GetClientProps = User & {
+export type GetClientProps = Pick<
+  User,
+  'firstName' | 'lastName' | 'id' | 'informationVisibility'
+> & {
   primaryUserCryptoAddress: null | UserCryptoAddress
 } & Pick<ClientUser, 'manuallySetInformation'>
 

--- a/src/components/app/pageLeaderboard/constants.tsx
+++ b/src/components/app/pageLeaderboard/constants.tsx
@@ -14,9 +14,8 @@ export const COMMUNITY_PAGINATION_DATA: Record<
     totalPregeneratedPages: maybeIgnorePreGeneration(10),
   },
   [RecentActivityAndLeaderboardTabs.LEADERBOARD]: {
-    // TODO enable more pages after we debug why builds are so sluggish when generating leaderboard content
-    totalPages: 1,
-    itemsPerPage: 400,
-    totalPregeneratedPages: maybeIgnorePreGeneration(1),
+    totalPages: 4,
+    itemsPerPage: 100,
+    totalPregeneratedPages: maybeIgnorePreGeneration(4),
   },
 }

--- a/src/data/aggregations/getSumDonationsByUser.ts
+++ b/src/data/aggregations/getSumDonationsByUser.ts
@@ -1,7 +1,6 @@
 import 'server-only'
 
-import { DataCreationMethod, UserInformationVisibility } from '@prisma/client'
-import { Decimal } from '@prisma/client/runtime/library'
+import { UserInformationVisibility } from '@prisma/client'
 import { compact, keyBy } from 'lodash-es'
 
 import { getClientLeaderboardUser } from '@/clientModels/clientUser/clientLeaderboardUser'
@@ -15,31 +14,8 @@ export type SumDonationsByUserConfig = {
   pageNum: number
 }
 
-type GetSumDonationByUserQueryResult = Array<{
-  id: string
-  totalDonationAmountUsd: Decimal
-  primaryUserCryptoAddress: {
-    id: string
-    cryptoNetwork: 'ETH'
-    cryptoAddress: string
-    datetimeUpdated: Date
-    datetimeCreated: Date
-    userId: string
-    dataCreationMethod: DataCreationMethod
-    hasBeenVerifiedViaAuth: boolean
-    embeddedWalletUserEmailAddressId: string | null
-  } | null
-  address: {
-    administrativeAreaLevel1: string
-    countryCode: string
-  } | null
-  firstName: string
-  lastName: string
-  informationVisibility: UserInformationVisibility
-}>
-
 async function getSumDonationsByUserQuery({ limit, offset }: SumDonationsByUserConfig) {
-  const total: GetSumDonationByUserQueryResult = await prismaClient.user.findMany({
+  const total = await prismaClient.user.findMany({
     select: {
       id: true,
       totalDonationAmountUsd: true,

--- a/src/data/aggregations/getSumDonationsByUser.ts
+++ b/src/data/aggregations/getSumDonationsByUser.ts
@@ -12,7 +12,9 @@ import { prismaClient } from '@/utils/server/prismaClient'
 export type SumDonationsByUserConfig = {
   limit: number
   offset?: number
+  pageNum: number
 }
+
 
 async function getSumDonationsByUserQuery({ limit, offset }: SumDonationsByUserConfig) {
   const total: {
@@ -98,5 +100,7 @@ function manuallyAdjustResults(results: SumDonationsByUser) {
 export async function getSumDonationsByUser(config: SumDonationsByUserConfig) {
   const result = await getSumDonationsByUserQuery(config)
   const withUserData = await getSumDonationsByUserData(result)
-  return manuallyAdjustResults(withUserData)
+
+  const isFirstPage = config.pageNum === 1
+  return isFirstPage ? manuallyAdjustResults(withUserData) : withUserData
 }

--- a/src/data/pageSpecific/getHomepageData.ts
+++ b/src/data/pageSpecific/getHomepageData.ts
@@ -37,7 +37,7 @@ export async function getHomepageData(props?: GetHomePageDataProps) {
     getHomepageTopLevelMetrics(),
     getPublicRecentActivity({ limit: props?.recentActivityLimit ?? 10 }),
     queryDTSIHomepagePeople(),
-    getSumDonationsByUser({ limit: 10 }),
+    getSumDonationsByUser({ limit: 10, pageNum: 1 }),
   ])
   return {
     sumDonations,


### PR DESCRIPTION
closes #1044

## What changed? Why?

One of the main reasons why the donation leaderboard page was taking so long to build was related to ENS avatar and name lookups.  As we can't remove the feature of showing the donator ENS information, I added pagination for this page to reduce the amount of ENS lookup calls for each page. We also had an unnecessary DB query that I removed.


## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
