### PR TITLE
feat: remove opt in from active email notification

### DIFF
--- a/src/utils/server/email/templates/common/constants.ts
+++ b/src/utils/server/email/templates/common/constants.ts
@@ -9,7 +9,6 @@ export enum EmailActiveActions {
 }
 
 export enum EmailEnabledActionNFTs {
-  OPT_IN = 'OPT_IN',
   CALL = 'CALL',
   VOTER_REGISTRATION = 'VOTER_REGISTRATION',
 }
@@ -19,7 +18,6 @@ export type EmailEnabledActionNFTsNames = `${EmailEnabledActionNFTs}`
 export const NFT_SLUG_TO_EMAIL_ACTIVE_ACTION: Partial<Record<NFTSlug, EmailEnabledActionNFTs>> = {
   [NFTSlug.CALL_REPRESENTATIVE_SEPT_11]: EmailEnabledActionNFTs.CALL,
   [NFTSlug.I_AM_A_VOTER]: EmailEnabledActionNFTs.VOTER_REGISTRATION,
-  [NFTSlug.SWC_SHIELD]: EmailEnabledActionNFTs.OPT_IN,
 }
 
 // Keys in this object are still type enforced, we don't want to use the prisma enum due to errors on dev environment
@@ -91,10 +89,6 @@ export const NFT_IMAGES_BY_ACTION: Record<
   CALL: {
     src: '/email/nfts/call.png',
     alt: 'Call Action NFT',
-  },
-  OPT_IN: {
-    src: '/email/nfts/join.png',
-    alt: 'Join Action NFT',
   },
   VOTER_REGISTRATION: {
     src: '/email/nfts/voter-registration.png',


### PR DESCRIPTION
## What changed? Why?
Since we already have the welcome email the opt in nft email looks duplicated, so we're removing it

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
