### PR TITLE
fix: remove lodash template from addVariablesToMessage

### DIFF
--- a/src/inngest/functions/sms/utils/enqueueMessages.test.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.test.ts
@@ -182,17 +182,15 @@ describe('enqueueMessages function', () => {
 
   it.each([
     [
-      `Please, finish your profile at ${fullUrl(`/profile<%= sessionId ? "?sessionId=" + sessionId : "" %>`)}`,
-      mockedUserSession?.id
-        ? `Please, finish your profile at ${fullUrl(`/profile?sessionId=${mockedUserSession.id}`)}`
-        : `Please, finish your profile at ${fullUrl(`/profile`)}`,
+      `Please, finish your profile at ${fullUrl(`/profile?sessionId={{ sessionId }}`)}`,
+      `Please, finish your profile at ${fullUrl(`/profile?sessionId=${mockedUserSession?.id ?? ''}`)}`,
     ],
     [
-      `<%= firstName && lastName ? firstName + " " + lastName + ", t": "T" %>hanks for subscribing to Stand With Crypto`,
-      mockedUser.firstName && mockedUser.lastName
-        ? `${mockedUser.firstName} ${mockedUser.lastName}, thanks for subscribing to Stand With Crypto`
-        : 'Thanks for subscribing to Stand With Crypto',
+      `{{ firstName }} {{ lastName }}, thanks for subscribing to Stand With Crypto`,
+      `${mockedUser.firstName} ${mockedUser.lastName}, thanks for subscribing to Stand With Crypto`,
     ],
+    [`You received a NFT: {{ invalidVariable }}`, `You received a NFT: `],
+    ['Message with no variables', 'Message with no variables'],
   ])('should correctly parse the sms body with custom variables', async (input, output) => {
     // eslint-disable-next-line no-extra-semi
     ;(getUserByPhoneNumber as jest.Mock).mockImplementation(() =>

--- a/src/inngest/functions/sms/utils/enqueueMessages.test.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.test.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker'
 import { describe, expect, it } from '@jest/globals'
+import { User, UserSession } from '@prisma/client'
 
 import {
   countMessagesAndSegments,
@@ -9,6 +10,7 @@ import {
 } from '@/inngest/functions/sms/utils/enqueueMessages'
 import { flagInvalidPhoneNumbers } from '@/inngest/functions/sms/utils/flagInvalidPhoneNumbers'
 import { fakerFields } from '@/mocks/fakerUtils'
+import { mockUser } from '@/mocks/models/mockUser'
 import { sendSMS, SendSMSError } from '@/utils/server/sms'
 import { optOutUser } from '@/utils/server/sms/actions'
 import type { SendSMSPayload } from '@/utils/server/sms/sendSMS'
@@ -17,7 +19,9 @@ import {
   IS_UNSUBSCRIBED_USER_CODE,
   TOO_MANY_REQUESTS_CODE,
 } from '@/utils/server/sms/SendSMSError'
+import { getUserByPhoneNumber } from '@/utils/server/sms/utils'
 import { sleep } from '@/utils/shared/sleep'
+import { fullUrl } from '@/utils/shared/urls'
 
 const invalidPhoneNumber = fakerFields.phoneNumber()
 const optedOutUserPhoneNumber = fakerFields.phoneNumber()
@@ -162,5 +166,49 @@ describe('enqueueMessages function', () => {
 
     expect(optOutUser).toBeCalledTimes(1)
     expect(optOutUser).toBeCalledWith(optedOutUserPhoneNumber, undefined)
+  })
+
+  const mockedUser = { ...mockUser(), phoneNumber: fakerFields.phoneNumber() }
+  const mockedUserSession: UserSession | undefined = faker.helpers.maybe(() => true, {
+    probability: 0.5,
+  })
+    ? {
+        id: faker.string.uuid(),
+        datetimeCreated: faker.date.anytime(),
+        datetimeUpdated: faker.date.anytime(),
+        userId: mockedUser.id,
+      }
+    : undefined
+
+  it.each([
+    [
+      `Please, finish your profile at ${fullUrl(`/profile<%= sessionId ? "?sessionId=" + sessionId : "" %>`)}`,
+      mockedUserSession?.id
+        ? `Please, finish your profile at ${fullUrl(`/profile?sessionId=${mockedUserSession.id}`)}`
+        : `Please, finish your profile at ${fullUrl(`/profile`)}`,
+    ],
+    [
+      `<%= firstName && lastName ? firstName + " " + lastName + ", t": "T" %>hanks for subscribing to Stand With Crypto`,
+      mockedUser.firstName && mockedUser.lastName
+        ? `${mockedUser.firstName} ${mockedUser.lastName}, thanks for subscribing to Stand With Crypto`
+        : 'Thanks for subscribing to Stand With Crypto',
+    ],
+  ])('should correctly parse the sms body with custom variables', async (input, output) => {
+    // eslint-disable-next-line no-extra-semi
+    ;(getUserByPhoneNumber as jest.Mock).mockImplementation(() =>
+      Promise.resolve<User & { userSessions?: Array<typeof mockedUserSession> }>({
+        ...mockedUser,
+        userSessions: [mockedUserSession],
+      }),
+    )
+
+    await enqueueMessages([
+      {
+        messages: [{ body: input, journeyType: 'BULK_SMS' }],
+        phoneNumber: mockedUser.phoneNumber,
+      },
+    ])
+
+    expect(sendSMS).toHaveBeenCalledWith({ body: output, to: mockedUser.phoneNumber })
   })
 })

--- a/src/inngest/functions/sms/utils/enqueueMessages.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.ts
@@ -1,7 +1,7 @@
 import { UserCommunicationJourneyType } from '@prisma/client'
 import * as Sentry from '@sentry/node'
 import { NonRetriableError } from 'inngest'
-import { template, update } from 'lodash-es'
+import { update } from 'lodash-es'
 
 import { sendSMS, SendSMSError } from '@/utils/server/sms'
 import { optOutUser } from '@/utils/server/sms/actions'
@@ -222,7 +222,7 @@ interface Variables {
 }
 
 function addVariablesToMessage(message: string, variables: Variables) {
-  const compiled = template(message)
-
-  return compiled(variables)
+  return message.replace(/{{\s*(\w+)\s*}}/g, (_, variable: keyof Variables) =>
+    variables[variable] !== undefined ? (variables[variable] ?? '') : '',
+  )
 }

--- a/src/inngest/functions/sms/utils/enqueueMessages.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.ts
@@ -222,7 +222,8 @@ interface Variables {
 }
 
 function addVariablesToMessage(message: string, variables: Variables) {
-  return message.replace(/{{\s*(\w+)\s*}}/g, (_, variable: keyof Variables) =>
-    variables[variable] !== undefined ? (variables[variable] ?? '') : '',
+  return message.replace(
+    /{{\s*(\w+)\s*}}/g,
+    (_, variable: keyof Variables) => variables[variable] ?? '',
   )
 }

--- a/src/utils/server/sms/utils/getUserByPhoneNumber.ts
+++ b/src/utils/server/sms/utils/getUserByPhoneNumber.ts
@@ -9,6 +9,14 @@ export async function getUserByPhoneNumber(phoneNumber: string) {
     orderBy: {
       datetimeUpdated: 'desc',
     },
+    include: {
+      userSessions: {
+        orderBy: {
+          datetimeUpdated: 'desc',
+        },
+        take: 1,
+      },
+    },
     take: 1,
   })
 


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

The lodash `template` function was causing timeouts on Vercel, preventing messages from being sent, so I switched to a simpler approach using regex.

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
