### PR TITLE
Fix: Leaderboard page build timeout

### DIFF
--- a/src/utils/shared/raceAll.test.ts
+++ b/src/utils/shared/raceAll.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from '@jest/globals'
+
+import { raceAll } from '@/utils/shared/raceAll'
+
+describe('utils/raceAll', () => {
+  it('Should resolve all promises correctly', async () => {
+    const promisesArray = [
+      new Promise(resolve => setTimeout(() => resolve('1'), 100)),
+      new Promise(resolve => setTimeout(() => resolve('2'), 200)),
+      new Promise(resolve => setTimeout(() => resolve('3'), 300)),
+    ]
+
+    const result = await raceAll(promisesArray, 500)
+
+    expect(result).toEqual(['1', '2', '3'])
+  })
+
+  it('Should return the promise result value for all promises that resolved within the maximum timeout', async () => {
+    const promisesArray = [
+      new Promise(resolve => setTimeout(() => resolve('1'), 100)),
+      new Promise(resolve => setTimeout(() => resolve('2'), 900)),
+      new Promise(resolve => setTimeout(() => resolve('3'), 300)),
+    ]
+
+    const result = await raceAll(promisesArray, 600, 'defaultValueWhenTimeoutisReached')
+
+    expect(result).toEqual(['1', 'defaultValueWhenTimeoutisReached', '3'])
+  })
+
+  it('Should return the default value for each promises that reaches the maximum timeout', async () => {
+    const promisesArray = [
+      new Promise(resolve => setTimeout(() => resolve('1'), 800)),
+      new Promise(resolve => setTimeout(() => resolve('2'), 900)),
+      new Promise(resolve => setTimeout(() => resolve('3'), 700)),
+    ]
+
+    const result = await raceAll(promisesArray, 200, 'defaultValueWhenTimeoutisReached')
+
+    expect(result).toEqual([
+      'defaultValueWhenTimeoutisReached',
+      'defaultValueWhenTimeoutisReached',
+      'defaultValueWhenTimeoutisReached',
+    ])
+  })
+})

--- a/src/utils/shared/raceAll.ts
+++ b/src/utils/shared/raceAll.ts
@@ -1,0 +1,42 @@
+/**
+ * Runs a race between a promise and a timeout, resolving with the
+ * first value. Runs this race for an array of promises.
+ *
+ * This allows promises to be resolved within a specified timeout,
+ * defaulting to a fallback value if the timeout is reached first.
+ *
+ * @param promises - An array of promises to race against timeouts
+ * @param timeoutTime - The timeout duration in milliseconds
+ * @param defaultValueForTimeout - The value to resolve with if timeout occurs
+ *
+ * Example:
+ *
+ * ```
+ * const promisesArray = [
+      new Promise(resolve => setTimeout(() => resolve('1'), 100)),
+      new Promise(resolve => setTimeout(() => resolve('2'), 900)),
+      new Promise(resolve => setTimeout(() => resolve('3'), 300)),
+    ]
+
+    const result = await raceAll(promisesArray, 600, 'defaultValueWhenTimeoutisReached')
+    // result will be equal to ['1', 'defaultValueWhenTimeoutisReached', '3']
+
+ *
+ * ```
+*/
+export async function raceAll<T>(
+  promises: Promise<T>[],
+  timeoutTime: number,
+  defaultValueForTimeout: T | null = null,
+) {
+  return await Promise.all(
+    promises.map(promise => {
+      return Promise.race<T>([
+        promise,
+        new Promise<T>(resolve => {
+          setTimeout(() => resolve(defaultValueForTimeout as T), timeoutTime)
+        }),
+      ])
+    }),
+  )
+}


### PR DESCRIPTION
closes #1044 

## What changed? Why?

This PR creates a new approach for returning default values for promises inside an Promise.all when a defined maximum timeout is reached. The idea here is to prevent the build page worker on Vercel from killing the build process because a promise was not resolved during the default 60 seconds limit on the Leaderboard page.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
