### PR TITLE
refactor: add ens extra avatar format parsing

### DIFF
--- a/src/utils/server/formatENSAvatar.ts
+++ b/src/utils/server/formatENSAvatar.ts
@@ -1,5 +1,8 @@
 import * as Sentry from '@sentry/nextjs'
-// expand this as we learn about additional formats
+/**
+ * expand this as we learn about additional formats
+ * https://docs.ens.domains/web/avatars#uri-schemas
+ */
 export function formatENSAvatar(avatar: string) {
   avatar = avatar.trim()
 
@@ -11,6 +14,9 @@ export function formatENSAvatar(avatar: string) {
   }
   if (avatar.startsWith('ipfs://')) {
     avatar = `https://ipfs.io/ipfs/${avatar.slice(7)}`
+    return avatar
+  }
+  if (avatar.startsWith('data:image/svg+xml;base64')) {
     return avatar
   }
   Sentry.captureMessage(`Unknown ENS avatar format`, {

--- a/src/utils/shared/parseENSImageUrl/index.ts
+++ b/src/utils/shared/parseENSImageUrl/index.ts
@@ -9,6 +9,10 @@ const RESOLVERS = [
     match: (url: string) => url.startsWith('ipfs://'),
     resolve: (url: string) => `https://ipfs.io/ipfs/${url.slice(7)}`,
   },
+  {
+    match: (url: string) => url.startsWith('data:image/svg+xml;base64'),
+    resolve: (url: string) => url,
+  },
 ]
 
 export function parseENSImageUrl(avatar: string) {

--- a/src/utils/shared/parseENSImageUrl/parseENSAvatarUrl.test.ts
+++ b/src/utils/shared/parseENSImageUrl/parseENSAvatarUrl.test.ts
@@ -16,4 +16,9 @@ describe('utils/parseENSImageUrl', () => {
       'https://ipfs.io/ipfs/QmZzQW8DjZ5hBvQGjXkzJ7fZ1R8j2k1Q2h2X1tBZJ9rZoU',
     )
   })
+
+  it('should return the url itself for data:image/svg+xml;base64 urls', () => {
+    const url = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmci'
+    expect(parseENSImageUrl(url)).toBe(url)
+  })
 })


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged --> https://github.com/Stand-With-Crypto/swc-web/issues/1264
 
fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes --> https://stand-with-crypto.sentry.io/issues/5003561526/?referrer=github_integration

## What changed? Why?

allow for data uri avatar images such as below:

![image](https://github.com/user-attachments/assets/94000c2c-ed1f-49ee-abf0-4ea7850352a5)
![image](https://github.com/user-attachments/assets/808c5cbb-82b7-4654-86bc-2ffab13bcd68)


<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
