### PR TITLE
feat: change copy for email subtext

### DIFF
--- a/src/components/app/userActionRowCTA/constants.tsx
+++ b/src/components/app/userActionRowCTA/constants.tsx
@@ -66,7 +66,7 @@ export const USER_ACTION_ROW_CTA_INFO: Record<
     actionType: UserActionType.EMAIL,
     image: { src: '/actionTypeIcons/email.png' },
     text: `Email your ${getYourPoliticianCategoryShortDisplayName(EMAIL_FLOW_POLITICIANS_CATEGORY)}`,
-    subtext: "Follow-up your call with an email. We'll make it simple.",
+    subtext: 'Make your voice heard. We make it easy.',
     shortText: 'Send an email',
     shortSubtext: 'We drafted one for you. All you have to do is hit send.',
     canBeTriggeredMultipleTimes: true,

--- a/src/utils/server/getMaybeUserAndMethodOfMatch.ts
+++ b/src/utils/server/getMaybeUserAndMethodOfMatch.ts
@@ -1,6 +1,6 @@
 'use server'
 import { Prisma, UserCryptoAddress } from '@prisma/client'
-import { GetFindResult } from '@prisma/client/runtime/library'
+import { GetResult } from '@prisma/client/runtime/library'
 import * as Sentry from '@sentry/nextjs'
 
 import { appRouterGetAuthUser } from '@/utils/server/authentication/appRouterGetAuthUser'
@@ -15,11 +15,11 @@ type PrismaBase = Omit<Prisma.UserFindFirstArgs, 'where'>
 
 type BaseUserAndMethodOfMatch<S extends string | undefined, I extends PrismaBase = PrismaBase> =
   | {
-      user: GetFindResult<Prisma.$UserPayload, I>
+      user: GetResult<Prisma.$UserPayload, I, 'findFirst'>
       userCryptoAddress: UserCryptoAddress | null
     }
   | {
-      user: GetFindResult<Prisma.$UserPayload, I> | null
+      user: GetResult<Prisma.$UserPayload, I, 'findFirst'> | null
       sessionId: S
     }
 
@@ -95,7 +95,7 @@ async function baseGetMaybeUserAndMethodOfMatch<
       : Promise.resolve(null),
   ])
   const userWithoutReturnTypes = authFoundUser || sessionUser
-  const user = userWithoutReturnTypes as GetFindResult<Prisma.$UserPayload, I> | null
+  const user = userWithoutReturnTypes as GetResult<Prisma.$UserPayload, I, 'findFirst'> | null
   if (authUser) {
     if (!user) {
       if (NEXT_PUBLIC_ENVIRONMENT === 'production') {


### PR DESCRIPTION
closes #1074 

## What changed? Why?

This changes the copy for the email action subtext and fixes a type issue that is blocking builds

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
