### PR TITLE
Show 'Profile' instead of wallet hash for users without info

### DIFF
--- a/src/components/app/navbar/navbarLoggedInButton/index.tsx
+++ b/src/components/app/navbar/navbarLoggedInButton/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useEvent } from 'react-use'
 
 import { Button } from '@/components/ui/button'
@@ -18,9 +18,18 @@ export function NavbarLoggedInButton({ onOpenChange }: { onOpenChange: (open: bo
   const [isLoggingOut, setIsLoggingOut] = useState(false)
 
   const userWithMaybeEnsData = useUserWithMaybeENSData()
-  const displayName = userWithMaybeEnsData
-    ? getSensitiveDataUserDisplayName(userWithMaybeEnsData)
-    : null
+
+  const displayName = useMemo(() => {
+    if (!userWithMaybeEnsData) return null
+
+    const hasUserProvidedInfo =
+      userWithMaybeEnsData.firstName || userWithMaybeEnsData.primaryUserEmailAddress?.emailAddress
+    if (!hasUserProvidedInfo) {
+      return 'Profile'
+    }
+
+    return getSensitiveDataUserDisplayName(userWithMaybeEnsData)
+  }, [userWithMaybeEnsData])
 
   const handleLogoutEvent = useCallback(() => {
     setIsLoggingOut(oldState => !oldState)


### PR DESCRIPTION
closes #1170

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

Signup with wallet/phone number and not finishing the profile:
![image](https://github.com/user-attachments/assets/418d15b8-46c8-4b19-9da2-201c891d3ffa)

After finishing the profile:
![image](https://github.com/user-attachments/assets/4f5338db-28dd-426b-975a-899b197d4c9f)

Signup with email, without providing a name:
![image](https://github.com/user-attachments/assets/47c10e32-d973-4797-93c3-da28b2d91f9b)



<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
