### PR TITLE
feat: support sms message variables

### DIFF
--- a/src/inngest/functions/sms/utils/enqueueMessages.test.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.test.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { describe, expect, it } from '@jest/globals'
+import { User, UserSession } from '@prisma/client'
 
 import {
   countMessagesAndSegments,
@@ -9,6 +10,7 @@ import {
 } from '@/inngest/functions/sms/utils/enqueueMessages'
 import { flagInvalidPhoneNumbers } from '@/inngest/functions/sms/utils/flagInvalidPhoneNumbers'
 import { fakerFields } from '@/mocks/fakerUtils'
+import { mockUser } from '@/mocks/models/mockUser'
 import { sendSMS, SendSMSError } from '@/utils/server/sms'
 import { optOutUser } from '@/utils/server/sms/actions'
 import type { SendSMSPayload } from '@/utils/server/sms/sendSMS'
@@ -17,7 +19,9 @@ import {
   IS_UNSUBSCRIBED_USER_CODE,
   TOO_MANY_REQUESTS_CODE,
 } from '@/utils/server/sms/SendSMSError'
+import { getUserByPhoneNumber } from '@/utils/server/sms/utils'
 import { sleep } from '@/utils/shared/sleep'
+import { fullUrl } from '@/utils/shared/urls'
 
 const invalidPhoneNumber = fakerFields.phoneNumber()
 const optedOutUserPhoneNumber = fakerFields.phoneNumber()
@@ -162,5 +166,49 @@ describe('enqueueMessages function', () => {
 
     expect(optOutUser).toBeCalledTimes(1)
     expect(optOutUser).toBeCalledWith(optedOutUserPhoneNumber, undefined)
+  })
+
+  const mockedUser = { ...mockUser(), phoneNumber: fakerFields.phoneNumber() }
+  const mockedUserSession: UserSession | undefined = faker.helpers.maybe(() => true, {
+    probability: 0.5,
+  })
+    ? {
+        id: faker.string.uuid(),
+        datetimeCreated: faker.date.anytime(),
+        datetimeUpdated: faker.date.anytime(),
+        userId: mockedUser.id,
+      }
+    : undefined
+
+  it.each([
+    [
+      `Please, finish your profile at ${fullUrl(`/profile<%= sessionId ? "?sessionId=" + sessionId : "" %>`)}`,
+      mockedUserSession?.id
+        ? `Please, finish your profile at ${fullUrl(`/profile?sessionId=${mockedUserSession.id}`)}`
+        : `Please, finish your profile at ${fullUrl(`/profile`)}`,
+    ],
+    [
+      `<%= firstName && lastName ? firstName + " " + lastName + ", t": "T" %>hanks for subscribing to Stand With Crypto`,
+      mockedUser.firstName && mockedUser.lastName
+        ? `${mockedUser.firstName} ${mockedUser.lastName}, thanks for subscribing to Stand With Crypto`
+        : 'Thanks for subscribing to Stand With Crypto',
+    ],
+  ])('should correctly parse the sms body with custom variables', async (input, output) => {
+    // eslint-disable-next-line no-extra-semi
+    ;(getUserByPhoneNumber as jest.Mock).mockImplementation(() =>
+      Promise.resolve<User & { userSessions?: Array<typeof mockedUserSession> }>({
+        ...mockedUser,
+        userSessions: [mockedUserSession],
+      }),
+    )
+
+    await enqueueMessages([
+      {
+        messages: [{ body: input, journeyType: 'BULK_SMS' }],
+        phoneNumber: mockedUser.phoneNumber,
+      },
+    ])
+
+    expect(sendSMS).toHaveBeenCalledWith({ body: output, to: mockedUser.phoneNumber })
   })
 })

--- a/src/inngest/functions/sms/utils/enqueueMessages.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.ts
@@ -59,7 +59,7 @@ export async function enqueueMessages(payload: EnqueueMessagePayload[], attempt 
           const parsedBody = addVariablesToMessage(body, {
             firstName: user?.firstName,
             lastName: user?.lastName,
-            sessionId: user?.userSessions[0]?.id,
+            sessionId: user?.userSessions?.[0]?.id,
             userId: user?.id,
           })
 

--- a/src/inngest/functions/sms/utils/enqueueMessages.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.ts
@@ -57,10 +57,10 @@ export async function enqueueMessages(payload: EnqueueMessagePayload[], attempt 
           const user = await getUserByPhoneNumber(phoneNumber)
 
           const parsedBody = addVariablesToMessage(body, {
-            firstName: user.firstName,
-            lastName: user.lastName,
-            sessionId: user.userSessions[0].id,
-            userId: user.id,
+            firstName: user?.firstName,
+            lastName: user?.lastName,
+            sessionId: user?.userSessions[0]?.id,
+            userId: user?.id,
           })
 
           const queuedMessage = await sendSMS({

--- a/src/inngest/functions/sms/utils/enqueueMessages.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.ts
@@ -1,7 +1,7 @@
 import { UserCommunicationJourneyType } from '@prisma/client'
 import * as Sentry from '@sentry/node'
 import { NonRetriableError } from 'inngest'
-import { update } from 'lodash-es'
+import { template, update } from 'lodash-es'
 
 import { sendSMS, SendSMSError } from '@/utils/server/sms'
 import { optOutUser } from '@/utils/server/sms/actions'
@@ -54,8 +54,17 @@ export async function enqueueMessages(payload: EnqueueMessagePayload[], attempt 
 
       try {
         if (body) {
+          const user = await getUserByPhoneNumber(phoneNumber)
+
+          const parsedBody = addVariablesToMessage(body, {
+            firstName: user.firstName,
+            lastName: user.lastName,
+            sessionId: user.userSessions[0].id,
+            userId: user.id,
+          })
+
           const queuedMessage = await sendSMS({
-            body,
+            body: parsedBody,
             to: phoneNumber,
             media,
           })
@@ -74,7 +83,7 @@ export async function enqueueMessages(payload: EnqueueMessagePayload[], attempt 
             )
           }
 
-          segmentsSent += countSegments(body)
+          segmentsSent += countSegments(parsedBody)
           queuedMessages += 1
         } else {
           update(
@@ -203,4 +212,17 @@ export function countMessagesAndSegments(payload: EnqueueMessagePayload[]) {
       messages: 0,
     },
   )
+}
+
+interface Variables {
+  firstName?: string
+  lastName?: string
+  sessionId?: string
+  userId?: string
+}
+
+function addVariablesToMessage(message: string, variables: Variables) {
+  const compiled = template(message)
+
+  return compiled(variables)
 }

--- a/src/utils/server/sms/utils/getUserByPhoneNumber.ts
+++ b/src/utils/server/sms/utils/getUserByPhoneNumber.ts
@@ -9,6 +9,14 @@ export async function getUserByPhoneNumber(phoneNumber: string) {
     orderBy: {
       datetimeUpdated: 'desc',
     },
+    include: {
+      userSessions: {
+        orderBy: {
+          datetimeUpdated: 'desc',
+        },
+        take: 1,
+      },
+    },
     take: 1,
   })
 


### PR DESCRIPTION
closes [#191](https://github.com/Stand-With-Crypto/swc-internal/issues/191)

## What changed? Why?

Adds support for variables in the sms body so that we can send custom messages for each user

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [x] Unit test
- [ ] Functional test
