### PR TITLE
fix: add correct referrer to google civic api requests

### DIFF
--- a/src/utils/shared/googleCivicInfo.ts
+++ b/src/utils/shared/googleCivicInfo.ts
@@ -4,6 +4,7 @@ import { convertToOnlyEnglishCharacters } from '@/utils/shared/convertToOnlyEngl
 import { fetchReq } from '@/utils/shared/fetchReq'
 import { logger } from '@/utils/shared/logger'
 import { requiredEnv } from '@/utils/shared/requiredEnv'
+import { fullUrl } from '@/utils/shared/urls'
 
 /*
 Sample response
@@ -138,10 +139,16 @@ export function getGoogleCivicDataFromAddress(address: string) {
     return Promise.resolve(cached)
   }
 
-  return fetchReq(apiUrl.toString(), undefined, {
-    isValidRequest: (response: Response) =>
-      (response.status >= 200 && response.status < 300) || response.status === 404,
-  })
+  return fetchReq(
+    apiUrl.toString(),
+    {
+      referrer: fullUrl('/'),
+    },
+    {
+      isValidRequest: (response: Response) =>
+        (response.status >= 200 && response.status < 300) || response.status === 404,
+    },
+  )
     .then(res => res.json())
     .then(res => {
       const response = res as GoogleCivicInfoResponse | GoogleCivicErrorResponse


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

We are getting a lot of errors on the Inngest function to backfill usCongressionalDistricts with reason `CIVIC_AP_DOWN`. This is being caused because Inngest doesn't make a request to our production static URL `https://standwithcrypto.org`, making instead to the URL created by Vercel on each deploy and the Civic API key on production only accepts requests from referrer `https://standwithcrypto.org`. This PR adds the correct URL to the referrer on production.

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
