### PR TITLE
Refactor serverside analytics calls to use waitUntil

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@udecode/plate": "^29.0.1",
         "@upstash/ratelimit": "^1.0.0",
         "@upstash/redis": "^1.28.4",
+        "@vercel/functions": "^1.4.0",
         "@vercel/og": "^0.6.1",
         "@vercel/speed-insights": "^1.0.5",
         "bowser": "^2.11.0",
@@ -15325,6 +15326,22 @@
       "integrity": "sha512-5WOilc7AE0ITAdE3NCyMwgOq1n3RHcqW0OfmbotiAyfA+QAEe1R7kXin8L/Yladgdc5lkA0GcYyewqKfAw53jQ==",
       "dependencies": {
         "crypto-js": "^4.2.0"
+      }
+    },
+    "node_modules/@vercel/functions": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vercel/functions/-/functions-1.4.0.tgz",
+      "integrity": "sha512-Ln6SpIkms1UJg306X2kbEMyG9ol+mjDr2xx389cvsBxgFyFMI9Bm+LYOG4N3TSik4FI59MECyyc4oz7AIAYmqQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-web-identity": "*"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-web-identity": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vercel/og": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@udecode/plate": "^29.0.1",
     "@upstash/ratelimit": "^1.0.0",
     "@upstash/redis": "^1.28.4",
+    "@vercel/functions": "^1.4.0",
     "@vercel/og": "^0.6.1",
     "@vercel/speed-insights": "^1.0.5",
     "bowser": "^2.11.0",

--- a/src/actions/actionCreateUserActionEmailCongressperson.ts
+++ b/src/actions/actionCreateUserActionEmailCongressperson.ts
@@ -12,6 +12,7 @@ import {
   UserInformationVisibility,
 } from '@prisma/client'
 import * as Sentry from '@sentry/nextjs'
+import { waitUntil } from '@vercel/functions'
 import { z } from 'zod'
 
 import { getClientUser } from '@/clientModels/clientUser/clientUser'
@@ -158,7 +159,7 @@ async function _actionCreateUserActionEmailCongressperson(input: Input) {
       userState,
       ...convertAddressToAnalyticsProperties(validatedFields.data.address),
     })
-    await beforeFinish()
+    waitUntil(beforeFinish())
     return { user: getClientUser(user) }
   }
 
@@ -237,7 +238,7 @@ async function _actionCreateUserActionEmailCongressperson(input: Input) {
     data: payload,
   })
 
-  await beforeFinish()
+  waitUntil(beforeFinish())
   return { user: getClientUser(user) }
 }
 

--- a/src/actions/actionCreateUserActionNFTMint.ts
+++ b/src/actions/actionCreateUserActionNFTMint.ts
@@ -4,6 +4,7 @@ import 'server-only'
 import { NFTCurrency, NFTMintStatus, NFTMintType, User, UserActionType } from '@prisma/client'
 import { Decimal } from '@prisma/client/runtime/library'
 import * as Sentry from '@sentry/nextjs'
+import { waitUntil } from '@vercel/functions'
 import { BigNumber } from 'ethers'
 import { nativeEnum, object, z } from 'zod'
 
@@ -118,7 +119,7 @@ async function _actionCreateUserActionMintNFT(input: CreateActionMintNFTInput) {
     ethTransactionValue,
   })
 
-  await analytics.flush()
+  waitUntil(analytics.flush())
   return { user: getClientUser(user) }
 }
 

--- a/src/actions/actionCreateUserActionTweet.ts
+++ b/src/actions/actionCreateUserActionTweet.ts
@@ -8,6 +8,7 @@ import {
   UserCryptoAddress,
   UserInformationVisibility,
 } from '@prisma/client'
+import { waitUntil } from '@vercel/functions'
 
 import { getClientUser } from '@/clientModels/clientUser/clientUser'
 import { getMaybeUserAndMethodOfMatch } from '@/utils/server/getMaybeUserAndMethodOfMatch'
@@ -98,7 +99,7 @@ async function _actionCreateUserActionTweet() {
       creationMethod: 'On Site',
       userState,
     })
-    await beforeFinish()
+    waitUntil(beforeFinish())
     return { user: getClientUser(user) }
   }
 
@@ -123,7 +124,7 @@ async function _actionCreateUserActionTweet() {
     userState,
   })
 
-  await beforeFinish()
+  waitUntil(beforeFinish())
   logger.info('created action')
   return { user: getClientUser(user) }
 }

--- a/src/actions/actionCreateUserActionVoterRegistration.ts
+++ b/src/actions/actionCreateUserActionVoterRegistration.ts
@@ -2,6 +2,7 @@
 import 'server-only'
 
 import { User, UserActionType, UserInformationVisibility } from '@prisma/client'
+import { waitUntil } from '@vercel/functions'
 import { nativeEnum, object, z } from 'zod'
 
 import { getClientUser } from '@/clientModels/clientUser/clientUser'
@@ -103,7 +104,7 @@ async function _actionCreateUserActionVoterRegistration(input: CreateActionVoter
       validatedInput,
       sharedDependencies: { analytics },
     })
-    await beforeFinish()
+    waitUntil(beforeFinish())
     return { user: getClientUser(user) }
   }
 
@@ -120,7 +121,7 @@ async function _actionCreateUserActionVoterRegistration(input: CreateActionVoter
     await claimNFTAndSendEmailNotification(userAction, user.primaryUserCryptoAddress)
   }
 
-  await beforeFinish()
+  waitUntil(beforeFinish())
   return { user: getClientUser(user) }
 }
 
@@ -149,7 +150,11 @@ async function createUser(sharedDependencies: Pick<SharedDependencies, 'localUse
     userId: createdUser.id,
   })
   if (localUser?.persisted) {
-    peopleAnalytics.setOnce(mapPersistedLocalUserToAnalyticsProperties(localUser.persisted))
+    waitUntil(
+      peopleAnalytics
+        .setOnce(mapPersistedLocalUserToAnalyticsProperties(localUser.persisted))
+        .flush(),
+    )
   }
 
   return { user: createdUser, peopleAnalytics }

--- a/src/actions/actionUpdateUserHasOptedInSMS.ts
+++ b/src/actions/actionUpdateUserHasOptedInSMS.ts
@@ -2,6 +2,7 @@
 import 'server-only'
 
 import { Address, User, UserCryptoAddress } from '@prisma/client'
+import { waitUntil } from '@vercel/functions'
 import { z } from 'zod'
 
 import { getClientUser } from '@/clientModels/clientUser/clientUser'
@@ -47,12 +48,16 @@ async function _actionUpdateUserHasOptedInToSMS(data: UpdateUserHasOptedInToSMSP
     },
   })
 
-  await getServerPeopleAnalytics({
-    userId: authUser.userId,
-    localUser: parseLocalUserFromCookies(),
-  }).set({
-    'Has Opted In to SMS': true,
-  })
+  waitUntil(
+    getServerPeopleAnalytics({
+      userId: authUser.userId,
+      localUser: parseLocalUserFromCookies(),
+    })
+      .set({
+        'Has Opted In to SMS': true,
+      })
+      .flush(),
+  )
 
   const updatedUser = await prismaClient.user.update({
     where: {

--- a/src/actions/actionUpdateUserInformationVisibility.ts
+++ b/src/actions/actionUpdateUserInformationVisibility.ts
@@ -1,6 +1,7 @@
 'use server'
 import 'server-only'
 
+import { waitUntil } from '@vercel/functions'
 import { z } from 'zod'
 
 import { getClientUser } from '@/clientModels/clientUser/clientUser'
@@ -38,12 +39,16 @@ async function _actionUpdateUserInformationVisibility(
       id: authUser.userId,
     },
   })
-  await getServerPeopleAnalytics({
-    userId: authUser.userId,
-    localUser: parseLocalUserFromCookies(),
-  }).set({
-    'Information Visibility': informationVisibility,
-  })
+  waitUntil(
+    getServerPeopleAnalytics({
+      userId: authUser.userId,
+      localUser: parseLocalUserFromCookies(),
+    })
+      .set({
+        'Information Visibility': informationVisibility,
+      })
+      .flush(),
+  )
 
   const updatedUser = await prismaClient.user.update({
     where: {

--- a/src/app/api/internal/commerce-webhook/route.ts
+++ b/src/app/api/internal/commerce-webhook/route.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
+import { waitUntil } from '@vercel/functions'
 import { NextRequest, NextResponse } from 'next/server'
 
 import { authenticatePaymentRequest } from '@/utils/server/coinbaseCommerce/authenticatePaymentRequest'
@@ -100,7 +101,7 @@ export async function POST(request: NextRequest) {
     })
     return new NextResponse('internal error', { status: 500 })
   } finally {
-    await analytics.flush()
+    waitUntil(analytics.flush())
   }
   return new NextResponse('success', { status: 200 })
 }

--- a/src/utils/server/coinbaseCommerce/storePaymentRequest.ts
+++ b/src/utils/server/coinbaseCommerce/storePaymentRequest.ts
@@ -6,6 +6,7 @@ import {
   UserSession,
 } from '@prisma/client'
 import * as Sentry from '@sentry/nextjs'
+import { waitUntil } from '@vercel/functions'
 
 import { CoinbaseCommercePayment } from '@/utils/server/coinbaseCommerce/paymentRequest'
 import { prismaClient } from '@/utils/server/prismaClient'
@@ -327,12 +328,16 @@ async function createUserActionDonation(
   // Track user action created analytics.
   const localUser = getLocalUserFromUser(user)
   const analytics = getServerAnalytics({ userId: user.id, localUser })
-  analytics.trackUserActionCreated({
-    actionType: UserActionType.DONATION,
-    campaignName: UserActionDonationCampaignName.DEFAULT,
-    creationMethod: 'On Site',
-    userState: isNewUser ? 'New' : 'Existing',
-  })
+  waitUntil(
+    analytics
+      .trackUserActionCreated({
+        actionType: UserActionType.DONATION,
+        campaignName: UserActionDonationCampaignName.DEFAULT,
+        creationMethod: 'On Site',
+        userState: isNewUser ? 'New' : 'Existing',
+      })
+      .flush(),
+  )
 
   return donationAction
 }

--- a/src/utils/server/nft/mintPastActions.ts
+++ b/src/utils/server/nft/mintPastActions.ts
@@ -1,4 +1,5 @@
 import { UserCryptoAddress } from '@prisma/client'
+import { waitUntil } from '@vercel/functions'
 
 import { ACTION_NFT_SLUG, claimNFT } from '@/utils/server/nft/claimNFT'
 import { prismaClient } from '@/utils/server/prismaClient'
@@ -46,6 +47,6 @@ export async function mintPastActions(
     await claimNFT(action, userCryptoAddress)
   }
 
-  await analytics.flush()
+  waitUntil(analytics.flush())
   return actions
 }

--- a/src/utils/server/sms/actions.ts
+++ b/src/utils/server/sms/actions.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import { SMSStatus, User } from '@prisma/client'
+import { waitUntil } from '@vercel/functions'
 
 import { GOODBYE_SMS_COMMUNICATION_JOURNEY_INNGEST_EVENT_NAME } from '@/inngest/functions/sms/goodbyeSMSCommunicationJourney'
 import { UNSTOP_CONFIRMATION_SMS_COMMUNICATION_JOURNEY_INNGEST_EVENT_NAME } from '@/inngest/functions/sms/unstopConfirmationSMSCommunicationJourney'
@@ -39,14 +40,16 @@ export async function optInUser(phoneNumber: string, user: User) {
     },
   })
 
-  await getServerAnalytics({
-    localUser: getLocalUserFromUser(user),
-    userId: user.id,
-  })
-    .track('User SMS Opt-In', {
-      provider: 'twilio',
+  waitUntil(
+    getServerAnalytics({
+      localUser: getLocalUserFromUser(user),
+      userId: user.id,
     })
-    .flush()
+      .track('User SMS Opt-In', {
+        provider: 'twilio',
+      })
+      .flush(),
+  )
 }
 
 export async function optOutUser(phoneNumber: string, isSWCKeyword: boolean, user?: User) {
@@ -72,14 +75,16 @@ export async function optOutUser(phoneNumber: string, isSWCKeyword: boolean, use
   }
 
   if (user) {
-    await getServerAnalytics({
-      localUser: getLocalUserFromUser(user),
-      userId: user.id,
-    })
-      .track('User SMS Opt-out', {
-        type: isSWCKeyword ? 'SWC STOP Keyword' : 'STOP Keyword',
+    waitUntil(
+      getServerAnalytics({
+        localUser: getLocalUserFromUser(user),
+        userId: user.id,
       })
-      .flush()
+        .track('User SMS Opt-out', {
+          type: isSWCKeyword ? 'SWC STOP Keyword' : 'STOP Keyword',
+        })
+        .flush(),
+    )
   }
 }
 
@@ -103,11 +108,13 @@ export async function optUserBackIn(phoneNumber: string, user?: User) {
   })
 
   if (user) {
-    await getServerAnalytics({
-      localUser: getLocalUserFromUser(user),
-      userId: user.id,
-    })
-      .track('User SMS Unstop')
-      .flush()
+    waitUntil(
+      getServerAnalytics({
+        localUser: getLocalUserFromUser(user),
+        userId: user.id,
+      })
+        .track('User SMS Unstop')
+        .flush(),
+    )
   }
 }

--- a/src/utils/server/thirdweb/onLogin.ts
+++ b/src/utils/server/thirdweb/onLogin.ts
@@ -14,6 +14,7 @@ import {
   UserInformationVisibility,
 } from '@prisma/client'
 import * as Sentry from '@sentry/nextjs'
+import { waitUntil } from '@vercel/functions'
 import { compact, groupBy } from 'lodash-es'
 import { cookies } from 'next/headers'
 import { VerifyLoginPayloadParams } from 'thirdweb/auth'
@@ -351,7 +352,7 @@ export async function onNewLogin(props: NewLoginParams) {
     'Datetime of Last Login': new Date(),
   })
 
-  await beforeFinish()
+  waitUntil(beforeFinish())
   return {
     userId: user.id,
     user,

--- a/src/utils/server/thirdweb/onLogout.ts
+++ b/src/utils/server/thirdweb/onLogout.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { waitUntil } from '@vercel/functions'
 import { jwtDecode } from 'jwt-decode'
 import { cookies } from 'next/headers'
 
@@ -14,7 +15,11 @@ export async function onLogout() {
   const decodedToken = token?.value ? jwtDecode<{ ctx?: { userId?: string } }>(token.value) : null
   const { userId } = decodedToken?.ctx ?? {}
 
-  getServerAnalytics({ userId: userId ?? '', localUser }).track('User Logged Out')
+  waitUntil(
+    getServerAnalytics({ userId: userId ?? '', localUser })
+      .track('User Logged Out')
+      .flush(),
+  )
 
   cookies().delete(THIRDWEB_AUTH_TOKEN_COOKIE_PREFIX)
 }


### PR DESCRIPTION
closes #841 

## What changed? Why?

Refactor our server side analytics calls to take advantage of nextjs [waitUntil
](https://vercel.com/docs/functions/functions-api-reference#waituntil)

Every server action should now be 70-90ms faster, as they no longer wait for mixpanel responses
<img width="580" alt="image" src="https://github.com/user-attachments/assets/fcaf376c-f669-46b0-89cb-e8b9b580c148">


## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
