### PR TITLE
User action form for voting_information_researched action

### DIFF
--- a/src/actions/actionCreateUserActionVotingInformationResearched.tsx
+++ b/src/actions/actionCreateUserActionVotingInformationResearched.tsx
@@ -1,0 +1,343 @@
+'use server'
+import 'server-only'
+
+import { SMSStatus, User, UserActionType, UserInformationVisibility } from '@prisma/client'
+import { waitUntil } from '@vercel/functions'
+import { nativeEnum, object, z } from 'zod'
+
+import { getClientUser } from '@/clientModels/clientUser/clientUser'
+import { getMaybeUserAndMethodOfMatch } from '@/utils/server/getMaybeUserAndMethodOfMatch'
+import { prismaClient } from '@/utils/server/prismaClient'
+import { getRequestRateLimiter } from '@/utils/server/ratelimit/throwIfRateLimited'
+import { getServerAnalytics, getServerPeopleAnalytics } from '@/utils/server/serverAnalytics'
+import {
+  mapLocalUserToUserDatabaseFields,
+  parseLocalUserFromCookies,
+} from '@/utils/server/serverLocalUser'
+import { getUserSessionId } from '@/utils/server/serverUserSessionId'
+import { withServerActionMiddleware } from '@/utils/server/serverWrappers/withServerActionMiddleware'
+import { createCountryCodeValidation } from '@/utils/server/userActionValidation/checkCountryCode'
+import { withValidations } from '@/utils/server/userActionValidation/withValidations'
+import { mapPersistedLocalUserToAnalyticsProperties } from '@/utils/shared/localUser'
+import { getLogger } from '@/utils/shared/logger'
+import { generateReferralId } from '@/utils/shared/referralId'
+import { convertAddressToAnalyticsProperties } from '@/utils/shared/sharedAnalytics'
+import { DEFAULT_SUPPORTED_COUNTRY_CODE } from '@/utils/shared/supportedCountries'
+import { UserActionVotingInformationResearchedCampaignName } from '@/utils/shared/userActionCampaigns'
+import { zodAddress } from '@/validation/fields/zodAddress'
+
+export const createActionVotingInformationResearchedInputValidationSchema = object({
+  campaignName: nativeEnum(UserActionVotingInformationResearchedCampaignName),
+  shouldReceiveNotifications: z.boolean(),
+  address: zodAddress,
+})
+
+export type CreateActionVotingInformationResearchedInput = z.infer<
+  typeof createActionVotingInformationResearchedInputValidationSchema
+>
+
+const logger = getLogger('actionCreateUserActionVotingInformationResearched')
+
+export const actionCreateUserActionVotingInformationResearched = withServerActionMiddleware(
+  'actionCreateUserActionVotingInformationResearched',
+  withValidations(
+    [createCountryCodeValidation(DEFAULT_SUPPORTED_COUNTRY_CODE)],
+    _actionCreateUserActionVotingInformationResearched,
+  ),
+)
+
+async function _actionCreateUserActionVotingInformationResearched(
+  input: CreateActionVotingInformationResearchedInput,
+) {
+  logger.info('triggered')
+  const { triggerRateLimiterAtMostOnce } = getRequestRateLimiter({
+    context: 'unauthenticated',
+  })
+
+  const validatedInput =
+    createActionVotingInformationResearchedInputValidationSchema.safeParse(input)
+  if (!validatedInput.success) {
+    return {
+      errors: validatedInput.error.flatten().fieldErrors,
+    }
+  }
+
+  const localUser = parseLocalUserFromCookies()
+  const sessionId = getUserSessionId()
+
+  const actionType = UserActionType.VOTING_INFORMATION_RESEARCHED
+  const campaignName = validatedInput.data.campaignName
+
+  const userMatch = await getMaybeUserAndMethodOfMatch({
+    prisma: {
+      include: { primaryUserCryptoAddress: true, primaryUserEmailAddress: true, address: true },
+    },
+  })
+
+  if (!userMatch.user) {
+    await triggerRateLimiterAtMostOnce()
+  }
+
+  const user =
+    userMatch.user ||
+    (await createUser({ localUser, sessionId, address: validatedInput.data.address }))
+  const isNewUser = !userMatch.user
+
+  const peopleAnalytics = getServerPeopleAnalytics({
+    localUser,
+    userId: user.id,
+  })
+  const analytics = getServerAnalytics({
+    userId: user.id,
+    localUser,
+  })
+  const beforeFinish = () => Promise.all([analytics.flush(), peopleAnalytics.flush()])
+
+  const existingVotingInformationResearchAction = await getExistingUserAction(
+    user.id,
+    validatedInput,
+  )
+  const existingActionAddress = {
+    stateCode:
+      existingVotingInformationResearchAction?.userActionVotingInformationResearched?.address
+        ?.administrativeAreaLevel1,
+    congressionalDistrict:
+      existingVotingInformationResearchAction?.userActionVotingInformationResearched?.address
+        ?.usCongressionalDistrict,
+  }
+  const newAddress = {
+    stateCode: validatedInput.data.address?.administrativeAreaLevel1,
+    congressionalDistrict: validatedInput.data.address?.usCongressionalDistrict,
+  }
+
+  if (existingVotingInformationResearchAction) {
+    logger.info(
+      `User ${user.id} has already researched voting information for ${validatedInput.data.campaignName}`,
+    )
+
+    const shouldUpdateAction =
+      existingActionAddress.stateCode !== newAddress.stateCode ||
+      existingActionAddress.congressionalDistrict !== newAddress.congressionalDistrict
+
+    if (shouldUpdateAction) {
+      const { updatedUser } = await updateAction({
+        existingVotingInformationResearchAction,
+        validatedInput,
+      })
+
+      analytics.trackUserActionUpdated({
+        actionType,
+        campaignName,
+        creationMethod: 'On Site',
+        userState: isNewUser ? 'New' : 'Existing With Updates',
+      })
+
+      waitUntil(beforeFinish())
+      return { user: getClientUser(updatedUser) }
+    }
+
+    analytics.trackUserActionCreatedIgnored({
+      actionType,
+      campaignName,
+      reason: 'Too Many Recent',
+      userState: isNewUser ? 'New' : 'Existing With Updates',
+      ...convertAddressToAnalyticsProperties(validatedInput.data.address),
+    })
+    waitUntil(beforeFinish())
+    return { user: getClientUser(user) }
+  }
+
+  await triggerRateLimiterAtMostOnce()
+  const { updatedUser } = await createActionAndUpdateUser({
+    user,
+    validatedInput,
+    sessionId,
+  })
+
+  analytics.trackUserActionCreated({
+    actionType,
+    campaignName,
+    userState: !userMatch.user ? 'New' : 'Existing',
+    ...convertAddressToAnalyticsProperties(validatedInput.data.address),
+  })
+  peopleAnalytics.set({
+    ...convertAddressToAnalyticsProperties(validatedInput.data.address),
+  })
+
+  waitUntil(beforeFinish())
+  return { user: getClientUser(updatedUser) }
+}
+
+async function getExistingUserAction(
+  userId: User['id'],
+  validatedInput: z.SafeParseSuccess<CreateActionVotingInformationResearchedInput>,
+) {
+  return prismaClient.userAction.findFirst({
+    where: {
+      actionType: UserActionType.VOTING_INFORMATION_RESEARCHED,
+      campaignName: validatedInput.data.campaignName,
+      user: {
+        id: userId,
+      },
+    },
+    include: {
+      userActionVotingInformationResearched: {
+        include: {
+          address: true,
+        },
+      },
+    },
+  })
+}
+
+async function createUser({
+  localUser,
+  sessionId,
+  address,
+}: {
+  localUser: ReturnType<typeof parseLocalUserFromCookies>
+  sessionId: ReturnType<typeof getUserSessionId>
+  address?: z.infer<typeof zodAddress>
+}) {
+  const createdUser = await prismaClient.user.create({
+    data: {
+      referralId: generateReferralId(),
+      informationVisibility: UserInformationVisibility.ANONYMOUS,
+      userSessions: { create: { id: sessionId } },
+      hasOptedInToEmails: false,
+      hasOptedInToMembership: false,
+      smsStatus: SMSStatus.NOT_OPTED_IN,
+      ...(address
+        ? {
+            address: {
+              connectOrCreate: {
+                where: { googlePlaceId: address.googlePlaceId },
+                create: address,
+              },
+            },
+          }
+        : {}),
+      ...mapLocalUserToUserDatabaseFields(localUser),
+    },
+    include: {
+      primaryUserCryptoAddress: true,
+      address: true,
+    },
+  })
+  logger.info('created user')
+
+  if (localUser?.persisted) {
+    waitUntil(
+      getServerPeopleAnalytics({ localUser, userId: createdUser.id })
+        .setOnce(mapPersistedLocalUserToAnalyticsProperties(localUser.persisted))
+        .flush(),
+    )
+  }
+
+  return createdUser
+}
+
+async function createActionAndUpdateUser({
+  user,
+  validatedInput,
+  sessionId,
+}: {
+  user: User
+  validatedInput: z.SafeParseSuccess<CreateActionVotingInformationResearchedInput>
+  sessionId: ReturnType<typeof getUserSessionId>
+}) {
+  const userAction = await prismaClient.userAction.create({
+    data: {
+      user: { connect: { id: user.id } },
+      actionType: UserActionType.VOTING_INFORMATION_RESEARCHED,
+      campaignName: validatedInput.data.campaignName,
+      ...(user.primaryUserCryptoAddressId
+        ? {
+            userCryptoAddress: { connect: { id: user.primaryUserCryptoAddressId } },
+          }
+        : { userSession: { connect: { id: sessionId } } }),
+      userActionVotingInformationResearched: {
+        create: {
+          shouldReceiveNotifications: validatedInput.data.shouldReceiveNotifications,
+          address: {
+            connectOrCreate: {
+              where: { googlePlaceId: validatedInput.data.address.googlePlaceId },
+              create: validatedInput.data.address,
+            },
+          },
+        },
+      },
+    },
+    include: {
+      userActionVotingInformationResearched: true,
+    },
+  })
+
+  const updatedUser = await prismaClient.user.update({
+    where: { id: user.id },
+    data: {
+      address: {
+        connectOrCreate: {
+          where: { googlePlaceId: validatedInput.data.address.googlePlaceId },
+          create: validatedInput.data.address,
+        },
+      },
+    },
+    include: {
+      primaryUserCryptoAddress: true,
+      address: true,
+    },
+  })
+  logger.info('created user action and updated user')
+
+  return { userAction, updatedUser }
+}
+
+async function updateAction({
+  existingVotingInformationResearchAction,
+  validatedInput,
+}: {
+  existingVotingInformationResearchAction: NonNullable<
+    Awaited<ReturnType<typeof getExistingUserAction>>
+  >
+  validatedInput: z.SafeParseSuccess<CreateActionVotingInformationResearchedInput>
+}) {
+  const updatedAction = await prismaClient.userAction.update({
+    where: { id: existingVotingInformationResearchAction.id },
+    data: {
+      userActionVotingInformationResearched: {
+        update: {
+          shouldReceiveNotifications: validatedInput.data.shouldReceiveNotifications,
+          address: {
+            connectOrCreate: {
+              where: { googlePlaceId: validatedInput.data.address.googlePlaceId },
+              create: validatedInput.data.address,
+            },
+          },
+        },
+      },
+    },
+    include: {
+      userActionVotingInformationResearched: true,
+    },
+  })
+
+  const updatedUser = await prismaClient.user.update({
+    where: { id: existingVotingInformationResearchAction.userId },
+    data: {
+      address: {
+        connectOrCreate: {
+          where: { googlePlaceId: validatedInput.data.address.googlePlaceId },
+          create: validatedInput.data.address,
+        },
+      },
+    },
+    include: {
+      primaryUserCryptoAddress: true,
+      address: true,
+    },
+  })
+
+  logger.info('updated user action and user')
+  return { updatedAction, updatedUser }
+}

--- a/src/actions/actionCreateUserActionVotingInformationResearched.tsx
+++ b/src/actions/actionCreateUserActionVotingInformationResearched.tsx
@@ -26,7 +26,7 @@ import { DEFAULT_SUPPORTED_COUNTRY_CODE } from '@/utils/shared/supportedCountrie
 import { UserActionVotingInformationResearchedCampaignName } from '@/utils/shared/userActionCampaigns'
 import { zodAddress } from '@/validation/fields/zodAddress'
 
-export const createActionVotingInformationResearchedInputValidationSchema = object({
+const createActionVotingInformationResearchedInputValidationSchema = object({
   campaignName: nativeEnum(UserActionVotingInformationResearchedCampaignName),
   shouldReceiveNotifications: z.boolean(),
   address: zodAddress,
@@ -100,14 +100,14 @@ async function _actionCreateUserActionVotingInformationResearched(
   const existingActionAddress = {
     stateCode:
       existingVotingInformationResearchAction?.userActionVotingInformationResearched?.address
-        ?.administrativeAreaLevel1,
+        ?.administrativeAreaLevel1 ?? null,
     congressionalDistrict:
       existingVotingInformationResearchAction?.userActionVotingInformationResearched?.address
-        ?.usCongressionalDistrict,
+        ?.usCongressionalDistrict ?? null,
   }
   const newAddress = {
-    stateCode: validatedInput.data.address?.administrativeAreaLevel1,
-    congressionalDistrict: validatedInput.data.address?.usCongressionalDistrict,
+    stateCode: validatedInput.data.address?.administrativeAreaLevel1 ?? null,
+    congressionalDistrict: validatedInput.data.address?.usCongressionalDistrict ?? null,
   }
 
   if (existingVotingInformationResearchAction) {

--- a/src/components/app/userActionFormVotingInformationResearched/dialog.tsx
+++ b/src/components/app/userActionFormVotingInformationResearched/dialog.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useCallback } from 'react'
+import dynamic from 'next/dynamic'
+import { useSearchParams } from 'next/navigation'
+import { z } from 'zod'
+
+import { UserActionFormDialog } from '@/components/app/userActionFormCommon/dialog'
+import { LoadingOverlay } from '@/components/ui/loadingOverlay'
+import { useApiResponseForUserFullProfileInfo } from '@/hooks/useApiResponseForUserFullProfileInfo'
+import { useDialog } from '@/hooks/useDialog'
+import { useSession } from '@/hooks/useSession'
+import { openWindow } from '@/utils/shared/openWindow'
+import { UserActionVotingInformationResearchedCampaignName } from '@/utils/shared/userActionCampaigns'
+import { getUSStateNameFromStateCode } from '@/utils/shared/usStateUtils'
+import { zodAddress } from '@/validation/fields/zodAddress'
+
+import { FORM_NAME } from './formConfig'
+
+const UserActionFormVotingInformationResearched = dynamic(
+  () =>
+    import('@/components/app/userActionFormVotingInformationResearched').then(
+      mod => mod.UserActionFormVotingInformationResearched,
+    ),
+  {
+    loading: () => (
+      <div className="min-h-[400px]">
+        <LoadingOverlay />
+      </div>
+    ),
+  },
+)
+
+const buildElectoralUrl = (address: z.infer<typeof zodAddress>) => {
+  const baseUrl = 'https://turbovote.org/'
+  const state = address.administrativeAreaLevel1
+  const electionDate = '2024-11-05'
+
+  const params = new URLSearchParams({
+    street: `${address.streetNumber} ${address.route}`,
+    city: getUSStateNameFromStateCode(state),
+    state,
+    zip: address.postalCode,
+  })
+
+  return new URL(`/elections/${state.toLowerCase()}/${electionDate}?${params.toString()}`, baseUrl)
+}
+
+export function UserActionFormVotingInformationResearchedDialog({
+  children,
+  defaultOpen = false,
+}: {
+  children: React.ReactNode
+  defaultOpen?: boolean
+}) {
+  const searchParams = useSearchParams()
+
+  const dialogProps = useDialog({
+    initialOpen: defaultOpen,
+    analytics: FORM_NAME,
+  })
+
+  const { user, isLoading } = useSession()
+  const { mutate } = useApiResponseForUserFullProfileInfo()
+
+  const handleSuccess = useCallback(
+    (address: z.infer<typeof zodAddress>) => {
+      void mutate()
+      const target = searchParams?.get('target') ?? '_blank'
+      const url = buildElectoralUrl(address)
+      openWindow(url.toString(), target, `noopener`)
+      dialogProps.onOpenChange(false)
+    },
+    [dialogProps, mutate, searchParams],
+  )
+
+  return (
+    <UserActionFormDialog {...dialogProps} trigger={children}>
+      {isLoading ? (
+        <div className="min-h-[400px]">
+          <LoadingOverlay />
+        </div>
+      ) : (
+        <UserActionFormVotingInformationResearched
+          initialValues={{
+            address: user?.address
+              ? {
+                  description: user?.address?.formattedDescription,
+                  place_id: user?.address?.googlePlaceId,
+                }
+              : undefined,
+            campaignName: UserActionVotingInformationResearchedCampaignName['2024_ELECTION'],
+            shouldReceiveNotifications: false,
+          }}
+          onSuccess={handleSuccess}
+        />
+      )}
+    </UserActionFormDialog>
+  )
+}

--- a/src/components/app/userActionFormVotingInformationResearched/formConfig.ts
+++ b/src/components/app/userActionFormVotingInformationResearched/formConfig.ts
@@ -1,0 +1,35 @@
+import { boolean, nativeEnum, object, type z } from 'zod'
+
+import { GetUserFullProfileInfoResponse } from '@/app/api/identified-user/full-profile-info/route'
+import { UserActionVotingInformationResearchedCampaignName } from '@/utils/shared/userActionCampaigns'
+import { GooglePlaceAutocompletePrediction } from '@/utils/web/googlePlaceUtils'
+import { zodGooglePlacesAutocompletePrediction } from '@/validation/fields/zodGooglePlacesAutocompletePrediction'
+
+export const FORM_NAME = 'Voting Information Researched'
+
+export const votingInformationResearchedFormValidationSchema = object({
+  address: zodGooglePlacesAutocompletePrediction,
+  campaignName: nativeEnum(UserActionVotingInformationResearchedCampaignName),
+  shouldReceiveNotifications: boolean(),
+})
+
+export type VotingInformationResearchedFormValues = z.infer<
+  typeof votingInformationResearchedFormValidationSchema
+>
+
+export function getDefaultValues({
+  user,
+}: {
+  user?: GetUserFullProfileInfoResponse['user']
+}): VotingInformationResearchedFormValues {
+  return {
+    address: user?.address
+      ? {
+          description: user?.address.formattedDescription,
+          place_id: user?.address.googlePlaceId,
+        }
+      : ({} as GooglePlaceAutocompletePrediction),
+    campaignName: UserActionVotingInformationResearchedCampaignName['2024_ELECTION'],
+    shouldReceiveNotifications: false,
+  }
+}

--- a/src/components/app/userActionFormVotingInformationResearched/index.tsx
+++ b/src/components/app/userActionFormVotingInformationResearched/index.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useRef } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { UserActionType } from '@prisma/client'
+import * as Sentry from '@sentry/nextjs'
+import { useRouter } from 'next/navigation'
+import { z } from 'zod'
+
+import { actionCreateUserActionVotingInformationResearched } from '@/actions/actionCreateUserActionVotingInformationResearched'
+import { UserActionFormLayout } from '@/components/app/userActionFormCommon'
+import { Button } from '@/components/ui/button'
+import { ErrorMessage } from '@/components/ui/errorMessage'
+import { Form, FormControl, FormField, FormItem } from '@/components/ui/form'
+import { GooglePlacesSelect } from '@/components/ui/googlePlacesSelect'
+import { useIsMobile } from '@/hooks/useIsMobile'
+import { convertAddressToAnalyticsProperties } from '@/utils/shared/sharedAnalytics'
+import { trackFormSubmissionSyncErrors, triggerServerActionForForm } from '@/utils/web/formUtils'
+import { convertGooglePlaceAutoPredictionToAddressSchema } from '@/utils/web/googlePlaceUtils'
+import { identifyUserOnClient } from '@/utils/web/identifyUser'
+import {
+  catchUnexpectedServerErrorAndTriggerToast,
+  toastGenericError,
+} from '@/utils/web/toastUtils'
+import { zodAddress } from '@/validation/fields/zodAddress'
+
+import {
+  FORM_NAME,
+  votingInformationResearchedFormValidationSchema,
+  VotingInformationResearchedFormValues,
+} from './formConfig'
+
+interface UserActionFormVotingInformationResearchedProps {
+  onSuccess: (address: z.infer<typeof zodAddress>) => void
+  initialValues?: Partial<VotingInformationResearchedFormValues>
+}
+
+export const UserActionFormVotingInformationResearched = (
+  props: UserActionFormVotingInformationResearchedProps,
+) => {
+  const { onSuccess, initialValues } = props
+
+  const router = useRouter()
+
+  const form = useForm<VotingInformationResearchedFormValues>({
+    defaultValues: initialValues,
+    resolver: zodResolver(votingInformationResearchedFormValidationSchema),
+  })
+
+  const isMobile = useIsMobile({ defaultState: true })
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const error = form.formState.errors?.root
+  const errorRef = useRef(error)
+
+  useEffect(() => {
+    if (!isMobile && !errorRef.current && !initialValues?.address) {
+      inputRef.current?.click()
+    }
+  }, [form, isMobile, initialValues])
+
+  return (
+    <UserActionFormLayout>
+      <div className="flex h-full flex-1 flex-col">
+        <div className="space-y-6">
+          <p className="text-center text-2xl font-semibold">Prepare to vote</p>
+          <p className="text-center text-fontcolor-muted">
+            Find your polling location and check to see if there are early voting options in your
+            district.
+          </p>
+
+          <div className="mx-auto w-full max-w-lg">
+            <Form {...form}>
+              <form
+                id="view-key-races-form"
+                onSubmit={form.handleSubmit(async formValues => {
+                  const address = await convertGooglePlaceAutoPredictionToAddressSchema(
+                    formValues.address,
+                  ).catch(e => {
+                    Sentry.captureException(e)
+                    catchUnexpectedServerErrorAndTriggerToast(e)
+                    return null
+                  })
+                  if (!address) {
+                    form.setError('root', {
+                      message: 'Invalid address',
+                    })
+                    return
+                  }
+                  const result = await triggerServerActionForForm(
+                    {
+                      form,
+                      formName: FORM_NAME,
+                      analyticsProps: {
+                        ...(address ? convertAddressToAnalyticsProperties(address) : {}),
+                        'Campaign Name': formValues.campaignName,
+                        'User Action Type': UserActionType.VOTING_INFORMATION_RESEARCHED,
+                        'Subscribed to notifications': formValues.shouldReceiveNotifications,
+                      },
+                      payload: { ...formValues, address },
+                      onError: (_, e) => {
+                        form.setError('root', {
+                          message: e.message,
+                        })
+                        toastGenericError()
+                      },
+                    },
+                    payload =>
+                      actionCreateUserActionVotingInformationResearched(payload).then(
+                        actionResult => {
+                          if (actionResult && 'user' in actionResult && actionResult.user) {
+                            identifyUserOnClient(actionResult.user)
+                          }
+                          return actionResult
+                        },
+                      ),
+                  )
+                  if (result.status === 'success') {
+                    router.refresh()
+                    onSuccess(address)
+                  }
+                }, trackFormSubmissionSyncErrors(FORM_NAME))}
+              >
+                <FormField
+                  control={form.control}
+                  name="address"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl aria-invalid={!!error}>
+                        <GooglePlacesSelect
+                          {...field}
+                          className="h-14 rounded-full bg-secondary"
+                          onChange={newAddress => {
+                            form.clearErrors('root')
+                            field.onChange(newAddress)
+                          }}
+                          placeholder="Your full address"
+                          ref={inputRef}
+                          value={field.value}
+                        />
+                      </FormControl>
+                      {!!error && <ErrorMessage>{error?.message}</ErrorMessage>}
+                    </FormItem>
+                  )}
+                />
+              </form>
+            </Form>
+          </div>
+        </div>
+
+        <Button
+          className="mx-auto mt-auto"
+          disabled={form.formState.isSubmitting || !form.formState.isValid}
+          form="view-key-races-form"
+          size="lg"
+          type="submit"
+        >
+          Check your voting information
+        </Button>
+      </div>
+    </UserActionFormLayout>
+  )
+}

--- a/src/components/ui/googlePlacesSelect/index.tsx
+++ b/src/components/ui/googlePlacesSelect/index.tsx
@@ -50,6 +50,7 @@ export const GooglePlacesSelect = React.forwardRef<
       language: 'en',
       types: ['street_address', 'premise', 'postal_code', 'subpremise', 'route'],
     },
+    initOnMount: false,
   })
   // For some countries, the route type is required to show addresses options correctly
   // But for US, if we allow users to use an address with the route type,


### PR DESCRIPTION
[GH-176](https://github.com/Stand-With-Crypto/swc-internal/issues/176)


## What changed? Why?

Adds the `userActionFormVotingInformationResearched` form & dialog to be used in the Voter Guide page

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

Added `initOnMount: false` to the `usePlacesAutocomplete` hook to fix the undefined maps error. We are manually initializing the hook once the `GoogleMapScript`  status is `ready`.

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
