### PR TITLE
Erase sessionId param from url

### DIFF
--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useEffect } from 'react'
 import * as Sentry from '@sentry/nextjs'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { ThirdwebProvider, useAutoConnect } from 'thirdweb/react'
 
 import { useThirdwebAuthUser } from '@/hooks/useAuthUser'
@@ -20,6 +20,7 @@ import { identifyUserOnClient } from '@/utils/web/identifyUser'
 const InitialOrchestration = () => {
   const pathname = usePathname()
   const searchParams = useSearchParams()
+  const router = useRouter()
   const authUser = useThirdwebAuthUser()
 
   useReloadDueToInactivity({ timeInMinutes: 25 })
@@ -67,6 +68,16 @@ const InitialOrchestration = () => {
       action: AnalyticActionType.view,
     })
   }, [pathname])
+  const searchParamsSessionId = searchParams?.get('sessionId')
+  useEffect(() => {
+    if (searchParamsSessionId) {
+      const params = new URLSearchParams(searchParams?.toString())
+      params.delete('sessionId')
+      params.delete('userId')
+      router.replace(`${pathname || '/'}?${params.toString()}`)
+    }
+  }, [searchParamsSessionId, router, searchParams, pathname])
+
   return null
 }
 

--- a/src/app/[locale]/topLevelClientLogic.tsx
+++ b/src/app/[locale]/topLevelClientLogic.tsx
@@ -39,8 +39,8 @@ const InitialOrchestration = () => {
       Sentry.setUser({ id: sessionId, idType: 'session' })
     }
   }, [])
-  const clientUserId = getUserIdOnClient()
   useEffect(() => {
+    const clientUserId = getUserIdOnClient()
     if (authUser.user?.userId || clientUserId) {
       identifyUserOnClient({ userId: authUser.user?.userId ?? clientUserId! })
     }
@@ -52,7 +52,7 @@ const InitialOrchestration = () => {
         },
       })
     }
-  }, [authUser.user, clientUserId])
+  }, [authUser.user])
   const unexpectedUrl = searchParams?.get('unexpectedUrl')
   useEffect(() => {
     if (unexpectedUrl) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,7 @@ import {
 } from '@/utils/server/getCountryCode'
 import { isCypress } from '@/utils/shared/executionEnvironment'
 import { getLogger } from '@/utils/shared/logger'
+import { USER_ID_COOKIE_NAME } from '@/utils/shared/userId'
 import { generateUserSessionId, USER_SESSION_ID_COOKIE_NAME } from '@/utils/shared/userSessionId'
 
 const logger = getLogger('middleware')
@@ -43,6 +44,15 @@ export function middleware(request: NextRequest) {
     i18nParsedResponse.cookies.set({
       name: USER_SESSION_ID_COOKIE_NAME,
       value: sessionId,
+      httpOnly: false,
+    })
+  }
+
+  const urlUserId = request.nextUrl.searchParams.get('userId')
+  if (urlUserId) {
+    i18nParsedResponse.cookies.set({
+      name: USER_ID_COOKIE_NAME,
+      value: urlUserId,
       httpOnly: false,
     })
   }

--- a/src/utils/shared/userId.ts
+++ b/src/utils/shared/userId.ts
@@ -1,0 +1,7 @@
+import cookie from 'js-cookie'
+
+export const USER_ID_COOKIE_NAME = 'SWC_USER_ID'
+
+export const getUserIdOnClient = () => {
+  return cookie.get(USER_ID_COOKIE_NAME)
+}


### PR DESCRIPTION

## What changed? Why?

Remove `sessionId` & `userId`  params from url. This will not have an impact on client analytics or logout the user.


## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
