### PR TITLE
Revert "feat: support sms message variables (#1352)"

### DIFF
--- a/src/inngest/functions/sms/utils/enqueueMessages.test.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.test.ts
@@ -1,6 +1,5 @@
 import { faker } from '@faker-js/faker'
 import { describe, expect, it } from '@jest/globals'
-import { User, UserSession } from '@prisma/client'
 
 import {
   countMessagesAndSegments,
@@ -10,7 +9,6 @@ import {
 } from '@/inngest/functions/sms/utils/enqueueMessages'
 import { flagInvalidPhoneNumbers } from '@/inngest/functions/sms/utils/flagInvalidPhoneNumbers'
 import { fakerFields } from '@/mocks/fakerUtils'
-import { mockUser } from '@/mocks/models/mockUser'
 import { sendSMS, SendSMSError } from '@/utils/server/sms'
 import { optOutUser } from '@/utils/server/sms/actions'
 import type { SendSMSPayload } from '@/utils/server/sms/sendSMS'
@@ -19,9 +17,7 @@ import {
   IS_UNSUBSCRIBED_USER_CODE,
   TOO_MANY_REQUESTS_CODE,
 } from '@/utils/server/sms/SendSMSError'
-import { getUserByPhoneNumber } from '@/utils/server/sms/utils'
 import { sleep } from '@/utils/shared/sleep'
-import { fullUrl } from '@/utils/shared/urls'
 
 const invalidPhoneNumber = fakerFields.phoneNumber()
 const optedOutUserPhoneNumber = fakerFields.phoneNumber()
@@ -166,49 +162,5 @@ describe('enqueueMessages function', () => {
 
     expect(optOutUser).toBeCalledTimes(1)
     expect(optOutUser).toBeCalledWith(optedOutUserPhoneNumber, undefined)
-  })
-
-  const mockedUser = { ...mockUser(), phoneNumber: fakerFields.phoneNumber() }
-  const mockedUserSession: UserSession | undefined = faker.helpers.maybe(() => true, {
-    probability: 0.5,
-  })
-    ? {
-        id: faker.string.uuid(),
-        datetimeCreated: faker.date.anytime(),
-        datetimeUpdated: faker.date.anytime(),
-        userId: mockedUser.id,
-      }
-    : undefined
-
-  it.each([
-    [
-      `Please, finish your profile at ${fullUrl(`/profile<%= sessionId ? "?sessionId=" + sessionId : "" %>`)}`,
-      mockedUserSession?.id
-        ? `Please, finish your profile at ${fullUrl(`/profile?sessionId=${mockedUserSession.id}`)}`
-        : `Please, finish your profile at ${fullUrl(`/profile`)}`,
-    ],
-    [
-      `<%= firstName && lastName ? firstName + " " + lastName + ", t": "T" %>hanks for subscribing to Stand With Crypto`,
-      mockedUser.firstName && mockedUser.lastName
-        ? `${mockedUser.firstName} ${mockedUser.lastName}, thanks for subscribing to Stand With Crypto`
-        : 'Thanks for subscribing to Stand With Crypto',
-    ],
-  ])('should correctly parse the sms body with custom variables', async (input, output) => {
-    // eslint-disable-next-line no-extra-semi
-    ;(getUserByPhoneNumber as jest.Mock).mockImplementation(() =>
-      Promise.resolve<User & { userSessions?: Array<typeof mockedUserSession> }>({
-        ...mockedUser,
-        userSessions: [mockedUserSession],
-      }),
-    )
-
-    await enqueueMessages([
-      {
-        messages: [{ body: input, journeyType: 'BULK_SMS' }],
-        phoneNumber: mockedUser.phoneNumber,
-      },
-    ])
-
-    expect(sendSMS).toHaveBeenCalledWith({ body: output, to: mockedUser.phoneNumber })
   })
 })

--- a/src/utils/server/sms/utils/getUserByPhoneNumber.ts
+++ b/src/utils/server/sms/utils/getUserByPhoneNumber.ts
@@ -9,14 +9,6 @@ export async function getUserByPhoneNumber(phoneNumber: string) {
     orderBy: {
       datetimeUpdated: 'desc',
     },
-    include: {
-      userSessions: {
-        orderBy: {
-          datetimeUpdated: 'desc',
-        },
-        take: 1,
-      },
-    },
     take: 1,
   })
 


### PR DESCRIPTION
This reverts commit e0dcccf8b78818f50746e300b7a7a4b5ea7a5fd0.

closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
