### PR TITLE
Fix: google translate breaking swc-web

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -53,7 +53,7 @@ export default function Layout({ children, params }: PageProps & { children: Rea
   }
 
   return (
-    <html lang={locale}>
+    <html lang={locale} translate="no">
       <body className={fontClassName}>
         <OverrideGlobalLocalStorage />
         <NextTopLoader

--- a/src/app/embedded/email/unsubscribe-success/layout.tsx
+++ b/src/app/embedded/email/unsubscribe-success/layout.tsx
@@ -27,7 +27,7 @@ export const viewport: Viewport = defaultViewport
 
 export default function Layout({ children }: PageProps & { children: React.ReactNode }) {
   return (
-    <html lang={SupportedLocale.EN_US}>
+    <html lang={SupportedLocale.EN_US} translate="no">
       <body className={fontClassName}>
         <OverrideGlobalLocalStorage />
         <FullHeight.Container>

--- a/src/app/embedded/map/layout.tsx
+++ b/src/app/embedded/map/layout.tsx
@@ -40,7 +40,7 @@ export const viewport: Viewport = {
 
 export default function Layout({ children }: PageProps & { children: React.ReactNode }) {
   return (
-    <html lang={SupportedLocale.EN_US}>
+    <html lang={SupportedLocale.EN_US} translate="no">
       <body className={cn(fontClassName, 'bg-black')}>
         <OverrideGlobalLocalStorage />
         <FullHeight.Container>

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -21,7 +21,7 @@ export default function GlobalErrorPage({
   })
 
   return (
-    <html lang="en">
+    <html lang="en" translate="no">
       <body className={cn(fontClassName, 'flex h-screen content-center items-center')}>
         <ErrorPagesContent reset={reset} />
       </body>

--- a/src/components/app/defaultLocaleLayout.tsx
+++ b/src/components/app/defaultLocaleLayout.tsx
@@ -15,7 +15,7 @@ export const dynamic = 'error'
 
 export function DefaultLocaleLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" translate="no">
       <body className={fontClassName}>
         {/* LATER-TASK add back once https://github.com/TheSGJ/nextjs-toploader/issues/66 is resolved */}
         {/* <NextTopLoader /> */}


### PR DESCRIPTION
closes #1188 

fixes  <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

Users that are using google translate are having an issue after logging in that causes the page to break and the user gets stuck on the global error page. This is being caused by google translate messing with react dom. This PR fixes this issue preventing google translate to translate swc-web pages.

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
