### PR TITLE
Allow partner endpoint to accept invalid phone numbers

### DIFF
--- a/src/app/api/verified-swc-partner/user-action-opt-in/route.ts
+++ b/src/app/api/verified-swc-partner/user-action-opt-in/route.ts
@@ -1,4 +1,6 @@
+import * as Sentry from '@sentry/nextjs'
 import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
 
 import {
   verifiedSWCPartnersUserActionOptIn,
@@ -6,12 +8,49 @@ import {
 } from '@/data/verifiedSWCPartners/userActionOptIn'
 import { authenticateAndGetVerifiedSWCPartnerFromHeader } from '@/utils/server/verifiedSWCPartner/getVerifiedSWCPartnerFromHeader'
 
+type RequestBody = z.infer<typeof zodVerifiedSWCPartnersUserActionOptIn>
+
 export async function POST(request: NextRequest) {
   const partner = authenticateAndGetVerifiedSWCPartnerFromHeader()
-  const validatedFields = zodVerifiedSWCPartnersUserActionOptIn.parse(await request.json())
+  const requestBody = await request.json()
+
+  const baseValidationResult = zodVerifiedSWCPartnersUserActionOptIn
+    .omit({ phoneNumber: true })
+    .safeParse(requestBody)
+
+  if (!baseValidationResult.success) {
+    Sentry.captureException(baseValidationResult.error, {
+      extra: {
+        partner,
+        requestBody,
+      },
+    })
+    return NextResponse.json({ error: baseValidationResult.error }, { status: 400 })
+  }
+
+  const phoneNumberValidationResult =
+    zodVerifiedSWCPartnersUserActionOptIn.shape.phoneNumber.safeParse(
+      (requestBody as RequestBody)?.phoneNumber,
+    )
+
+  let validatedFields: RequestBody = baseValidationResult.data as RequestBody
+
+  if (!phoneNumberValidationResult.success) {
+    Sentry.captureException(phoneNumberValidationResult.error, {
+      extra: {
+        partner,
+        requestBody,
+      },
+    })
+    validatedFields = { ...validatedFields, phoneNumber: (requestBody as RequestBody)?.phoneNumber }
+  } else {
+    validatedFields = { ...validatedFields, phoneNumber: phoneNumberValidationResult.data }
+  }
+
   const result = await verifiedSWCPartnersUserActionOptIn({
     ...validatedFields,
     partner,
   })
+
   return NextResponse.json(result)
 }


### PR DESCRIPTION
closes #1160 

## What changed? Why?

Allows partners to signup users with invalid phone numbers and improve Sentry logs by appending the request body.

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
