### PR TITLE
fix: remove default bulk welcome

### DIFF
--- a/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
+++ b/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
@@ -77,7 +77,8 @@ export const bulkSMSCommunicationJourney = inngest.createFunction(
         phoneNumber,
         messages: [
           {
-            body: WELCOME_MESSAGE,
+            // TODO: We're testing a new variant to send welcome text in the same bulk message
+            // body: WELCOME_MESSAGE,
             journeyType: UserCommunicationJourneyType.WELCOME_SMS,
           },
           {

--- a/src/inngest/functions/sms/utils/communicationJourney.ts
+++ b/src/inngest/functions/sms/utils/communicationJourney.ts
@@ -66,6 +66,7 @@ export async function createCommunicationJourneys(
         in: usersWithPhoneNumber,
       },
       journeyType,
+      campaignName,
     },
     select: {
       id: true,


### PR DESCRIPTION
## What changed? Why?

We intend to test a new variation of bulk messages by sending the legal disclaimer along with the actual bulk text, so to do this we need to remove the default welcome message that's being sent in the bulk sms

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
