### PR TITLE
fix: change email base url

### DIFF
--- a/src/utils/server/email/constants.ts
+++ b/src/utils/server/email/constants.ts
@@ -1,3 +1,5 @@
+import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
+
 export enum EmailEventName {
   PROCESSED = 'processed',
   DEFERRED = 'deferred',
@@ -36,6 +38,15 @@ export const EVENT_NAME_TO_HUMAN_READABLE_STRING: Record<EmailEventName, string>
   [EmailEventName.GROUP_RESUBSCRIBE]: 'Group Resubscribe',
 }
 
-export const INTERNAL_BASE_URL = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
-  : 'http://localhost:3000'
+function getBaseUrl() {
+  switch (NEXT_PUBLIC_ENVIRONMENT) {
+    case 'production':
+      return 'https://www.standwithcrypto.org'
+    case 'preview':
+      return `https://${process.env.VERCEL_URL!}`
+    default:
+      return 'http://localhost:3000'
+  }
+}
+
+export const INTERNAL_BASE_URL = getBaseUrl()


### PR DESCRIPTION
## What changed? Why?

In a few sentry errors we identified that we're sending vercel deploy urls to transaction email links, this fixes it

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
