### PR TITLE
style: adjust actions email template

### DIFF
--- a/src/utils/server/email/templates/ui/heading.tsx
+++ b/src/utils/server/email/templates/ui/heading.tsx
@@ -9,6 +9,7 @@ export const headingVariantsConfig = {
     lg: 'text-3xl',
     md: 'text-xl',
     sm: 'text-base md:text-lg',
+    xs: 'text-sm md:text-base',
   },
   gutterBottom: {
     none: '',

--- a/src/utils/server/email/templates/ui/keepUpTheFightSection.tsx
+++ b/src/utils/server/email/templates/ui/keepUpTheFightSection.tsx
@@ -66,7 +66,7 @@ export function KeepUpTheFightSection({
               />
             </Column>
             <Column className="px-4">
-              <Heading align="start" as="h3" size="sm">
+              <Heading align="start" as="h3" size="xs">
                 {metadata.text}
               </Heading>
               <Text className="text-foreground-muted my-0">{metadata.subtext}</Text>

--- a/src/utils/server/email/templates/ui/keepUpTheFightSection.tsx
+++ b/src/utils/server/email/templates/ui/keepUpTheFightSection.tsx
@@ -56,16 +56,16 @@ export function KeepUpTheFightSection({
                 width="24"
               />
             </Column>
-            <Column className="hidden w-[100px] pr-4 md:table-cell">
+            <Column className="hidden h-[100px] w-[100px] rounded-xl bg-black md:table-cell">
               <Img
                 alt={`${metadata.type} action icon`}
-                className="rounded-xl bg-black"
-                height="100"
+                className="m-auto"
+                height="80"
                 src={buildTemplateInternalUrl(metadata.image, hrefSearchParams)}
-                width="100"
+                width="80"
               />
             </Column>
-            <Column className="pr-4">
+            <Column className="px-4">
               <Heading align="start" as="h3" size="sm">
                 {metadata.text}
               </Heading>


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged --> https://github.com/Stand-With-Crypto/swc-web/issues/1215

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

added more padding around action images 

before:
![image](https://github.com/user-attachments/assets/01e5c7b1-56c2-4249-9ce7-139aa3a21942)

after: 
![image](https://github.com/user-attachments/assets/d9f1c576-344d-4e46-83ff-65ec2a7822a7)


<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
