### PR TITLE
Fix: rsvp event name in prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -433,6 +433,7 @@ model UserActionRsvpEvent {
   userAction                 UserAction @relation(fields: [id], references: [id])
 
   @@index([eventSlug, eventState])
+  @@map("user_action_rsvp_event")
 }
 
 enum UserCommunicationJourneyType {


### PR DESCRIPTION

## What changed? Why?

This PR fixes an issue related to rsvp user action table model

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
