### PR TITLE
Fix bug where we were returning auth user when none existed

### DIFF
--- a/src/hooks/useAuthUser.ts
+++ b/src/hooks/useAuthUser.ts
@@ -25,9 +25,11 @@ export function useThirdwebAuthUser() {
 
   return {
     isLoggedIn: !!userId,
-    user: {
-      userId,
-      address: parseThirdwebAddress(address ?? ''),
-    },
+    user: userId
+      ? {
+          userId,
+          address: parseThirdwebAddress(address ?? ''),
+        }
+      : undefined,
   }
 }


### PR DESCRIPTION
## What changed? Why?

Updated the `useThirdwebAuthUser` hook so that it doesn't return the user object if no user is found in the JWT.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
