### PR TITLE
refactor: adjust dynamicParams to false when dynamic = 'error'

### DIFF
--- a/src/app/[locale]/races/page.tsx
+++ b/src/app/[locale]/races/page.tsx
@@ -6,10 +6,9 @@ import { PageProps } from '@/types'
 import { generateMetadataDetails } from '@/utils/server/metadataUtils'
 import { prismaClient } from '@/utils/server/prismaClient'
 import { SECONDS_DURATION } from '@/utils/shared/seconds'
-import { toBool } from '@/utils/shared/toBool'
 
 export const dynamic = 'error'
-export const dynamicParams = toBool(process.env.MINIMIZE_PAGE_PRE_GENERATION)
+export const dynamicParams = false
 export const revalidate = SECONDS_DURATION['10_MINUTES']
 
 type LocationUnitedStatesPageProps = PageProps

--- a/src/app/[locale]/races/state/[stateCode]/district/[district]/page.tsx
+++ b/src/app/[locale]/races/state/[stateCode]/district/[district]/page.tsx
@@ -18,7 +18,7 @@ import { zodNormalizedDTSIDistrictId } from '@/validation/fields/zodNormalizedDT
 import { zodUsaState } from '@/validation/fields/zodUsaState'
 
 export const dynamic = 'error'
-export const dynamicParams = toBool(process.env.MINIMIZE_PAGE_PRE_GENERATION)
+export const dynamicParams = false
 export const revalidate = SECONDS_DURATION['10_MINUTES']
 
 type LocationDistrictSpecificPageProps = PageProps<{

--- a/src/app/[locale]/races/state/[stateCode]/page.tsx
+++ b/src/app/[locale]/races/state/[stateCode]/page.tsx
@@ -14,7 +14,7 @@ import {
 import { zodUsaState } from '@/validation/fields/zodUsaState'
 
 export const dynamic = 'error'
-export const dynamicParams = toBool(process.env.MINIMIZE_PAGE_PRE_GENERATION)
+export const dynamicParams = false
 export const revalidate = SECONDS_DURATION['10_MINUTES']
 
 type LocationStateSpecificPageProps = PageProps<{


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged --> https://github.com/Stand-With-Crypto/swc-web/issues/1342

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
