### PR TITLE
feat: updates user actions on profile page after the user completes an action

### DIFF
--- a/src/components/app/pageUserProfile/index.tsx
+++ b/src/components/app/pageUserProfile/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { UserActionType } from '@prisma/client'
 import { sumBy, uniq } from 'lodash-es'
 
@@ -15,6 +17,7 @@ import { FormattedNumber } from '@/components/ui/formattedNumber'
 import { PageSubTitle } from '@/components/ui/pageSubTitle'
 import { PageTitle } from '@/components/ui/pageTitleText'
 import { Progress } from '@/components/ui/progress'
+import { useApiResponseForUserFullProfileInfo } from '@/hooks/useApiResponseForUserFullProfileInfo'
 import { PageProps } from '@/types'
 import { SupportedFiatCurrencyCodes } from '@/utils/shared/currency'
 import { getUserActionsProgress } from '@/utils/shared/getUserActionsProgress'
@@ -35,7 +38,12 @@ interface PageUserProfile extends PageProps {
 export function PageUserProfile({ params, user }: PageUserProfile) {
   const { locale } = params
 
-  const { userActions } = user
+  const { data } = useApiResponseForUserFullProfileInfo()
+
+  const { userActions: userActionsFromLoadedUserInServerSide } = user
+
+  const userActions = data?.user?.userActions ?? userActionsFromLoadedUserInServerSide
+
   const performedUserActionTypes = uniq(
     userActions.map(x => ({ actionType: x.actionType, campaignName: x.campaignName })),
   )

--- a/src/components/app/userActionFormSuccessScreen/index.tsx
+++ b/src/components/app/userActionFormSuccessScreen/index.tsx
@@ -33,6 +33,12 @@ export function UserActionFormSuccessScreen(props: UserActionFormSuccessScreenPr
 
   useEffectOnce(props.onLoad ?? noop)
 
+  useEffectOnce(() => {
+    // This revalidation is used to revalidate the user's completed actions list
+    // after they complete any action
+    void mutate(apiUrls.userFullProfileInfo())
+  })
+
   if (!isLoggedIn || !user) {
     return <JoinSWC onClose={onClose} />
   }


### PR DESCRIPTION
closes #1279

## What changed? Why?

This PR fixes the issue where the list of completed actions is not updated upon action complete on profile page

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
