### PR TITLE
Defines new strategy to handle `flaky` tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -8,6 +8,15 @@ export default defineConfig({
   viewportWidth: 390,
   viewportHeight: 844,
   defaultCommandTimeout: 10000,
+  retries: {
+    experimentalStrategy: 'detect-flake-and-pass-on-threshold',
+    experimentalOptions: {
+      maxRetries: 5,
+      passesRequired: 2,
+    },
+    openMode: true,
+    runMode: true,
+  },
   e2e: {
     env: {
       SWC_INTERNAL_ENDPOINTS_SECRET: process.env.SWC_INTERNAL_ENDPOINTS_SECRET,


### PR DESCRIPTION
closes #1046 

## What changed? Why?

This PR addresses the issue of flaky tests that are causing inconsistencies in our CI workflows. To mitigate this, Cypress offers a retry functionality that helps prevent flaky tests from disrupting our deployment cycles. Additionally, there is an experimental feature that allows us to set a maximum number of retries and a minimum number of successful passes, establishing a threshold for a test to be considered successful. In this PR, I’ve implemented this feature by setting the maximum retries to 5 and requiring at least 2 successful runs for a test to be considerate a pass.

[Documentation for this experimental feature](https://docs.cypress.io/guides/references/experiments#Experimental-Test-Retries)

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
