### PR TITLE
Reactivates Join E2E test

### DIFF
--- a/cypress/e2e/12-action-join-stand-with-crypto.cy.ts
+++ b/cypress/e2e/12-action-join-stand-with-crypto.cy.ts
@@ -3,7 +3,7 @@
 describe('action - join stand with crypto', () => {
   // Temporarily skipping this test because we need to update a Thirdweb API key configuration
   // and the person responsible for this is OOO
-  it.skip('should join stand with crypto, logout and ask for profile update once', () => {
+  it('should join stand with crypto, ask for profile update and then logout', () => {
     cy.visit('/')
 
     cy.get('button').contains('Join Stand With Crypto').click()
@@ -15,20 +15,12 @@ describe('action - join stand with crypto', () => {
     cy.contains('You joined Stand With Crypto!').should('be.visible')
     cy.get('[role="dialog"]').find('button').contains('Close').click({ force: true })
 
-    cy.waitForLogout()
-
-    // login again and assert that no profile is asked to be updated
-    cy.get('button').contains('Join Stand With Crypto').click()
-
-    cy.waitForLogin()
-    // click next to update profile and submit
-    cy.get('button[type="submit"]').contains('Next').click()
-    cy.contains('Submit').should('be.visible').click()
-
-    // wait for content to show up
-    cy.wait(500)
-
     // asserts that join with crypto is done and not clickable
     cy.contains('Join Stand With Crypto').should('exist').should('not.be.enabled')
+
+    cy.waitForLogout()
+
+    // asserts that join with crypto is clickable again after logout
+    cy.contains('Join Stand With Crypto').should('exist').should('be.enabled')
   })
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -151,9 +151,6 @@ Cypress.Commands.add('waitForProfileCreation', (customUser = mockRandomUser) => 
     .scrollIntoView()
     .click()
 
-  // selects the first option Anonymous as how the user wants to be displayed
-  cy.contains('Submit').should('be.visible').click()
-
   cy.wait(500)
 
   cy.contains('Profile updated')


### PR DESCRIPTION
## What changed? Why?

This PR reactivates the join e2e test to test login and update profile flow.

## Notes to reviewers

As we are mocking the login by generating a random wallet each time cypress clicks on the test login button, the old flow of login -> update profile -> logout -> don't ask for profile update again won't work because each login click now generates a new user.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
