### PR TITLE
Activity feed not showing dc events

### DIFF
--- a/src/components/app/recentActivityRow/variantRecentActivityRow.tsx
+++ b/src/components/app/recentActivityRow/variantRecentActivityRow.tsx
@@ -29,7 +29,7 @@ import {
   UserActionEmailCampaignName,
   UserActionTweetCampaignName,
 } from '@/utils/shared/userActionCampaigns'
-import { US_MAIN_STATE_CODE_TO_DISPLAY_NAME_MAP } from '@/utils/shared/usStateUtils'
+import { US_STATE_CODE_TO_DISPLAY_NAME_MAP } from '@/utils/shared/usStateUtils'
 import { listOfThings } from '@/utils/web/listOfThings'
 
 const MainText = ({ children }: { children: React.ReactNode }) => (
@@ -264,8 +264,8 @@ export const VariantRecentActivityRow = function VariantRecentActivityRow({
             <MainText>
               New sign up for an SWC event in{' '}
               {
-                US_MAIN_STATE_CODE_TO_DISPLAY_NAME_MAP[
-                  action.eventState as keyof typeof US_MAIN_STATE_CODE_TO_DISPLAY_NAME_MAP
+                US_STATE_CODE_TO_DISPLAY_NAME_MAP[
+                  action.eventState as keyof typeof US_STATE_CODE_TO_DISPLAY_NAME_MAP
                 ]
               }
             </MainText>


### PR DESCRIPTION
## What changed? Why?

This PR fixes the issue of not showing DC events on the activity feed because we were using a const that doesn't have the US territories, only main states.


## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
