### PR TITLE
fix: event reminder sending wrong payload to bulk-sms

### DIFF
--- a/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
+++ b/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
@@ -28,7 +28,7 @@ const MESSAGE_SEGMENTS_PER_SECOND = Number(
 )
 const MAX_QUEUE_LENGTH = Number(requiredEnv(process.env.MAX_QUEUE_LENGTH, 'MAX_QUEUE_LENGTH'))
 
-interface BulkSMSPayload {
+export interface BulkSMSPayload {
   messages: Array<{
     smsBody: string
     userWhereInput?: GetPhoneNumberOptions['userWhereInput']


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes [PROD-SWC-WEB-4SY](https://stand-with-crypto.sentry.io/issues/5820938436/events/88c1107c11254961a1073adb346299b4/)

## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
