### PR TITLE
Prevents broken address from being processed on backfill repeatedly

### DIFF
--- a/src/actions/actionCreateUserActionViewKeyRaces.ts
+++ b/src/actions/actionCreateUserActionViewKeyRaces.ts
@@ -114,7 +114,7 @@ async function _actionCreateUserActionViewKeyRaces(input: CreateActionViewKeyRac
 
   const userAddressCongressionalDistrict =
     userAddress?.address?.usCongressionalDistrict &&
-    userAddress?.address?.usCongressionalDistrict !== 'NOT_FOUND'
+    userAddress?.address?.usCongressionalDistrict !== '0'
       ? userAddress?.address?.usCongressionalDistrict
       : null
 

--- a/src/actions/actionCreateUserActionViewKeyRaces.ts
+++ b/src/actions/actionCreateUserActionViewKeyRaces.ts
@@ -112,8 +112,14 @@ async function _actionCreateUserActionViewKeyRaces(input: CreateActionViewKeyRac
     { stateCode: currentUsaState as keyof typeof US_STATE_CODE_TO_DISPLAY_NAME_MAP },
   )) as GetCongressionalDistrictFromAddressSuccess
 
+  const userAddressCongressionalDistrict =
+    userAddress?.address?.usCongressionalDistrict &&
+    userAddress?.address?.usCongressionalDistrict !== 'NOT_FOUND'
+      ? userAddress?.address?.usCongressionalDistrict
+      : null
+
   const currentCongressionalDistrict =
-    userAddress?.address?.usCongressionalDistrict ||
+    userAddressCongressionalDistrict ||
     validatedInput.data?.usCongressionalDistrict ||
     maybeCongressionalDistrict?.districtNumber?.toString() ||
     null

--- a/src/inngest/functions/backfillCongressionalDistrictCronJob/index.ts
+++ b/src/inngest/functions/backfillCongressionalDistrictCronJob/index.ts
@@ -127,6 +127,34 @@ async function backfillUsCongressionalDistricts(
           },
         })
       }
+      if (
+        ['NOT_USA_ADDRESS', 'NOT_SAME_STATE', 'NOT_SPECIFIC_ENOUGH'].includes(
+          usCongressionalDistrict.notFoundReason,
+        )
+      ) {
+        logger.info(
+          `No usCongressionalDistrict found for address ${address.id} because ${usCongressionalDistrict.notFoundReason}. Updating the usCongressionalDistrict to NOT_FOUND`,
+        )
+
+        try {
+          await prismaClient.address.update({
+            where: {
+              id: address.id,
+            },
+            data: {
+              usCongressionalDistrict: 'NOT_FOUND',
+            },
+          })
+        } catch (error) {
+          Sentry.captureException(error, {
+            tags: {
+              domain: 'backfillUsCongressionalDistricts',
+              message: 'error getting upserting address congressional district metadata',
+            },
+          })
+        }
+      }
+
       continue
     }
 

--- a/src/inngest/functions/backfillCongressionalDistrictCronJob/index.ts
+++ b/src/inngest/functions/backfillCongressionalDistrictCronJob/index.ts
@@ -128,12 +128,15 @@ async function backfillUsCongressionalDistricts(
         })
       }
       if (
-        ['NOT_USA_ADDRESS', 'NOT_SAME_STATE', 'NOT_SPECIFIC_ENOUGH'].includes(
-          usCongressionalDistrict.notFoundReason,
-        )
+        [
+          'NOT_USA_ADDRESS',
+          'NOT_SAME_STATE',
+          'NOT_SPECIFIC_ENOUGH',
+          'CIVIC_API_BAD_REQUEST',
+        ].includes(usCongressionalDistrict.notFoundReason)
       ) {
         logger.info(
-          `No usCongressionalDistrict found for address ${address.id} because ${usCongressionalDistrict.notFoundReason}. Updating the usCongressionalDistrict to NOT_FOUND`,
+          `No usCongressionalDistrict found for address ${address.id} because ${usCongressionalDistrict.notFoundReason}. Updating the usCongressionalDistrict to 0`,
         )
 
         try {
@@ -142,7 +145,7 @@ async function backfillUsCongressionalDistricts(
               id: address.id,
             },
             data: {
-              usCongressionalDistrict: 'NOT_FOUND',
+              usCongressionalDistrict: '0',
             },
           })
         } catch (error) {

--- a/src/utils/server/externalOptIn/handleExternalUserActionViewKeyRaces.ts
+++ b/src/utils/server/externalOptIn/handleExternalUserActionViewKeyRaces.ts
@@ -86,7 +86,7 @@ export async function handleExternalUserActionViewKeyRaces(
 
   const userAddressCongressionalDistrict =
     userAddress?.address?.usCongressionalDistrict &&
-    userAddress?.address?.usCongressionalDistrict !== 'NOT_FOUND'
+    userAddress?.address?.usCongressionalDistrict !== '0'
       ? userAddress?.address?.usCongressionalDistrict
       : null
 
@@ -190,7 +190,7 @@ async function updateUserActionViewKeyRaces(
   const updateData: Record<string, string | undefined> = {
     ...(usaState !== null && { usaState }),
     ...(usCongressionalDistrict !== null &&
-      usCongressionalDistrict !== 'NOT_FOUND' && { usCongressionalDistrict }),
+      usCongressionalDistrict !== '0' && { usCongressionalDistrict }),
   }
 
   return prismaClient.userAction.update({

--- a/src/utils/server/externalOptIn/handleExternalUserActionViewKeyRaces.ts
+++ b/src/utils/server/externalOptIn/handleExternalUserActionViewKeyRaces.ts
@@ -84,8 +84,14 @@ export async function handleExternalUserActionViewKeyRaces(
     { stateCode: currentUsaState as keyof typeof US_STATE_CODE_TO_DISPLAY_NAME_MAP },
   )) as GetCongressionalDistrictFromAddressSuccess
 
+  const userAddressCongressionalDistrict =
+    userAddress?.address?.usCongressionalDistrict &&
+    userAddress?.address?.usCongressionalDistrict !== 'NOT_FOUND'
+      ? userAddress?.address?.usCongressionalDistrict
+      : null
+
   const currentCongressionalDistrict =
-    userAddress?.address?.usCongressionalDistrict ||
+    userAddressCongressionalDistrict ||
     usCongressionalDistrict ||
     maybeCongressionalDistrict?.districtNumber?.toString() ||
     null
@@ -183,7 +189,8 @@ async function updateUserActionViewKeyRaces(
 ) {
   const updateData: Record<string, string | undefined> = {
     ...(usaState !== null && { usaState }),
-    ...(usCongressionalDistrict !== null && { usCongressionalDistrict }),
+    ...(usCongressionalDistrict !== null &&
+      usCongressionalDistrict !== 'NOT_FOUND' && { usCongressionalDistrict }),
   }
 
   return prismaClient.userAction.update({

--- a/src/utils/shared/getCongressionalDistrictFromAddress.ts
+++ b/src/utils/shared/getCongressionalDistrictFromAddress.ts
@@ -108,6 +108,12 @@ export async function getCongressionalDistrictFromAddress(
     if (result.error.code === 429) {
       return { notFoundReason: 'CIVIC_API_QUOTA_LIMIT_REACHED' as const }
     }
+    if (result.error.code === 400) {
+      return { notFoundReason: 'CIVIC_API_BAD_REQUEST' as const }
+    }
+    if (result.error.code === 401) {
+      return { notFoundReason: 'CIVIC_API_UNAUTHORIZED' as const }
+    }
     return { notFoundReason: 'NOT_USA_ADDRESS' as const }
   }
 

--- a/src/utils/shared/googleCivicInfo.ts
+++ b/src/utils/shared/googleCivicInfo.ts
@@ -148,13 +148,15 @@ export function getGoogleCivicDataFromAddress(address: string) {
       isValidRequest: (response: Response) =>
         (response.status >= 200 && response.status < 300) ||
         response.status === 404 ||
-        response.status === 429,
+        response.status === 429 ||
+        response.status === 400 ||
+        response.status === 401,
     },
   )
     .then(res => res.json())
     .then(res => {
       const response = res as GoogleCivicInfoResponse | GoogleCivicErrorResponse
-      if ('error' in response && response.error.code === 429) {
+      if ('error' in response && [429, 400, 401].includes(response.error.code)) {
         return response
       }
       civicDataByAddressCache.set(apiUrl.toString(), response)

--- a/src/utils/shared/googleCivicInfo.ts
+++ b/src/utils/shared/googleCivicInfo.ts
@@ -111,7 +111,7 @@ export interface GoogleCivicInfoResponse {
 
 interface GoogleCivicErrorResponse {
   error: {
-    code: 404 | 429
+    code: 404 | 429 | 400 | 401
     errors: object[]
     message: string
   }


### PR DESCRIPTION
closes #1234 

## What changed? Why?

This PR saves the district number as 'NOT_FOUND' to prevent addresses that are broken from being processed everyday in the backfill cron job.


## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
