### PR TITLE
fix: pool connection limit exceeded

### DIFF
--- a/src/inngest/functions/sms/utils/communicationJourney.ts
+++ b/src/inngest/functions/sms/utils/communicationJourney.ts
@@ -179,7 +179,6 @@ export async function bulkCreateCommunicationJourney(
         }
 
         return {
-          ...user,
           messageId: message.messageId,
           userCommunicationJourneyId: communicationJourney.id,
           communicationType: CommunicationType.SMS,

--- a/src/inngest/functions/sms/utils/communicationJourney.ts
+++ b/src/inngest/functions/sms/utils/communicationJourney.ts
@@ -1,4 +1,4 @@
-import { CommunicationType, UserCommunicationJourneyType } from '@prisma/client'
+import { CommunicationType, Prisma, UserCommunicationJourneyType } from '@prisma/client'
 import { NonRetriableError } from 'inngest'
 
 import { prismaClient } from '@/utils/server/prismaClient'
@@ -90,4 +90,105 @@ export async function createCommunication(
       userCommunicationJourneyId: id,
     })),
   })
+}
+
+export const DEFAULT_CAMPAIGN_NAME = 'default'
+
+export type BulkCreateCommunicationJourneyPayload = Record<
+  string, // campaign name || DEFAULT_CAMPAIGN_NAME
+  Array<{ phoneNumber: string; messageId: string }>
+>
+
+export async function bulkCreateCommunicationJourney(
+  journeyType: UserCommunicationJourneyType,
+  payload: BulkCreateCommunicationJourneyPayload,
+) {
+  const getCampaignName = (campaignName: string) =>
+    campaignName === DEFAULT_CAMPAIGN_NAME ? undefined : campaignName
+
+  for (const campaignKey of Object.keys(payload)) {
+    const campaignName = getCampaignName(campaignKey)
+
+    const users = await prismaClient.user.findMany({
+      where: {
+        phoneNumber: {
+          in: payload[campaignKey].map(({ phoneNumber }) => phoneNumber),
+        },
+      },
+      select: {
+        id: true,
+        phoneNumber: true,
+      },
+    })
+
+    if (!campaignName && !journeyTypesWithSingleJourney.includes(journeyType)) {
+      throw new NonRetriableError(`Please inform a campaign name for journey ${journeyType}`)
+    }
+
+    const usersWithExistingCommunicationJourney = (
+      await prismaClient.userCommunicationJourney.findMany({
+        where: {
+          userId: {
+            in: users.map(({ id }) => id),
+          },
+          journeyType,
+          campaignName,
+        },
+        select: {
+          userId: true,
+        },
+      })
+    ).map(({ userId }) => userId)
+
+    await prismaClient.userCommunicationJourney.createMany({
+      data: users
+        .filter(({ id }) => !usersWithExistingCommunicationJourney.includes(id))
+        .map(({ id }) => ({
+          journeyType,
+          campaignName,
+          userId: id,
+        })),
+    })
+
+    const createdCommunicationJourneys = await prismaClient.userCommunicationJourney.findMany({
+      where: {
+        userId: {
+          in: users.map(({ id }) => id),
+        },
+        journeyType,
+        campaignName,
+      },
+      select: {
+        id: true,
+        userId: true,
+      },
+    })
+
+    const createCommunicationPayload = users
+      .map(user => {
+        // Using phone number here because multiple users can have the same phone number
+        const message = payload[campaignKey].find(
+          ({ phoneNumber }) => phoneNumber === user.phoneNumber,
+        )
+        const communicationJourney = createdCommunicationJourneys.find(
+          ({ userId }) => userId === user.id,
+        )
+
+        if (!message?.messageId || !communicationJourney?.id) {
+          return
+        }
+
+        return {
+          ...user,
+          messageId: message.messageId,
+          userCommunicationJourneyId: communicationJourney.id,
+          communicationType: CommunicationType.SMS,
+        }
+      })
+      .filter(communication => !!communication) as Prisma.UserCommunicationCreateManyArgs['data']
+
+    await prismaClient.userCommunication.createMany({
+      data: createCommunicationPayload,
+    })
+  }
 }

--- a/src/inngest/functions/sms/utils/enqueueMessages.test.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.test.ts
@@ -21,6 +21,7 @@ jest.mock('@/utils/shared/sleep', () => ({
 jest.mock('@/inngest/functions/sms/utils/communicationJourney', () => ({
   createCommunication: jest.fn(),
   createCommunicationJourneys: jest.fn(),
+  bulkCreateCommunicationJourney: jest.fn(),
 }))
 
 jest.mock('@/inngest/functions/sms/utils/flagInvalidPhoneNumbers', () => ({

--- a/src/inngest/functions/sms/utils/enqueueMessages.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.ts
@@ -1,12 +1,18 @@
 import { UserCommunicationJourneyType } from '@prisma/client'
 import * as Sentry from '@sentry/node'
 import { NonRetriableError } from 'inngest'
+import { update } from 'lodash-es'
 
 import { countSegments, sendSMS, SendSMSError } from '@/utils/server/sms'
 import { getLogger } from '@/utils/shared/logger'
 import { sleep } from '@/utils/shared/sleep'
 
-import { createCommunication, createCommunicationJourneys, flagInvalidPhoneNumbers } from '.'
+import {
+  bulkCreateCommunicationJourney,
+  BulkCreateCommunicationJourneyPayload,
+  DEFAULT_CAMPAIGN_NAME,
+} from './communicationJourney'
+import { flagInvalidPhoneNumbers } from './flagInvalidPhoneNumbers'
 
 const MAX_RETRY_ATTEMPTS = 5
 const PAYLOAD_LIMIT = 10000
@@ -32,6 +38,9 @@ export async function enqueueMessages(payload: EnqueueMessagePayload[], attempt 
 
   const invalidPhoneNumbers: string[] = []
   const failedPhoneNumbers: Record<string, EnqueueMessagePayload['messages']> = {}
+  const messagesSentByJourneyType: {
+    [key in UserCommunicationJourneyType]?: BulkCreateCommunicationJourneyPayload
+  } = {}
 
   let segmentsSent = 0
   let queuedMessages = 0
@@ -40,12 +49,6 @@ export async function enqueueMessages(payload: EnqueueMessagePayload[], attempt 
       const { body, journeyType, campaignName } = message
 
       try {
-        const communicationJourneys = await createCommunicationJourneys(
-          phoneNumber,
-          journeyType,
-          campaignName,
-        )
-
         if (body) {
           const queuedMessage = await sendSMS({
             body,
@@ -53,7 +56,17 @@ export async function enqueueMessages(payload: EnqueueMessagePayload[], attempt 
           })
 
           if (queuedMessage) {
-            await createCommunication(communicationJourneys, queuedMessage.sid)
+            update(
+              messagesSentByJourneyType,
+              [journeyType, campaignName ?? DEFAULT_CAMPAIGN_NAME],
+              (existingPayload = []) => [
+                ...existingPayload,
+                {
+                  messageId: queuedMessage.sid,
+                  phoneNumber,
+                },
+              ],
+            )
           }
 
           segmentsSent += countSegments(body)
@@ -96,6 +109,12 @@ export async function enqueueMessages(payload: EnqueueMessagePayload[], attempt 
   await Promise.all(enqueueMessagesPromise)
 
   logger.info(`Attempt ${attempt + 1} queued ${queuedMessages} messages (${segmentsSent} segments)`)
+
+  for (const journeyTypeKey of Object.keys(messagesSentByJourneyType)) {
+    const journeyType = journeyTypeKey as UserCommunicationJourneyType
+
+    await bulkCreateCommunicationJourney(journeyType, messagesSentByJourneyType[journeyType]!)
+  }
 
   if (invalidPhoneNumbers.length > 0) {
     logger.info(`Found ${invalidPhoneNumbers.length} invalid phone numbers`)

--- a/src/inngest/functions/sms/utils/enqueueMessages.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.ts
@@ -71,6 +71,18 @@ export async function enqueueMessages(payload: EnqueueMessagePayload[], attempt 
 
           segmentsSent += countSegments(body)
           queuedMessages += 1
+        } else if (journeyType === UserCommunicationJourneyType.WELCOME_SMS) {
+          // TODO: remove this when we finish testing the new welcome sms variant
+          update(
+            messagesSentByJourneyType,
+            [journeyType, DEFAULT_CAMPAIGN_NAME],
+            (existingPayload = []) => [
+              ...existingPayload,
+              {
+                phoneNumber,
+              },
+            ],
+          )
         }
       } catch (error) {
         if (error instanceof SendSMSError) {
@@ -112,6 +124,8 @@ export async function enqueueMessages(payload: EnqueueMessagePayload[], attempt 
 
   for (const journeyTypeKey of Object.keys(messagesSentByJourneyType)) {
     const journeyType = journeyTypeKey as UserCommunicationJourneyType
+
+    logger.info(`Creating ${journeyType} communication journey`)
 
     await bulkCreateCommunicationJourney(journeyType, messagesSentByJourneyType[journeyType]!)
   }


### PR DESCRIPTION
closes #1223 

fixes PROD-SWC-WEB-4KD

## What changed? Why?

Previously, `enqueueMessages` was invoking `createCommunicationJourneys` and `createCommunication` for each message, leading to a **pool connection limit exceeded** error. The new approach with `bulkCreateCommunicationJourney` reduces database interactions by consolidating them into a single call per `journeyType`.

### Example: Sending Bulk SMS to 1000 Users Who Did Not Receive a Welcome Message

Users are divided into 2 chunks of **500**.

#### Previous Implementation:

- For each chunk of 500 users and 2 message types (BULK + WELCOME):
  - (500 messages * 3 findMany calls) * 2 message types = 3000 * 2 chunks = 6000 findMany calls
  - (500 messages * 2 createMany calls) * 2 message types = 2000 * 2 chunks = 4000 createMany calls

#### New Implementation:

- For each chunk of 500 users and 2 message types (BULK + WELCOME):
  - 3 findMany calls * 2 message types = 6 * 2 chunks = 12 findMany calls
  - 2 createMany calls * 2 message types = 4 * 2 chunks = 8 createMany calls

This optimization significantly reduces the number of database calls, improving efficiency and avoiding connection limit issues.

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
