### PR TITLE
feat: add global privacy control awareness

### DIFF
--- a/src/components/app/cookieConsent/cookieConsent.tsx
+++ b/src/components/app/cookieConsent/cookieConsent.tsx
@@ -19,8 +19,13 @@ export default function CookieConsent({
   locale,
   debug = process.env.NEXT_PUBLIC_DEBUG_COOKIE_CONSENT === 'true',
 }: CookieConsentProps) {
-  const { acceptAllCookies, rejectAllOptionalCookies, acceptSpecificCookies, acceptedCookies } =
-    useCookieConsent()
+  const {
+    acceptAllCookies,
+    rejectAllOptionalCookies,
+    acceptSpecificCookies,
+    acceptedCookies,
+    hasGlobalPrivacyControl,
+  } = useCookieConsent()
   const [shouldShowBanner, setShouldShowBanner] = React.useState(() => debug || !acceptedCookies)
 
   const handleActionThenClose = React.useCallback(
@@ -32,7 +37,7 @@ export default function CookieConsent({
     [setShouldShowBanner],
   )
 
-  if (!shouldShowBanner) {
+  if (hasGlobalPrivacyControl || !shouldShowBanner) {
     return null
   }
 

--- a/src/components/app/cookieConsent/useCookieConsent.ts
+++ b/src/components/app/cookieConsent/useCookieConsent.ts
@@ -9,16 +9,17 @@ import {
 } from '@/utils/shared/cookieConsent'
 import { setClientCookieConsent } from '@/utils/web/clientCookieConsent'
 
+const REJECTED_VALUES = {
+  functional: false,
+  performance: false,
+  targeting: false,
+}
+
 export function useCookieConsent() {
   const [cookieConsentCookie, setCookieConsentCookie, removeCookieConsentCookie] = useCookieState(
     COOKIE_CONSENT_COOKIE_NAME,
   )
 
-  const rejectAllValues = {
-    functional: false,
-    performance: false,
-    targeting: false,
-  }
   const hasGlobalPrivacyControl =
     typeof window !== 'undefined' && !!window.navigator?.globalPrivacyControl
 
@@ -41,7 +42,7 @@ export function useCookieConsent() {
   )
 
   const rejectAllOptionalCookies = React.useCallback(() => {
-    acceptSpecificCookies(rejectAllValues)
+    acceptSpecificCookies(REJECTED_VALUES)
   }, [acceptSpecificCookies])
 
   const acceptAllCookies = React.useCallback(() => {
@@ -54,8 +55,8 @@ export function useCookieConsent() {
 
   useEffect(() => {
     if (hasGlobalPrivacyControl) {
-      setCookieConsentCookie(serializeCookieConsent(rejectAllValues))
-      setClientCookieConsent(rejectAllValues)
+      setCookieConsentCookie(serializeCookieConsent(REJECTED_VALUES))
+      setClientCookieConsent(REJECTED_VALUES)
     }
   }, [])
 

--- a/src/components/app/cookieConsent/useCookieConsent.ts
+++ b/src/components/app/cookieConsent/useCookieConsent.ts
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import Cookies from 'js-cookie'
 import mixpanel from 'mixpanel-browser'
 
@@ -13,6 +13,14 @@ export function useCookieConsent() {
   const [cookieConsentCookie, setCookieConsentCookie, removeCookieConsentCookie] = useCookieState(
     COOKIE_CONSENT_COOKIE_NAME,
   )
+
+  const rejectAllValues = {
+    functional: false,
+    performance: false,
+    targeting: false,
+  }
+  const hasGlobalPrivacyControl =
+    typeof window !== 'undefined' && !!window.navigator?.globalPrivacyControl
 
   const toggleProviders = React.useCallback((permissions: CookieConsentPermissions) => {
     if (!permissions.targeting) {
@@ -33,11 +41,7 @@ export function useCookieConsent() {
   )
 
   const rejectAllOptionalCookies = React.useCallback(() => {
-    acceptSpecificCookies({
-      functional: false,
-      performance: false,
-      targeting: false,
-    })
+    acceptSpecificCookies(rejectAllValues)
   }, [acceptSpecificCookies])
 
   const acceptAllCookies = React.useCallback(() => {
@@ -48,12 +52,20 @@ export function useCookieConsent() {
     })
   }, [acceptSpecificCookies])
 
+  useEffect(() => {
+    if (hasGlobalPrivacyControl) {
+      setCookieConsentCookie(serializeCookieConsent(rejectAllValues))
+      setClientCookieConsent(rejectAllValues)
+    }
+  }, [])
+
   return {
     acceptSpecificCookies,
     rejectAllOptionalCookies,
     acceptAllCookies,
     resetCookieConsent: removeCookieConsentCookie,
     acceptedCookies: !!cookieConsentCookie,
+    hasGlobalPrivacyControl,
   }
 }
 

--- a/src/utils/shared/executionEnvironment.ts
+++ b/src/utils/shared/executionEnvironment.ts
@@ -4,6 +4,10 @@ declare global {
   interface Window {
     Cypress: unknown
   }
+
+  interface Navigator {
+    globalPrivacyControl?: boolean
+  }
 }
 
 export const isCypress = Boolean(

--- a/src/utils/web/clientAnalytics.ts
+++ b/src/utils/web/clientAnalytics.ts
@@ -16,6 +16,8 @@ const NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN = requiredEnv(
 const environmentHasAnalyticsEnabled =
   !isStorybook && !isCypress && !!NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN
 
+const hasTargetingEnabled = getClientCookieConsent().targeting
+
 let init = false
 export function maybeInitClientAnalytics() {
   if (!init) {
@@ -27,7 +29,7 @@ export function maybeInitClientAnalytics() {
   }
 }
 export function identifyClientAnalyticsUser(userId: string) {
-  if (environmentHasAnalyticsEnabled) {
+  if (environmentHasAnalyticsEnabled && hasTargetingEnabled) {
     maybeInitClientAnalytics()
     mixpanel.identify(userId)
   }
@@ -57,7 +59,7 @@ export function trackClientAnalytic(eventName: string, _eventProperties?: Analyt
   )
 
   maybeInitClientAnalytics()
-  const hasTargetingEnabled = getClientCookieConsent().targeting
+
   if (environmentHasAnalyticsEnabled && hasTargetingEnabled) {
     mixpanel.track(eventName, eventProperties)
   }


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged --> https://github.com/Stand-With-Crypto/swc-internal/issues/167

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

Global privacy control on new browsers and if the user enables it, we must not track or show cookies consent banners whatsoever

https://globalprivacycontrol.org/
https://global-privacy-control.glitch.me/

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
