### PR TITLE
Creates new confirm registration form

### DIFF
--- a/src/components/app/userActionFormVoterRegistration/constants.ts
+++ b/src/components/app/userActionFormVoterRegistration/constants.ts
@@ -4,6 +4,7 @@ export enum SectionNames {
   SURVEY = 'Survey',
   VOTER_REGISTRATION_FORM = 'Voter Registration Form',
   CHECK_REGISTRATION_FORM = 'Check Registration Form',
+  CONFIRM_REGISTRATION_FORM = 'Confirm Registration Form',
   CLAIM_NFT = 'Claim NFT',
   ACCOUNT_REGISTRATION = 'Account Registration',
   SUCCESS = 'Success',

--- a/src/components/app/userActionFormVoterRegistration/index.tsx
+++ b/src/components/app/userActionFormVoterRegistration/index.tsx
@@ -49,6 +49,15 @@ export function UserActionFormVoterRegistration({
             {...sectionProps}
           />
         )
+      case SectionNames.CONFIRM_REGISTRATION_FORM:
+        return (
+          <VoterRegistrationForm
+            registrationConfirm
+            setStateCode={setStateCode}
+            stateCode={stateCode}
+            {...sectionProps}
+          />
+        )
       case SectionNames.CLAIM_NFT:
         return <ClaimNft stateCode={stateCode} {...sectionProps} />
       case SectionNames.ACCOUNT_REGISTRATION:

--- a/src/components/app/userActionFormVoterRegistration/sections/survey.tsx
+++ b/src/components/app/userActionFormVoterRegistration/sections/survey.tsx
@@ -36,7 +36,7 @@ export function Survey({ goToSection }: SurveyProps) {
             <div className="flex flex-grow flex-col items-center gap-3 lg:flex-row lg:justify-center">
               <Button
                 className="w-full lg:w-auto"
-                onClick={createSelectionHandler(SectionNames.CLAIM_NFT)}
+                onClick={createSelectionHandler(SectionNames.CONFIRM_REGISTRATION_FORM)}
                 size="lg"
                 variant="secondary"
               >

--- a/src/components/app/userActionFormVoterRegistration/sections/voterRegistrationForm.tsx
+++ b/src/components/app/userActionFormVoterRegistration/sections/voterRegistrationForm.tsx
@@ -37,6 +37,12 @@ const COPY = {
     step2: 'Check voter registration',
     step2Cta: 'Check',
   },
+  registrationConfirm: {
+    title: 'Awesome, thank you for being registered',
+    subtitle: "Let's double check your information to make sure you have no issues voting.",
+    step2: 'Check voter registration',
+    step2Cta: 'Check',
+  },
 } as const
 
 const WY_DISCLAIMER =
@@ -87,22 +93,25 @@ function disclaimer(stateCode: USStateCode | undefined) {
 
 interface VoterRegistrationFormProps extends UseSectionsReturn<SectionNames> {
   checkRegistration?: boolean
+  registrationConfirm?: boolean
   stateCode?: USStateCode
   setStateCode: Dispatch<SetStateAction<USStateCode | undefined>>
 }
 
 export function VoterRegistrationForm({
   checkRegistration,
+  registrationConfirm,
   goToSection,
   stateCode,
   setStateCode,
 }: VoterRegistrationFormProps) {
   const [completeStep2, setCompleteStep2] = useState(false)
 
-  const { title, subtitle, step2, step2Cta } = useMemo(
-    () => COPY[checkRegistration ? 'checkRegistration' : 'register'],
-    [checkRegistration],
-  )
+  const { title, subtitle, step2, step2Cta } = useMemo(() => {
+    if (registrationConfirm) return COPY.registrationConfirm
+
+    return checkRegistration ? COPY.checkRegistration : COPY.register
+  }, [checkRegistration, registrationConfirm])
 
   const link = stateCode
     ? REGISTRATION_URLS_BY_STATE[stateCode][


### PR DESCRIPTION
## What changed? Why?

This PR adds a new confirm registration step for  users who have registered to vote because it's important for these folks to check their registration because they might have had an issue come up, their address might be out of date, etc

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
