### PR TITLE
Fix: State events dialog showing past events

### DIFF
--- a/src/components/app/pageEvents/components/eventsMap.tsx
+++ b/src/components/app/pageEvents/components/eventsMap.tsx
@@ -2,7 +2,6 @@
 
 import { MouseEvent, useCallback, useEffect, useMemo, useState } from 'react'
 import { ComposableMap, Geographies, Geography, Marker } from 'react-simple-maps'
-import { isAfter } from 'date-fns'
 import { AnimatePresence, motion } from 'framer-motion'
 
 import {
@@ -34,18 +33,8 @@ export function EventsMap({ events }: { events: SWCEvents }) {
   const currentStroke = '#DAC5FF'
   const currentHoverAndPressedFill = '#DDC9FF'
 
-  const filteredFutureEvents = useMemo(() => {
-    return events.filter(event => {
-      const eventDate = event.data?.time
-        ? new Date(`${event.data.date}T${event.data.time}`)
-        : new Date(event.data.date)
-
-      return isAfter(eventDate, new Date())
-    })
-  }, [events])
-
   const eventsFromState = useMemo(() => {
-    const stateWithEvents = filteredFutureEvents.reduce(
+    const stateWithEvents = events.reduce(
       (acc, event) => {
         const state = event.data.state
         acc[state] = (acc[state] || 0) + 1
@@ -55,7 +44,7 @@ export function EventsMap({ events }: { events: SWCEvents }) {
     )
 
     return stateWithEvents
-  }, [filteredFutureEvents])
+  }, [events])
 
   const eventsFromStateKeys = Object.keys(eventsFromState)
 

--- a/src/components/app/pageEvents/components/eventsNearYou.tsx
+++ b/src/components/app/pageEvents/components/eventsNearYou.tsx
@@ -70,7 +70,7 @@ export function _EventsNearYou({ events }: EventsNearYouProps) {
 
 function FilteredEventsNearUser({ events, userState }: { events: SWCEvents; userState: string }) {
   const filteredEventsNearUser = useMemo(() => {
-    return userState ? events.filter(event => event.data.state === userState) : []
+    return events.filter(event => event.data.state === userState)
   }, [events, userState])
 
   const hasEvents = filteredEventsNearUser.length > 0

--- a/src/components/app/pageEvents/components/eventsNearYou.tsx
+++ b/src/components/app/pageEvents/components/eventsNearYou.tsx
@@ -2,7 +2,6 @@
 
 import { Suspense, useMemo } from 'react'
 import Balancer from 'react-wrap-balancer'
-import { isAfter } from 'date-fns'
 
 import { EventCard } from '@/components/app/pageEvents/components/eventCard'
 import { GooglePlacesSelect } from '@/components/ui/googlePlacesSelect'
@@ -71,15 +70,7 @@ export function _EventsNearYou({ events }: EventsNearYouProps) {
 
 function FilteredEventsNearUser({ events, userState }: { events: SWCEvents; userState: string }) {
   const filteredEventsNearUser = useMemo(() => {
-    return userState
-      ? events.filter(event => {
-          const eventDate = event.data?.time
-            ? new Date(`${event.data.date}T${event.data.time}`)
-            : new Date(event.data.date)
-
-          return event.data.state === userState && isAfter(eventDate, new Date())
-        })
-      : []
+    return userState ? events.filter(event => event.data.state === userState) : []
   }, [events, userState])
 
   const hasEvents = filteredEventsNearUser.length > 0

--- a/src/components/app/pageEvents/components/stateEventsDialogContent.tsx
+++ b/src/components/app/pageEvents/components/stateEventsDialogContent.tsx
@@ -72,7 +72,7 @@ interface StateDialogEventCardProps {
 }
 
 function StateDialogEventCard({ event }: StateDialogEventCardProps) {
-  const formattedEventDate = format(new Date(event.date), 'MMMM d, yyyy')
+  const formattedEventDate = format(new Date(`${event.date}T00:00`), 'MMMM d, yyyy')
 
   return (
     <div className="flex w-full max-w-[856px] flex-col gap-2 rounded-2xl bg-backgroundAlternate p-6 pt-4 transition hover:bg-backgroundAlternate/60 lg:flex-row lg:items-center lg:p-4 lg:pt-4">

--- a/src/components/app/pageEvents/components/upcomingEvents.tsx
+++ b/src/components/app/pageEvents/components/upcomingEvents.tsx
@@ -23,21 +23,11 @@ export function UpcomingEventsList({ events }: UpcomingEventsProps) {
   const [eventsToShow, setEventsToShow] = useState(5)
   const [selectedStateFilter, setSelectedStateFilter] = useState('All')
 
-  const filteredFutureEvents = useMemo(() => {
-    return events.filter(event => {
-      const eventDate = event.data?.time
-        ? new Date(`${event.data.date}T${event.data.time}`)
-        : new Date(event.data.date)
-
-      return isAfter(eventDate, new Date())
-    })
-  }, [events])
-
   const filteredEvents = useMemo(() => {
     const result =
       selectedStateFilter === 'All'
-        ? filteredFutureEvents
-        : filteredFutureEvents.filter(event => event.data.state === selectedStateFilter)
+        ? events
+        : events.filter(event => event.data.state === selectedStateFilter)
 
     const orderedResult = result.sort((a, b) => {
       const aDate = a.data.time ? new Date(`${a.data.date}T${a.data.time}`) : new Date(a.data.date)
@@ -47,10 +37,10 @@ export function UpcomingEventsList({ events }: UpcomingEventsProps) {
     })
 
     return orderedResult
-  }, [filteredFutureEvents, selectedStateFilter])
+  }, [events, selectedStateFilter])
 
   const stateFilterOptions = useMemo(() => {
-    const stateWithEvents = filteredFutureEvents.reduce(
+    const stateWithEvents = events.reduce(
       (acc, event) => {
         const state = event.data.state
         acc[state] = (acc[state] || 0) + 1
@@ -69,7 +59,7 @@ export function UpcomingEventsList({ events }: UpcomingEventsProps) {
     options.unshift({ key: 'All', name: 'All' })
 
     return options
-  }, [filteredFutureEvents])
+  }, [events])
 
   return (
     <>

--- a/src/components/app/pageEvents/eventsPageDialogDeeplinkLayout.tsx
+++ b/src/components/app/pageEvents/eventsPageDialogDeeplinkLayout.tsx
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import React, { cloneElement, ReactElement } from 'react'
+import { isAfter, parseISO, subDays } from 'date-fns'
 import { X } from 'lucide-react'
 
 import NotFound from '@/app/not-found'
@@ -34,6 +35,10 @@ export async function EventsPageDialogDeeplinkLayout({
     return NotFound()
   }
 
+  const filteredFutureEvents = events.filter(event =>
+    isAfter(parseISO(event.data.date), subDays(new Date(), 1)),
+  )
+
   return (
     <>
       <InternalLink
@@ -42,14 +47,14 @@ export async function EventsPageDialogDeeplinkLayout({
         replace
       />
       <div className={cn(dialogContentStyles, 'min-h-[200px]')}>
-        {cloneElement(children, { events })}
+        {cloneElement(children, { events: filteredFutureEvents })}
         <InternalLink className={dialogCloseStyles} href={urls.events()} replace>
           <X size={20} />
           <span className="sr-only">Close</span>
         </InternalLink>
       </div>
 
-      <EventsPage events={events!} isDeepLink />
+      <EventsPage events={filteredFutureEvents!} isDeepLink />
     </>
   )
 }

--- a/src/components/app/pageEvents/index.tsx
+++ b/src/components/app/pageEvents/index.tsx
@@ -1,3 +1,5 @@
+import { isAfter, parseISO, subDays } from 'date-fns'
+
 import { GeoGate } from '@/components/app/geoGate'
 import { AllUpcomingEvents } from '@/components/app/pageEvents/components/allUpcomingEvents'
 import { EventsIntro } from '@/components/app/pageEvents/components/eventsIntro'
@@ -13,6 +15,10 @@ interface EventsPageProps {
 }
 
 export function EventsPage({ events, isDeepLink }: EventsPageProps) {
+  const filteredFutureEvents = events.filter(event =>
+    isAfter(parseISO(event.data.date), subDays(new Date(), 1)),
+  )
+
   return (
     <div
       className={cn(
@@ -22,13 +28,13 @@ export function EventsPage({ events, isDeepLink }: EventsPageProps) {
     >
       <EventsIntro />
 
-      <PromotedEvents events={events} />
+      <PromotedEvents events={filteredFutureEvents} />
 
       <GeoGate countryCode={DEFAULT_SUPPORTED_COUNTRY_CODE} unavailableContent={null}>
-        <EventsNearYou events={events} />
+        <EventsNearYou events={filteredFutureEvents} />
       </GeoGate>
 
-      <AllUpcomingEvents events={events} />
+      <AllUpcomingEvents events={filteredFutureEvents} />
 
       {/* <FeaturedPastEvents events={events} /> */}
     </div>


### PR DESCRIPTION
closes #1280

## What changed? Why?

This PR fixes the state events dialog problem of showing past events. You can check the current error here: https://standwithcrypto.org/events/ga 

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
