### PR TITLE
add name of state to map hover tooltip

### DIFF
--- a/src/components/app/pageAdvocatesHeatmap/advocatesHeatmapTooltip.tsx
+++ b/src/components/app/pageAdvocatesHeatmap/advocatesHeatmapTooltip.tsx
@@ -41,7 +41,7 @@ export function TotalAdvocatesPerStateTooltip({
 
   if (!totalAdvocatesPerState) return null
 
-  const formattedNumber = `${FormattedNumber({ amount: totalAdvocatesPerState, locale })} advocates`
+  const formattedNumber = `${FormattedNumber({ amount: totalAdvocatesPerState, locale })} advocates in ${hoveredStateName}`
 
   const tooltipWidth = formattedNumber.length * 10
   const offsetX = tooltipWidth / 2


### PR DESCRIPTION
## What changed? Why?
![image](https://github.com/user-attachments/assets/5e7b315d-0235-4ac7-a08e-9bcf93252f2b)

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
