### PR TITLE
fix: conflict when using sendgrid prod on local env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ GOOGLE_PLACES_BACKEND_API_KEY=$NEXT_PUBLIC_GOOGLE_PLACES_API_KEY
 # You can get this by creating a free Sentgrid account and generating your api key at https://app.sendgrid.com/settings/api_keys 
 # and setting up a sender at https://app.sendgrid.com/settings/sender_auth
 SENDGRID_API_KEY=
-SENDGRID_SENDER="no-reply@communication.standwithcrypto.org"
+SENDGRID_SENDER=
 SENDGRID_WEBHOOK_VERIFICATION_KEY=
 
 # Create a new Ethereum wallet with your preferred wallet provider (e.g. MetaMask, Coinbase Wallet, etc.) and paste the private key here.

--- a/src/utils/server/email/index.ts
+++ b/src/utils/server/email/index.ts
@@ -1,6 +1,6 @@
 export type { EmailEvent } from './constants'
 export { EmailEventName, EVENT_NAME_TO_HUMAN_READABLE_STRING } from './constants'
 export type { SendMailPayload } from './sendMail'
-export { sendMail, sendMultipleMails } from './sendMail'
+export { sendMail } from './sendMail'
 export { parseEventsWebhookRequest } from './utils/parseEventsWebhookRequest'
 export { verifySignature } from './utils/verifySignature'

--- a/src/utils/server/email/utils/verifySignature.ts
+++ b/src/utils/server/email/utils/verifySignature.ts
@@ -1,13 +1,18 @@
 import { EventWebhook, EventWebhookHeader } from '@sendgrid/eventwebhook'
 
-import { requiredEnv } from '@/utils/shared/requiredEnv'
+import { requiredOutsideLocalEnv } from '@/utils/shared/requiredEnv'
 
-const SENDGRID_WEBHOOK_VERIFICATION_KEY = requiredEnv(
+const SENDGRID_WEBHOOK_VERIFICATION_KEY = requiredOutsideLocalEnv(
   process.env.SENDGRID_WEBHOOK_VERIFICATION_KEY,
   'SENDGRID_WEBHOOK_VERIFICATION_KEY',
+  'Sendgrid Events Webhook',
 )
 
 export async function verifySignature(request: Request) {
+  if (!SENDGRID_WEBHOOK_VERIFICATION_KEY) {
+    return false
+  }
+
   const signature = request.headers.get(EventWebhookHeader.SIGNATURE())
   const timestamp = request.headers.get(EventWebhookHeader.TIMESTAMP())
 


### PR DESCRIPTION
fixes PROD-SWC-WEB-26X

## What changed? Why?

This disables Sendgrid locally when the env variables are not set

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
