### PR TITLE
fix: add more logs to enqueueMessages

### DIFF
--- a/src/inngest/functions/sms/utils/enqueueMessages.ts
+++ b/src/inngest/functions/sms/utils/enqueueMessages.ts
@@ -58,6 +58,8 @@ export async function enqueueMessages(
     payload.map(({ phoneNumber }) => phoneNumber),
   )
 
+  logger.info('Got variables')
+
   let segmentsSent = 0
   let queuedMessages = 0
   const enqueueMessagesPromise = payload.map(async ({ messages, phoneNumber }) => {
@@ -150,11 +152,15 @@ export async function enqueueMessages(
     logger.info(`Creating ${journeyType} communication journey`)
 
     await bulkCreateCommunicationJourney(journeyType, messagesSentByJourneyType[journeyType]!)
+
+    logger.info(`Created ${journeyType} communication journey`)
   }
 
   if (invalidPhoneNumbers.length > 0) {
     logger.info(`Found ${invalidPhoneNumbers.length} invalid phone numbers`)
     await flagInvalidPhoneNumbers(invalidPhoneNumbers)
+
+    logger.info(`Invalid phone numbers flagged`)
   }
 
   if (unsubscribedUsers.length > 0) {
@@ -166,6 +172,8 @@ export async function enqueueMessages(
     })
 
     await Promise.all(optOutUserPromises)
+
+    logger.info(`Opted out ${unsubscribedUsers.length} users`)
   }
 
   const failedEnqueueMessagePayload: EnqueueMessagePayload[] = Object.keys(failedPhoneNumbers).map(
@@ -180,7 +188,7 @@ export async function enqueueMessages(
     const waitingTime = 1000 * (attempt + 1)
 
     logger.info(
-      `Failed to send SMS to ${failedEnqueueMessagePayload.length} phone numbers. Attempting again in ${waitingTime} seconds`,
+      `Failed to send SMS to ${failedEnqueueMessagePayload.length} phone numbers. Attempting again in ${waitingTime} millisecond`,
     )
 
     await sleep(waitingTime)
@@ -194,6 +202,8 @@ export async function enqueueMessages(
     segmentsSent += segments
     queuedMessages += messages
   }
+
+  logger.info('Messages queued successfully')
 
   return { segments: segmentsSent, messages: queuedMessages }
 }

--- a/src/utils/shared/logger.ts
+++ b/src/utils/shared/logger.ts
@@ -85,13 +85,9 @@ export function getLogger(namespace: string): Logger {
     info: wrappedLogger('info', console.info, namespace),
     debug: wrappedLogger('debug', console.debug, namespace),
     child: (childMetadata?: ChildMetadata) =>
-      getLogger(`${namespace}: ${formatChildMetadata(childMetadata)}`),
+      getLogger(`${namespace} [${formatChildMetadata(childMetadata)}]`),
   }
 }
 
 const formatChildMetadata = (childMetadata?: ChildMetadata) =>
-  childMetadata
-    ? Object.keys(childMetadata)
-        .map(key => `${key}:${childMetadata[key]}`)
-        .join('; ')
-    : ''
+  childMetadata ? Object.values(childMetadata).join('; ') : ''


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

Adding more logs to `enqueuMessage` to debug a timeout issue with bulk-sms

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
