### PR TITLE
Fix wrong completed action numbers in profile page

### DIFF
--- a/src/utils/shared/getUserActionsProgress.ts
+++ b/src/utils/shared/getUserActionsProgress.ts
@@ -1,5 +1,5 @@
 import { UserActionType } from '@prisma/client'
-import uniq from 'lodash-es/uniq'
+import { uniqBy } from 'lodash-es'
 
 import { USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP } from '@/utils/shared/userActionCampaigns'
 import { USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN } from '@/utils/web/userActionUtils'
@@ -28,7 +28,10 @@ export function getUserActionsProgress({
       : USER_ACTIONS_EXCLUDED_FROM_CTA,
   )
 
-  const numActionsCompleted = uniq(performedUserActionTypes).reduce((count, action) => {
+  const numActionsCompleted = uniqBy(
+    performedUserActionTypes,
+    action => `${action.actionType}-${action.campaignName}`,
+  ).reduce((count, action) => {
     return excludeUserActionTypes.has(action.actionType) ||
       action.campaignName !== USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP[action.actionType]
       ? count


### PR DESCRIPTION
closes #1196

## What changed? Why?

This PR fixes the calc around completed user actions

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test


## Proof of solution:
![image](https://github.com/user-attachments/assets/ec3b2d11-04a3-4aa0-a59a-0f88e10c8103)
![image](https://github.com/user-attachments/assets/b4831db9-1b6c-4412-b776-551290f54b49)

7 is the expected number here