### PR TITLE
Adds `ignoreDuringbuilds` eslint config to `next.config.js`

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -181,6 +181,9 @@ const nextConfig = {
   experimental: {
     instrumentationHook: true,
   },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   images: {
     minimumCacheTTL: 60 * 60 * 24 * 7, // 7 days
     unoptimized: false,


### PR DESCRIPTION
closes #1064 

## What changed? Why?

This PR disables the lint step in next build for Vercel deploys to fix the build process being stuck during build some times.

More information around this issue can be found [here](https://www.reddit.com/r/nextjs/comments/1dqslt6/nextjs_hangs_and_fails_on_linting_and_checking/)

Example of error occurring: [Link](https://vercel.com/coinbase-vercel/swc-web/44hsm4BiCqcRj7t4fvN9YvqcFLpj?filter=errors)

Documentation used for this change: [Link](https://nextjs.org/docs/app/api-reference/next-config-js/eslint)

---

There is a chance that we'll have to disable the type validation step as well. For so, we will use this documentation: [Link](https://nextjs.org/docs/app/api-reference/next-config-js/typescript)

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
