### PR TITLE
Fix: usCongressionalDistrict backfill inngest function memory limit reaching

### DIFF
--- a/src/inngest/functions/backfillCongressionalDistrictCronJob/index.ts
+++ b/src/inngest/functions/backfillCongressionalDistrictCronJob/index.ts
@@ -40,8 +40,10 @@ export const backfillCongressionalDistrictCronJob = inngest.createFunction(
   },
   async ({ step }) => {
     let currentCursor: string | undefined = undefined
-    if (!DATABASE_QUERY_LIMIT) return null
-
+    if (!DATABASE_QUERY_LIMIT) {
+      logger.error('DATABASE_QUERY_LIMIT is not set')
+      return null
+    }
     const numQueries = Math.ceil(
       MAX_US_CONGRESSIONAL_DISTRICTS_BACKFILL_COUNT / DATABASE_QUERY_LIMIT,
     )

--- a/src/inngest/functions/backfillCongressionalDistrictCronJob/index.ts
+++ b/src/inngest/functions/backfillCongressionalDistrictCronJob/index.ts
@@ -40,58 +40,53 @@ export const backfillCongressionalDistrictCronJob = inngest.createFunction(
   },
   async ({ step }) => {
     let currentCursor: string | undefined = undefined
+    if (!DATABASE_QUERY_LIMIT) return null
 
-    const addressesWithoutCongressionalDistrictsBatches = await step.run(
-      'script.get-addresses',
-      async () => {
-        if (!DATABASE_QUERY_LIMIT) return null
+    const numQueries = Math.ceil(
+      MAX_US_CONGRESSIONAL_DISTRICTS_BACKFILL_COUNT / DATABASE_QUERY_LIMIT,
+    )
 
-        const numQueries = Math.ceil(
-          MAX_US_CONGRESSIONAL_DISTRICTS_BACKFILL_COUNT / DATABASE_QUERY_LIMIT,
-        )
+    const addressesWithoutCongressionalDistricts: Pick<
+      Address,
+      'id' | 'formattedDescription' | 'countryCode'
+    >[][] = []
 
-        const addressesWithoutCongressionalDistricts: Omit<
-          Address,
-          'datetimeCreated' | 'datetimeUpdated'
-        >[][] = []
+    for (let i = 1; i <= numQueries; i++) {
+      const addresses = await step.run('script.get-addresses', async () => {
+        const rowsToTake =
+          i * DATABASE_QUERY_LIMIT > MAX_US_CONGRESSIONAL_DISTRICTS_BACKFILL_COUNT
+            ? MAX_US_CONGRESSIONAL_DISTRICTS_BACKFILL_COUNT - DATABASE_QUERY_LIMIT * (i - 1)
+            : DATABASE_QUERY_LIMIT
 
-        for (let i = 1; i <= numQueries; i++) {
-          const rowsToTake =
-            i * DATABASE_QUERY_LIMIT > MAX_US_CONGRESSIONAL_DISTRICTS_BACKFILL_COUNT
-              ? MAX_US_CONGRESSIONAL_DISTRICTS_BACKFILL_COUNT - DATABASE_QUERY_LIMIT * (i - 1)
-              : DATABASE_QUERY_LIMIT
+        return await prismaClient.address.findMany({
+          select: { id: true, formattedDescription: true, countryCode: true },
+          where: { usCongressionalDistrict: null, countryCode: 'US' },
+          cursor: currentCursor ? { id: currentCursor } : undefined,
+          skip: currentCursor ? 1 : 0,
+          take: rowsToTake,
+        })
+      })
 
-          const addresses = await prismaClient.address.findMany({
-            where: { usCongressionalDistrict: null, countryCode: 'US' },
-            cursor: currentCursor ? { id: currentCursor } : undefined,
-            skip: currentCursor ? 1 : 0,
-            take: rowsToTake,
-          })
+      if (!addresses.length) {
+        break
+      }
 
-          if (!addresses.length) {
-            break
-          }
+      currentCursor = addresses[addresses.length - 1].id
+      addressesWithoutCongressionalDistricts.push(addresses)
 
-          currentCursor = addresses[addresses.length - 1].id
-          addressesWithoutCongressionalDistricts.push(addresses)
+      if (addresses.length < DATABASE_QUERY_LIMIT) {
+        break
+      }
+    }
+    const flatAddressesWithoutCongressionalDistricts = addressesWithoutCongressionalDistricts.flat()
 
-          if (addresses.length < DATABASE_QUERY_LIMIT) {
-            break
-          }
-        }
+    logger.info(
+      `${flatAddressesWithoutCongressionalDistricts.length} addresses without usCongressionalDistrict found`,
+    )
 
-        const flatAddressesWithoutCongressionalDistricts =
-          addressesWithoutCongressionalDistricts.flat()
-
-        logger.info(
-          `${flatAddressesWithoutCongressionalDistricts.length} addresses without usCongressionalDistrict found`,
-        )
-
-        return chunk(
-          flatAddressesWithoutCongressionalDistricts,
-          BACKFILL_US_CONGRESSIONAL_DISTRICTS_BATCH_SIZE,
-        )
-      },
+    const addressesWithoutCongressionalDistrictsBatches = chunk(
+      flatAddressesWithoutCongressionalDistricts,
+      BACKFILL_US_CONGRESSIONAL_DISTRICTS_BATCH_SIZE,
     )
 
     if (!addressesWithoutCongressionalDistrictsBatches) {
@@ -126,7 +121,10 @@ export const backfillCongressionalDistrictCronJob = inngest.createFunction(
 )
 
 async function backfillUsCongressionalDistricts(
-  addressesWithoutCongressionalDistricts: Omit<Address, 'datetimeCreated' | 'datetimeUpdated'>[],
+  addressesWithoutCongressionalDistricts: Pick<
+    Address,
+    'id' | 'formattedDescription' | 'countryCode'
+  >[],
 ) {
   for (const address of addressesWithoutCongressionalDistricts) {
     let usCongressionalDistrict: Awaited<


### PR DESCRIPTION
## What changed? Why?

Making all queries in a single step was reaching vercel's serverless functions memory limit, so the query now returns only used data and each query is done a different step

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
