### PR TITLE
Fix profile form showing stale data after submit

### DIFF
--- a/src/components/app/authentication/loginDialogWrapper.tsx
+++ b/src/components/app/authentication/loginDialogWrapper.tsx
@@ -12,6 +12,7 @@ import {
   ANALYTICS_NAME_USER_ACTION_SUCCESS_JOIN_SWC,
 } from '@/components/app/authentication/constants'
 import { GeoGate } from '@/components/app/geoGate'
+import { UserProfileFormSections } from '@/components/app/updateUserProfileForm'
 import { LazyUpdateUserProfileForm } from '@/components/app/updateUserProfileForm/lazyLoad'
 import { UserActionFormActionUnavailable } from '@/components/app/userActionFormCommon/actionUnavailable'
 import { Dialog, DialogBody, DialogContent, DialogTrigger } from '@/components/ui/dialog'
@@ -299,7 +300,11 @@ function FinishProfileSection({ onSuccess }: { onSuccess: () => void }) {
 
   return (
     <React.Suspense fallback={loadingRender}>
-      <LazyUpdateUserProfileForm onSuccess={onSuccess} user={user} />
+      <LazyUpdateUserProfileForm
+        onSuccess={onSuccess}
+        skipSections={[UserProfileFormSections.InformationVisibility]}
+        user={user}
+      />
     </React.Suspense>
   )
 }

--- a/src/components/app/updateUserProfileForm/index.tsx
+++ b/src/components/app/updateUserProfileForm/index.tsx
@@ -1,14 +1,20 @@
 'use client'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { ArrowLeft } from 'lucide-react'
+import { useSWRConfig } from 'swr'
 
 import { ClientAddress } from '@/clientModels/clientAddress'
 import { SensitiveDataClientUserWithENSData } from '@/clientModels/clientUser/sensitiveDataClientUser'
 import { ANALYTICS_NAME_UPDATE_USER_PROFILE_FORM } from '@/components/app/updateUserProfileForm/constants'
 import { UpdateUserProfileFormExperimentTesting } from '@/components/app/updateUserProfileForm/step1'
+import { UpdateUserInformationVisibilityForm } from '@/components/app/updateUserProfileForm/step2'
+import { dialogButtonStyles } from '@/components/ui/dialog/styles'
 import { useSections } from '@/hooks/useSections'
+import { apiUrls } from '@/utils/shared/urls'
 import { trackSectionVisible } from '@/utils/web/clientAnalytics'
+import { cn } from '@/utils/web/cn'
 
-enum Sections {
+export enum UserProfileFormSections {
   Profile = 'Profile',
   InformationVisibility = 'Information Visibility', // Currently not used
 }
@@ -16,24 +22,58 @@ enum Sections {
 export function UpdateUserProfileFormContainer({
   user,
   onSuccess,
+  skipSections,
 }: {
   user: SensitiveDataClientUserWithENSData & { address: ClientAddress | null }
   onSuccess: () => void
+  skipSections?: UserProfileFormSections[]
 }) {
   const sections = useSections({
-    sections: [Sections.Profile, Sections.InformationVisibility],
-    initialSectionId: Sections.Profile,
+    sections: [UserProfileFormSections.Profile, UserProfileFormSections.InformationVisibility],
+    initialSectionId: UserProfileFormSections.Profile,
     analyticsName: ANALYTICS_NAME_UPDATE_USER_PROFILE_FORM,
+    skipSections,
   })
   useEffect(() => {
     trackSectionVisible({
       sectionGroup: ANALYTICS_NAME_UPDATE_USER_PROFILE_FORM,
-      section: Sections.Profile,
+      section: UserProfileFormSections.Profile,
     })
   }, [])
 
-  if (sections.currentSection === Sections.Profile) {
-    return <UpdateUserProfileFormExperimentTesting onSuccess={onSuccess} user={user} />
+  const { mutate } = useSWRConfig()
+
+  // we need to leverage the data submitted in the first step in the second step (whether we show the option to use first/last name)
+  const [statefulUser, setStatefulUser] = useState(user)
+
+  if (sections.currentSection === UserProfileFormSections.Profile) {
+    return (
+      <UpdateUserProfileFormExperimentTesting
+        onSuccess={newFields => {
+          setStatefulUser({ ...user, ...newFields })
+          void mutate(apiUrls.userFullProfileInfo())
+          sections.goToSection(UserProfileFormSections.InformationVisibility)
+          if (skipSections?.includes(UserProfileFormSections.InformationVisibility)) {
+            onSuccess()
+          }
+        }}
+        user={user}
+      />
+    )
+  }
+  if (sections.currentSection === UserProfileFormSections.InformationVisibility) {
+    return (
+      <>
+        <div
+          className={cn('left-2', dialogButtonStyles)}
+          onClick={() => sections.goToSection(UserProfileFormSections.Profile)}
+          role="button"
+        >
+          <ArrowLeft size={20} />
+        </div>
+        <UpdateUserInformationVisibilityForm onSuccess={onSuccess} user={statefulUser} />
+      </>
+    )
   }
 
   return null

--- a/src/hooks/useSections/index.tsx
+++ b/src/hooks/useSections/index.tsx
@@ -9,6 +9,7 @@ export function useSections<SectionKeys extends readonly string[]>({
   sections,
   initialSectionId,
   analyticsName,
+  skipSections,
 }: UseSectionsProps<SectionKeys>): UseSectionsReturn<SectionKeys[number]> {
   type Key = SectionKeys[number]
 
@@ -23,7 +24,7 @@ export function useSections<SectionKeys extends readonly string[]>({
 
   const goToSection: UseSectionsReturn<Key>['goToSection'] = React.useCallback(
     (section, options = {}) => {
-      if (section === currentSection) {
+      if (section === currentSection || (skipSections && skipSections.includes(section))) {
         return
       }
 
@@ -34,7 +35,7 @@ export function useSections<SectionKeys extends readonly string[]>({
         trackSectionVisible({ section, sectionGroup: analyticsName })
       }
     },
-    [currentSection, analyticsName],
+    [currentSection, skipSections, analyticsName],
   )
 
   const goBackSection: UseSectionsReturn<Key>['goBackSection'] = React.useCallback(() => {

--- a/src/hooks/useSections/index.tsx
+++ b/src/hooks/useSections/index.tsx
@@ -24,7 +24,7 @@ export function useSections<SectionKeys extends readonly string[]>({
 
   const goToSection: UseSectionsReturn<Key>['goToSection'] = React.useCallback(
     (section, options = {}) => {
-      if (section === currentSection || (skipSections && skipSections.includes(section))) {
+      if (section === currentSection || skipSections?.includes(section)) {
         return
       }
 

--- a/src/hooks/useSections/useSections.types.ts
+++ b/src/hooks/useSections/useSections.types.ts
@@ -2,6 +2,7 @@ export interface UseSectionsProps<SectionKeys extends readonly string[]> {
   sections: SectionKeys
   initialSectionId: SectionKeys[number]
   analyticsName: string
+  skipSections?: SectionKeys[number][]
 }
 
 export interface UseSectionsReturn<TabKey extends string = string> {


### PR DESCRIPTION
closes #1142 

## What changed? Why?

Fixes profile form displaying old data after submit and the profile visibility step is now only disabled on the onboarding flow

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
