### PR TITLE
feat: increase criticity of errors on critical flows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@sendgrid/eventwebhook": "^8.0.0",
         "@sendgrid/mail": "^8.1.3",
         "@sentry/nextjs": "^8.7.0",
+        "@sentry/types": "^8.31.0",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tanstack/react-table": "^8.11.2",
         "@thirdweb-dev/engine": "^0.0.4",
@@ -10471,6 +10472,14 @@
         "node": ">=14.18"
       }
     },
+    "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/types": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@sentry-internal/feedback": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.20.0.tgz",
@@ -10480,6 +10489,14 @@
         "@sentry/types": "8.20.0",
         "@sentry/utils": "8.20.0"
       },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback/node_modules/@sentry/types": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
       "engines": {
         "node": ">=14.18"
       }
@@ -10512,6 +10529,22 @@
         "node": ">=14.18"
       }
     },
+    "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/types": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay/node_modules/@sentry/types": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@sentry/babel-plugin-component-annotate": {
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.20.1.tgz",
@@ -10533,6 +10566,14 @@
         "@sentry/types": "8.20.0",
         "@sentry/utils": "8.20.0"
       },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/@sentry/types": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
       "engines": {
         "node": ">=14.18"
       }
@@ -10776,6 +10817,14 @@
         "node": ">=14.18"
       }
     },
+    "node_modules/@sentry/core/node_modules/@sentry/types": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@sentry/nextjs": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-8.20.0.tgz",
@@ -10808,6 +10857,14 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@sentry/nextjs/node_modules/@sentry/types": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/@sentry/nextjs/node_modules/chalk": {
@@ -10863,6 +10920,14 @@
         "opentelemetry-instrumentation-fetch-node": "1.2.3"
       }
     },
+    "node_modules/@sentry/node/node_modules/@sentry/types": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@sentry/opentelemetry": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.20.0.tgz",
@@ -10883,6 +10948,14 @@
         "@opentelemetry/semantic-conventions": "^1.25.1"
       }
     },
+    "node_modules/@sentry/opentelemetry/node_modules/@sentry/types": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@sentry/react": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.20.0.tgz",
@@ -10901,10 +10974,18 @@
         "react": "^16.14.0 || 17.x || 18.x || 19.x"
       }
     },
-    "node_modules/@sentry/types": {
+    "node_modules/@sentry/react/node_modules/@sentry/types": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
       "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "8.31.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.31.0.tgz",
+      "integrity": "sha512-prRM/n5nlP+xQZSpdEkSR8BwwZtgsLk0NbI8eCjTMu2isVlrlggop8pVaJb7y9HmElVtDA1Q6y4u8TD2htQKFQ==",
       "engines": {
         "node": ">=14.18"
       }
@@ -10920,6 +11001,14 @@
         "node": ">=14.18"
       }
     },
+    "node_modules/@sentry/utils/node_modules/@sentry/types": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
     "node_modules/@sentry/vercel-edge": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-8.20.0.tgz",
@@ -10929,6 +11018,14 @@
         "@sentry/types": "8.20.0",
         "@sentry/utils": "8.20.0"
       },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/vercel-edge/node_modules/@sentry/types": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.20.0.tgz",
+      "integrity": "sha512-6IP278KojOpiAA7vrd1hjhUyn26cl0n0nGsShzic5ztCVs92sTeVRnh7MTB9irDVtAbOEyt/YH6go3h+Jia1pA==",
       "engines": {
         "node": ">=14.18"
       }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@sendgrid/eventwebhook": "^8.0.0",
     "@sendgrid/mail": "^8.1.3",
     "@sentry/nextjs": "^8.7.0",
+    "@sentry/types": "^8.31.0",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tanstack/react-table": "^8.11.2",
     "@thirdweb-dev/engine": "^0.0.4",

--- a/src/components/app/pageDonate/donateButton.tsx
+++ b/src/components/app/pageDonate/donateButton.tsx
@@ -17,6 +17,9 @@ export function DonateButton() {
         formName: 'Donate Button',
         onError: toastGenericError,
         payload: undefined,
+        errorScopeContext: {
+          level: 'fatal',
+        },
       },
       () =>
         actionCreateCoinbaseCommerceCharge().then(res => {

--- a/src/utils/server/thirdweb/onLogin.ts
+++ b/src/utils/server/thirdweb/onLogin.ts
@@ -102,6 +102,7 @@ export async function login(payload: VerifyLoginPayloadParams) {
       Sentry.captureException(e, {
         tags: { domain: 'onLogin/existingUser' },
         extra: { existingVerifiedUser, cryptoAddress, localUser },
+        level: 'fatal',
       })
       throw e
     })
@@ -146,6 +147,7 @@ export async function login(payload: VerifyLoginPayloadParams) {
       Sentry.captureException(e, {
         tags: { domain: 'onLogin/newUser' },
         extra: { cryptoAddress, localUser },
+        level: 'fatal',
       })
       throw e
     })


### PR DESCRIPTION
closes #1353 

## What changed? Why?

We had incidents in the past where the Sentry logs were mixed with less relevant errors and that made harder to identify we had a critical problem happening. To address that we're increasing the criticality of exceptions captured in critical flows of the app.
In order to not flood the `fatal` level, to start we're only considering errors occurring on the login and donate flows as fatal errors. 

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
