### PR TITLE
Disables user actions not directly related to the election

### DIFF
--- a/cypress/e2e/04-action-email-your-congressperson.cy.ts
+++ b/cypress/e2e/04-action-email-your-congressperson.cy.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-it('action - email your congressperson', () => {
+it.skip('action - email your congressperson', () => {
   cy.visit('/')
 
   cy.contains('Email your congressperson').click()

--- a/cypress/e2e/06-donation-card-redirect.cy.ts
+++ b/cypress/e2e/06-donation-card-redirect.cy.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-it('donation card redirects to donation page', () => {
+it.skip('donation card redirects to donation page', () => {
   cy.visit('/')
 
   cy.contains('Donate to Stand With Crypto').click()

--- a/cypress/e2e/08-action-call-your-congressperson.cy.ts
+++ b/cypress/e2e/08-action-call-your-congressperson.cy.ts
@@ -2,7 +2,7 @@
 
 import { GoogleCivicInfoOfficial, GoogleCivicInfoResponse } from '@/utils/shared/googleCivicInfo'
 
-it('action - call your congressperson', () => {
+it.skip('action - call your congressperson', () => {
   cy.viewport('iphone-6')
   cy.visit('/')
 

--- a/cypress/e2e/13-user-action-unavailable.cy.ts
+++ b/cypress/e2e/13-user-action-unavailable.cy.ts
@@ -15,7 +15,7 @@ describe('disabled user actions for non-US users', () =>
     })
   }))
 
-it('should not create user action for non-US users', () => {
+it.skip('should not create user action for non-US users', () => {
   cy.setCookie('USER_COUNTRY_CODE', 'US')
   cy.visit('/')
   cy.contains('Email your congressperson').click()

--- a/src/components/app/pageUserProfile/disabledUserActionCampaigns.ts
+++ b/src/components/app/pageUserProfile/disabledUserActionCampaigns.ts
@@ -3,9 +3,14 @@ import { UserActionType } from '@prisma/client'
 import {
   UserActionCallCampaignName,
   UserActionCampaigns,
+  UserActionDonationCampaignName,
   UserActionEmailCampaignName,
   UserActionLiveEventCampaignName,
+  UserActionNftMintCampaignName,
   UserActionTweetAtPersonCampaignName,
+  UserActionTweetCampaignName,
+  UserActionVoterAttestationCampaignName,
+  UserActionVoterRegistrationCampaignName,
 } from '@/utils/shared/userActionCampaigns'
 
 type DisabledUserActionCampaigns = {
@@ -29,6 +34,10 @@ export const DISABLED_USER_ACTION_CAMPAIGNS: DisabledUserActionCampaigns = {
       title: 'FIT21 Email Campaign',
       subtitle: 'You emailed your representative and asked them to vote YES on FIT21.',
     },
+    [UserActionEmailCampaignName.FIT21_2024_04_FOLLOW_UP]: {
+      title: 'FIT21 Email Campaign',
+      subtitle: 'You emailed your representative to thank them for their vote on FIT21.',
+    },
     [UserActionEmailCampaignName.CNN_PRESIDENTIAL_DEBATE_2024]: {
       title: 'CNN Presidential Debate 2024',
       subtitle: "You emailed CNN and asked them to include the candidates' stance on crypto.",
@@ -42,6 +51,10 @@ export const DISABLED_USER_ACTION_CAMPAIGNS: DisabledUserActionCampaigns = {
     [UserActionTweetAtPersonCampaignName['2024_05_22_PIZZA_DAY']]: {
       title: 'Pizza Day 2024',
       subtitle: 'You tweeted your representative for pizza day.',
+    },
+    [UserActionTweetAtPersonCampaignName['DEFAULT']]: {
+      title: 'Tweet Campaign',
+      subtitle: 'You tweeted.',
     },
   },
   [UserActionType.CALL]: {
@@ -61,9 +74,37 @@ export const DISABLED_USER_ACTION_CAMPAIGNS: DisabledUserActionCampaigns = {
     },
   },
   [UserActionType.TWEET]: {
-    [UserActionTweetAtPersonCampaignName.DEFAULT]: {
+    [UserActionTweetCampaignName.DEFAULT]: {
       title: 'Tweet Campaign',
       subtitle: 'You helped bring more advocates to the cause by tweeting about SWC.',
+    },
+    [UserActionTweetCampaignName.FOLLOW_SWC_ON_X_2024]: {
+      title: 'Follow SWC on X - 2024 Campaign',
+      subtitle: 'You helped bring more advocates to the cause by following SWC on X.',
+    },
+  },
+  [UserActionType.DONATION]: {
+    [UserActionDonationCampaignName.DEFAULT]: {
+      title: 'Donation',
+      subtitle: 'You helped the cause by donating.',
+    },
+  },
+  [UserActionType.NFT_MINT]: {
+    [UserActionNftMintCampaignName.DEFAULT]: {
+      title: 'Minted NFT',
+      subtitle: 'You helped the cause by minting your supporter NFT.',
+    },
+  },
+  [UserActionType.VOTER_REGISTRATION]: {
+    [UserActionVoterRegistrationCampaignName.DEFAULT]: {
+      title: 'Registered to vote',
+      subtitle: 'You registered to vote.',
+    },
+  },
+  [UserActionType.VOTER_ATTESTATION]: {
+    [UserActionVoterAttestationCampaignName.DEFAULT]: {
+      title: 'Pledged to vote',
+      subtitle: 'You pledged to vote in the 2024 election.',
     },
   },
 }

--- a/src/utils/web/userActionUtils.ts
+++ b/src/utils/web/userActionUtils.ts
@@ -23,9 +23,9 @@ export const USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN: ReadonlyArray<{
     action: UserActionType.VOTER_ATTESTATION,
     campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.VOTER_ATTESTATION,
   },
-  { action: UserActionType.EMAIL, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.EMAIL },
-  { action: UserActionType.CALL, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.CALL },
+  // { action: UserActionType.EMAIL, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.EMAIL }, // Commented out because of the 2024 election.
+  // { action: UserActionType.CALL, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.CALL }, // Commented out because of the 2024 election.
   { action: UserActionType.TWEET, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.TWEET },
-  { action: UserActionType.DONATION, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.DONATION },
+  // { action: UserActionType.DONATION, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.DONATION }, // Commented out because of the 2024 election.
   { action: UserActionType.NFT_MINT, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.NFT_MINT },
 ]


### PR DESCRIPTION
closes #1354 

## What changed? Why?

This PR temporarily disables Call, Email and Donate actions to only show the actions that are directly related to the 2024 election. It also updates how we calculate completed actions in profile page to fix a bug that was calculating actions that are not in the CTA list.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
