### PR TITLE
Fix: `Rendered more hooks than during the previous render.` in `action/sign-up`

### DIFF
--- a/src/app/[locale]/(homepageDialogDeeplink)/action/sign-up/page.tsx
+++ b/src/app/[locale]/(homepageDialogDeeplink)/action/sign-up/page.tsx
@@ -54,6 +54,8 @@ export default function UserActionOptInSWCDeepLink() {
     }
   }, [session.isLoggedIn, handleRedirectOnLogin])
 
+  if (session.isLoading || session.isLoggedIn) return null
+
   return (
     <GeoGate
       bypassCountryCheck // For Onchain Summer


### PR DESCRIPTION
closes #1129

## What changed? Why?

Fixes an error when the user is already signed in, but navigates to `action/sign-up` causing a client render error

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
