### PR TITLE
fix: bulk sms timeout

### DIFF
--- a/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
+++ b/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
@@ -153,8 +153,6 @@ export const bulkSMSCommunicationJourney = inngest.createFunction(
 
     let segmentsInQueue = 0
     let timeToEmptyQueue = 0
-    // Previously we were trying to fill the queue in one single inngest step, but it was causing some errors when queuing more then 6k messages
-    // https://stand-with-crypto.sentry.io/issues/5691014147/events/84a3cb3472c14dcc85faa7845b045314/
     for (let i = 0; i < payloadChunks.length; i += 1) {
       const payloadChunk = payloadChunks[i]
 

--- a/src/utils/server/sms/messagingClient.ts
+++ b/src/utils/server/sms/messagingClient.ts
@@ -5,6 +5,6 @@ import { requiredEnv } from '@/utils/shared/requiredEnv'
 const TWILIO_ACCOUNT_SID = requiredEnv(process.env.TWILIO_ACCOUNT_SID, 'TWILIO_ACCOUNT_SID')
 const TWILIO_AUTH_TOKEN = requiredEnv(process.env.TWILIO_AUTH_TOKEN, 'TWILIO_AUTH_TOKEN')
 
-export const TWILIO_RATE_LIMIT = 500
+export const TWILIO_RATE_LIMIT = 750
 
 export const messagingClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)

--- a/src/utils/server/sms/sendSMS.ts
+++ b/src/utils/server/sms/sendSMS.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { requiredEnv } from '@/utils/shared/requiredEnv'
+import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
 import { apiUrls, fullUrl } from '@/utils/shared/urls'
 
 import { messagingClient } from './messagingClient'
@@ -26,7 +27,10 @@ export const sendSMS = async (payload: SendSMSPayload) => {
   const { body, to, media } = validatedInput.data
 
   try {
-    const statusCallback = fullUrl(apiUrls.smsStatusCallback())
+    let statusCallback
+    if (NEXT_PUBLIC_ENVIRONMENT !== 'local') {
+      statusCallback = fullUrl(apiUrls.smsStatusCallback())
+    }
 
     const message = await messagingClient.messages.create({
       from: TWILIO_PHONE_NUMBER,


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes [PROD-SWC-WEB-4ET](https://stand-with-crypto.sentry.io/issues/5691014147/events/84a3cb3472c14dcc85faa7845b045314/)

## What changed? Why?

Right now, we're queuing all messages in a single Inngest step, but this is causing timeout errors on Vercel because the step takes too long. This PR changes that by sending a batch of 750 messages per step.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
