### PR TITLE
fix: move campaign name to user communication

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -451,7 +451,6 @@ model UserCommunicationJourney {
   journeyType        UserCommunicationJourneyType @map("journey_type")
   datetimeCreated    DateTime                     @default(now()) @map("datetime_created")
   userCommunications UserCommunication[]
-  campaignName       String?                      @map("campaign_name")
 
   @@index([userId])
   @@map("user_communication_journey")
@@ -469,6 +468,7 @@ model UserCommunication {
   communicationType          CommunicationType        @map("communication_type")
   messageId                  String                   @map("message_id")
   datetimeCreated            DateTime                 @default(now()) @map("datetime_created")
+  campaignName               String?                  @map("campaign_name")
 
   @@index([userCommunicationJourneyId])
   @@map("user_communication")

--- a/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
+++ b/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
@@ -241,18 +241,25 @@ async function getPhoneNumberList(options: GetPhoneNumberOptions) {
   return prismaClient.user.groupBy({
     by: ['phoneNumber', 'datetimeCreated'],
     where: {
-      ...merge(options.userWhereInput, {
-        datetimeCreated: {
-          gte: options.cursor,
-        },
-        UserCommunicationJourney: {
-          every: {
-            campaignName: {
-              not: options.campaignName,
+      ...merge<Prisma.UserGroupByArgs['where'], Prisma.UserGroupByArgs['where']>(
+        options.userWhereInput,
+        {
+          datetimeCreated: {
+            gte: options.cursor,
+          },
+          UserCommunicationJourney: {
+            every: {
+              userCommunications: {
+                every: {
+                  campaignName: {
+                    not: options.campaignName,
+                  },
+                },
+              },
             },
           },
         },
-      }),
+      ),
       hasValidPhoneNumber: true,
       smsStatus: {
         in: [

--- a/src/inngest/functions/sms/utils/communicationJourney.ts
+++ b/src/inngest/functions/sms/utils/communicationJourney.ts
@@ -8,7 +8,6 @@ export type CreatedCommunicationJourneys = Awaited<ReturnType<typeof createCommu
 export async function createCommunicationJourneys(
   phoneNumber: string,
   journeyType: UserCommunicationJourneyType,
-  campaignName?: string,
 ) {
   const usersWithPhoneNumber = (
     await prismaClient.user.findMany({
@@ -45,7 +44,6 @@ export async function createCommunicationJourneys(
       .map(id => ({
         userId: id,
         journeyType,
-        campaignName,
       })),
   })
 
@@ -70,12 +68,14 @@ export async function createCommunicationJourneys(
 export async function createCommunication(
   communicationJourneys: CreatedCommunicationJourneys,
   messageId: string,
+  campaignName?: string,
 ) {
   await prismaClient.userCommunication.createMany({
     data: communicationJourneys.map(({ id }) => ({
       communicationType: CommunicationType.SMS,
       messageId,
       userCommunicationJourneyId: id,
+      campaignName,
     })),
   })
 }

--- a/src/inngest/functions/sms/utils/enqueueMessages.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.ts
@@ -24,11 +24,7 @@ export async function enqueueMessages(
   const { body, journeyType, campaignName } = payload
 
   const enqueueMessagesPromise = phoneNumbers.map(async phoneNumber => {
-    const communicationJourneys = await createCommunicationJourneys(
-      phoneNumber,
-      journeyType,
-      campaignName,
-    )
+    const communicationJourneys = await createCommunicationJourneys(phoneNumber, journeyType)
 
     const message = await sendSMS({
       body,
@@ -36,7 +32,7 @@ export async function enqueueMessages(
     })
 
     if (message) {
-      await createCommunication(communicationJourneys, message.sid)
+      await createCommunication(communicationJourneys, message.sid, campaignName)
     }
 
     return message


### PR DESCRIPTION
## What changed? Why?

I moved the `campaignName` column from `UserCommunicationJourney` to `UserCommunication`.

Here's why: Each user only has one `UserCommunicationJourney` per type (like `BULK_SMS`). Since all bulk communications are tracked in `UserCommunication`, having `campaignName` in `UserCommunicationJourney` would limit us to just one bulk campaign, which isn’t accurate. By moving `campaignName` to `UserCommunication`, we can track multiple bulk campaigns.

## PlanetScale deploy request

[#47](https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/47)

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
