### PR TITLE
fix: analytics flush hanging up

### DIFF
--- a/src/inngest/functions/airdropNFT/airdropNFT.tsx
+++ b/src/inngest/functions/airdropNFT/airdropNFT.tsx
@@ -2,6 +2,7 @@ import { NFTCurrency, NFTMintStatus } from '@prisma/client'
 import { Decimal } from '@prisma/client/runtime/library'
 import { render } from '@react-email/components'
 import * as Sentry from '@sentry/nextjs'
+import { waitUntil } from '@vercel/functions'
 import { NonRetriableError } from 'inngest'
 
 import { onFailureAirdropNFT } from '@/inngest/functions/airdropNFT/onFailureAirdropNFT'
@@ -172,7 +173,7 @@ export const airdropNFTWithInngest = inngest.createFunction(
           })
         })
 
-        await analytics.flush()
+        waitUntil(analytics.flush())
 
         return {
           messageId,

--- a/src/utils/server/serverAnalytics/serverAnalytics.ts
+++ b/src/utils/server/serverAnalytics/serverAnalytics.ts
@@ -37,7 +37,14 @@ export function getServerAnalytics(config: ServerAnalyticsConfig) {
 
   const flush = async () => {
     return resolveWithTimeout(Promise.all(trackingRequests), ANALYTICS_FLUSH_TIMEOUT_MS).catch(
-      () => {},
+      err => {
+        Sentry.captureException(err, {
+          tags: { domain: 'trackAnalytic' },
+          fingerprint: err?.message?.includes('Request timeout')
+            ? [`trackAnalyticFlushWithTimeout`]
+            : undefined,
+        })
+      },
     )
   }
 


### PR DESCRIPTION
## What changed? Why?

This adds better logging and register the exception from `resolveWithTimeout` from server analytics flush, this should add more context to #1151 

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
