### PR TITLE
Fix google places script error

### DIFF
--- a/src/hooks/useGoogleMapsScript.ts
+++ b/src/hooks/useGoogleMapsScript.ts
@@ -10,7 +10,7 @@ const NEXT_PUBLIC_GOOGLE_PLACES_API_KEY = requiredEnv(
  * See https://stackoverflow.com/a/75212692 for why we set callback to `Function.prototype`
  */
 function getGoogleMapsScriptSrc() {
-  return `https://maps.googleapis.com/maps/api/js?key=${NEXT_PUBLIC_GOOGLE_PLACES_API_KEY}&libraries=places&callback=Function.prototype`
+  return `https://maps.googleapis.com/maps/api/js?key=${NEXT_PUBLIC_GOOGLE_PLACES_API_KEY}&loading=async&libraries=places&callback=Function.prototype`
 }
 
 export function useGoogleMapsScript() {

--- a/src/hooks/useGoogleMapsScript.ts
+++ b/src/hooks/useGoogleMapsScript.ts
@@ -10,7 +10,7 @@ const NEXT_PUBLIC_GOOGLE_PLACES_API_KEY = requiredEnv(
  * See https://stackoverflow.com/a/75212692 for why we set callback to `Function.prototype`
  */
 function getGoogleMapsScriptSrc() {
-  return `https://maps.googleapis.com/maps/api/js?key=${NEXT_PUBLIC_GOOGLE_PLACES_API_KEY}&loading=async&libraries=places&callback=Function.prototype`
+  return `https://maps.googleapis.com/maps/api/js?key=${NEXT_PUBLIC_GOOGLE_PLACES_API_KEY}&libraries=places&callback=Function.prototype`
 }
 
 export function useGoogleMapsScript() {

--- a/src/hooks/usePlacesAutocompleteAddress.ts
+++ b/src/hooks/usePlacesAutocompleteAddress.ts
@@ -18,6 +18,7 @@ export function usePlacesAutocompleteAddress(address: string) {
       locationBias: 'IP_BIAS',
       language: 'en',
     },
+    initOnMount: false,
   })
   // the library returns a loading prop but it appears to always be false. Status will be an empty string unless it returns something
   const loading = !status

--- a/src/hooks/useScript.ts
+++ b/src/hooks/useScript.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import * as Sentry from '@sentry/nextjs'
 
 type UseScriptStatus = 'idle' | 'loading' | 'ready' | 'error'
 
@@ -71,13 +70,6 @@ export function useScript(src: string | null, options?: UseScriptOptions): UseSc
       scriptNode.addEventListener('error', setAttributeFromEvent)
     } else {
       setStatus(script.status ?? cachedScriptStatus ?? 'loading')
-      Sentry.captureMessage('Script node already exists', {
-        extra: {
-          src,
-          script,
-          cachedScriptStatus,
-        },
-      })
     }
 
     const setStateFromEvent = (event: Event) => {

--- a/src/hooks/useScript.ts
+++ b/src/hooks/useScript.ts
@@ -1,61 +1,106 @@
-import React from 'react'
+import { useEffect, useState } from 'react'
 import * as Sentry from '@sentry/nextjs'
 
-type Status = 'loading' | 'error' | 'ready' | 'unknown'
-// https://github.com/uidotdev/usehooks/blob/main/index.js
-export function useScript(src: string, options: { removeOnUnmount?: boolean } = {}) {
-  const [status, setStatus] = React.useState<Status>('loading')
-  const optionsRef = React.useRef(options)
+type UseScriptStatus = 'idle' | 'loading' | 'ready' | 'error'
 
-  React.useEffect(() => {
-    let script = document.querySelector<HTMLScriptElement>(`script[src="${src}"]`)
+type UseScriptOptions = {
+  shouldPreventLoad?: boolean
+  removeOnUnmount?: boolean
+  id?: string
+}
 
-    const domStatus = script?.getAttribute('data-status') as Status | null | undefined
-    if (domStatus) {
-      setStatus(domStatus)
+const cachedScriptStatuses = new Map<string, UseScriptStatus | undefined>()
+
+function getScriptNode(src: string) {
+  const node: HTMLScriptElement | null = document.querySelector(`script[src="${src}"]`)
+  const status = node?.getAttribute('data-status') as UseScriptStatus | undefined
+
+  return {
+    node,
+    status,
+  }
+}
+
+/**
+ * https://usehooks-ts.com/react-hook/use-script#hook
+ */
+export function useScript(src: string | null, options?: UseScriptOptions): UseScriptStatus {
+  const [status, setStatus] = useState<UseScriptStatus>(() => {
+    if (!src || options?.shouldPreventLoad) {
+      return 'idle'
+    }
+
+    if (typeof window === 'undefined') {
+      return 'loading'
+    }
+
+    return cachedScriptStatuses.get(src) ?? 'loading'
+  })
+
+  useEffect(() => {
+    if (!src || options?.shouldPreventLoad) {
       return
     }
 
-    if (script === null) {
-      script = document.createElement('script')
-      script.src = src
-      script.async = true
-      script.setAttribute('data-status', 'loading')
-      document.body.appendChild(script)
-
-      const handleScriptLoad = () => {
-        script!.setAttribute('data-status', 'ready')
-        setStatus('ready')
-        removeEventListeners()
-      }
-
-      const handleScriptError = () => {
-        script!.setAttribute('data-status', 'error')
-        setStatus('error')
-        removeEventListeners()
-      }
-
-      const removeEventListeners = () => {
-        script!.removeEventListener('load', handleScriptLoad)
-        script!.removeEventListener('error', handleScriptError)
-      }
-
-      script.addEventListener('load', handleScriptLoad)
-      script.addEventListener('error', handleScriptError)
-
-      const removeOnUnmount = optionsRef.current.removeOnUnmount
-
-      return () => {
-        if (removeOnUnmount === true) {
-          script!.remove()
-          removeEventListeners()
-        }
-      }
-    } else {
-      setStatus('unknown')
-      Sentry.captureMessage('Unexpected useScript state', { extra: { src, domStatus, options } })
+    const cachedScriptStatus = cachedScriptStatuses.get(src)
+    if (cachedScriptStatus === 'ready' || cachedScriptStatus === 'error') {
+      setStatus(cachedScriptStatus)
+      return
     }
-  }, [options, src])
+
+    const script = getScriptNode(src)
+    let scriptNode = script.node
+
+    if (!scriptNode) {
+      scriptNode = document.createElement('script')
+      scriptNode.src = src
+      scriptNode.async = true
+      if (options?.id) {
+        scriptNode.id = options.id
+      }
+      scriptNode.setAttribute('data-status', 'loading')
+      document.body.appendChild(scriptNode)
+
+      const setAttributeFromEvent = (event: Event) => {
+        const scriptStatus: UseScriptStatus = event.type === 'load' ? 'ready' : 'error'
+
+        scriptNode?.setAttribute('data-status', scriptStatus)
+      }
+
+      scriptNode.addEventListener('load', setAttributeFromEvent)
+      scriptNode.addEventListener('error', setAttributeFromEvent)
+    } else {
+      setStatus(script.status ?? cachedScriptStatus ?? 'loading')
+      Sentry.captureMessage('Script node already exists', {
+        extra: {
+          src,
+          script,
+          cachedScriptStatus,
+        },
+      })
+    }
+
+    const setStateFromEvent = (event: Event) => {
+      const newStatus = event.type === 'load' ? 'ready' : 'error'
+      setStatus(newStatus)
+      cachedScriptStatuses.set(src, newStatus)
+    }
+
+    scriptNode.addEventListener('load', setStateFromEvent)
+    scriptNode.addEventListener('error', setStateFromEvent)
+
+    return () => {
+      if (scriptNode) {
+        scriptNode.removeEventListener('load', setStateFromEvent)
+        scriptNode.removeEventListener('error', setStateFromEvent)
+      }
+
+      if (scriptNode && options?.removeOnUnmount) {
+        scriptNode.remove()
+        cachedScriptStatuses.delete(src)
+      }
+    }
+  }, [src, options?.shouldPreventLoad, options?.removeOnUnmount, options?.id])
 
   return status
 }


### PR DESCRIPTION
closes #1349 

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

Added `initOnMount: false` to ensure that the `usePlacesAutocomplete` hook only initializes after the google maps script is loaded.

Also added `&loading=async` to fix this warning
![image](https://github.com/user-attachments/assets/212418a9-299f-4e33-923d-93c9d73439ec)

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
