### PR TITLE
fix: add validation for active request in voter pledge races

### DIFF
--- a/src/components/app/userActionFormVoterAttestation/index.tsx
+++ b/src/components/app/userActionFormVoterAttestation/index.tsx
@@ -71,6 +71,8 @@ export function UserActionFormVoterAttestation({
   })
 
   const racesByAddressRequest = useRacesByAddress(address?.description)
+  const isRacesByAddressRequestActive = React.useRef(!!address?.description)
+  isRacesByAddressRequestActive.current = !!address?.description
 
   const addressProps: AddressProps = {
     initialValues: address
@@ -90,8 +92,7 @@ export function UserActionFormVoterAttestation({
   sectionPropsRef.current = sectionProps
   React.useEffect(() => {
     const { error, data, isLoading } = racesByAddressRequest
-
-    if (isLoading) {
+    if (isLoading || !isRacesByAddressRequestActive.current) {
       return
     }
 


### PR DESCRIPTION

fixes PROD-SWC-WEB-4G5

## What changed? Why?

This is adding a validation for error and success treatments to the races requests on the pledge flow when the request is not active

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
