### PR TITLE
NFT-Mint user action form to redirect on transaction sent

### DIFF
--- a/src/components/app/userActionFormNFTMint/sections/checkout/index.tsx
+++ b/src/components/app/userActionFormNFTMint/sections/checkout/index.tsx
@@ -1,6 +1,7 @@
 import React, { Dispatch, SetStateAction, useState } from 'react'
 import Balancer from 'react-wrap-balancer'
 import { noop } from 'lodash-es'
+import { TransactionReceipt } from 'node_modules/thirdweb/dist/types/transaction/types'
 import { getContract, PreparedTransaction } from 'thirdweb'
 import { base } from 'thirdweb/chains'
 import { TransactionButton, useActiveWalletConnectionStatus } from 'thirdweb/react'
@@ -42,7 +43,7 @@ interface UserActionFormNFTMintCheckoutProps
   extends UseSectionsReturn<UserActionFormNFTMintSectionNames>,
     UseCheckoutControllerReturn {
   prepareTransaction: () => PreparedTransaction | Promise<PreparedTransaction>
-  onMintCallback?: () => void
+  onMintCallback?: (receipt: TransactionReceipt) => void
   setTransactionHash: Dispatch<SetStateAction<string | null>>
   handleTransactionException: (e: unknown, extra: Record<string, unknown>) => void
   debug?: boolean
@@ -207,7 +208,10 @@ export function UserActionFormNFTMintCheckout({
               }
               onError={e => handleTransactionException(e, { isUSResident })}
               onTransactionConfirmed={onMintCallback}
-              onTransactionSent={result => setTransactionHash(result.transactionHash)}
+              onTransactionSent={result => {
+                setTransactionHash(result.transactionHash)
+                goToSection(UserActionFormNFTMintSectionNames.TRANSACTION_WATCH)
+              }}
               theme={theme}
               transaction={prepareTransaction}
             >


### PR DESCRIPTION
closes #1163 

## What changed? Why?

Users were not being redirected to the success screen after initiating a minting process. Consequently, the server action associated with the success screen was not being triggered.

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

We are not using the `onTransationConfirmed` callback because the transaction may take a while to be confirmed, so instead we redirect to the `TRANSACTION_WATCH` section as soon as the user triggers the transaction.

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
