### PR TITLE
feat: add more info to email events

### DIFF
--- a/src/app/api/public/sendgrid/events/route.ts
+++ b/src/app/api/public/sendgrid/events/route.ts
@@ -61,9 +61,10 @@ async function processEventChunk(messageId: string, events: EmailEvent[]) {
       'Sendgrid Message Id': messageId,
       'Sendgrid Event Id': eventEntry.sg_event_id,
       ...(eventEntry.useragent && { 'User Agent': eventEntry.useragent }),
-      ...(eventEntry.url && { Url: eventEntry.url }),
+      ...(eventEntry.url && { Url: new URL(eventEntry.url)?.origin }),
       ...(eventEntry.variant && { Variant: eventEntry.variant }),
       ...(eventEntry.category && { Category: eventEntry.category }),
+      ...(eventEntry.campaign && { Campaign: eventEntry.campaign }),
     })
 
     if (eventEntry.event === EmailEventName.UNSUBSCRIBE) {

--- a/src/inngest/functions/airdropNFT/airdropNFT.tsx
+++ b/src/inngest/functions/airdropNFT/airdropNFT.tsx
@@ -169,6 +169,7 @@ export const airdropNFTWithInngest = inngest.createFunction(
           customArgs: {
             userId: user.id,
             actionType,
+            campaign: NFTArrivedEmail.campaign,
           },
         }).catch(err => {
           Sentry.captureException(err, {

--- a/src/inngest/functions/backfillReactivation/index.tsx
+++ b/src/inngest/functions/backfillReactivation/index.tsx
@@ -239,6 +239,7 @@ async function sendBatchEmails(users: User[]) {
       customArgs: {
         userId: user.id,
         category: 'Reactivation Email Reminder',
+        campaign: ReactivationReminder.campaign,
       },
       html: render(
         <ReactivationReminder

--- a/src/inngest/functions/initialSignupUserCommunicationJourney/initialSignupUserCommunicationJourney.tsx
+++ b/src/inngest/functions/initialSignupUserCommunicationJourney/initialSignupUserCommunicationJourney.tsx
@@ -305,6 +305,7 @@ async function sendInitialSignUpEmail({
     ),
     customArgs: {
       userId: user.id,
+      campaign: Template.campaign,
     },
   }).catch(err => {
     Sentry.captureException(err, {

--- a/src/utils/server/email/sendMail.ts
+++ b/src/utils/server/email/sendMail.ts
@@ -32,6 +32,7 @@ interface CommonPayload {
   customArgs?: {
     variant?: string
     userId?: string
+    campaign?: string
     [key: string]: string | undefined
   }
 }

--- a/src/utils/server/email/templates/becomeMemberReminder.tsx
+++ b/src/utils/server/email/templates/becomeMemberReminder.tsx
@@ -14,6 +14,7 @@ import { buildTemplateInternalUrl } from '@/utils/server/email/utils/buildTempla
 type BecomeMemberReminderEmailProps = KeepUpTheFightSectionProps & EmailTemplateProps
 
 BecomeMemberReminderEmail.subjectLine = 'Level up your advocacy'
+BecomeMemberReminderEmail.campaign = 'become_member_reminder'
 
 export default function BecomeMemberReminderEmail({
   previewText,
@@ -22,7 +23,7 @@ export default function BecomeMemberReminderEmail({
   ...keepUpTheFightSectionProps
 }: BecomeMemberReminderEmailProps) {
   const hydratedHrefSearchParams = {
-    utm_campaign: 'become_member_reminder',
+    utm_campaign: BecomeMemberReminderEmail.campaign,
     ...hrefSearchParams,
     ...session,
   }

--- a/src/utils/server/email/templates/contactYourRepresentativeReminder.tsx
+++ b/src/utils/server/email/templates/contactYourRepresentativeReminder.tsx
@@ -14,6 +14,7 @@ import { buildTemplateInternalUrl } from '@/utils/server/email/utils/buildTempla
 type ContactYourRepresentativeReminderEmailProps = KeepUpTheFightSectionProps & EmailTemplateProps
 
 ContactYourRepresentativeReminderEmail.subjectLine = 'Make your voice heard'
+ContactYourRepresentativeReminderEmail.campaign = 'contact_your_representative_reminder'
 
 export default function ContactYourRepresentativeReminderEmail({
   previewText,
@@ -22,7 +23,7 @@ export default function ContactYourRepresentativeReminderEmail({
   ...keepUpTheFightSectionProps
 }: ContactYourRepresentativeReminderEmailProps) {
   const hydratedHrefSearchParams = {
-    utm_campaign: 'contact_your_representative_reminder',
+    utm_campaign: ContactYourRepresentativeReminderEmail.campaign,
     ...hrefSearchParams,
     ...session,
   }

--- a/src/utils/server/email/templates/finishSettingUpProfileReminder.tsx
+++ b/src/utils/server/email/templates/finishSettingUpProfileReminder.tsx
@@ -14,6 +14,7 @@ import { buildTemplateInternalUrl } from '@/utils/server/email/utils/buildTempla
 type FinishSettingUpProfileReminderEmailProps = KeepUpTheFightSectionProps & EmailTemplateProps
 
 FinishSettingUpProfileReminderEmail.subjectLine = 'Finish setting up your profile'
+FinishSettingUpProfileReminderEmail.campaign = 'finish_setting_up_profile'
 
 export default function FinishSettingUpProfileReminderEmail({
   previewText,
@@ -22,7 +23,7 @@ export default function FinishSettingUpProfileReminderEmail({
   ...keepUpTheFightSectionProps
 }: FinishSettingUpProfileReminderEmailProps) {
   const hydratedHrefSearchParams = {
-    utm_campaign: 'finish_setting_up_profile',
+    utm_campaign: FinishSettingUpProfileReminderEmail.campaign,
     ...hrefSearchParams,
     ...session,
   }

--- a/src/utils/server/email/templates/followOnXReminder.tsx
+++ b/src/utils/server/email/templates/followOnXReminder.tsx
@@ -17,6 +17,7 @@ import { buildTemplateInternalUrl } from '@/utils/server/email/utils/buildTempla
 type FollowOnXReminderEmailProps = KeepUpTheFightSectionProps & EmailTemplateProps
 
 FollowOnXReminderEmail.subjectLine = 'Stay up to date on crypto policy'
+FollowOnXReminderEmail.campaign = 'follow_on_x_reminder'
 
 export default function FollowOnXReminderEmail({
   previewText,
@@ -25,7 +26,7 @@ export default function FollowOnXReminderEmail({
   ...keepUpTheFightSectionProps
 }: FollowOnXReminderEmailProps) {
   const hydratedHrefSearchParams = {
-    utm_campaign: 'follow_on_x_reminder',
+    utm_campaign: FollowOnXReminderEmail.campaign,
     ...hrefSearchParams,
     ...session,
   }

--- a/src/utils/server/email/templates/initialSignUp.tsx
+++ b/src/utils/server/email/templates/initialSignUp.tsx
@@ -13,6 +13,7 @@ import { buildTemplateInternalUrl } from '@/utils/server/email/utils/buildTempla
 type InitialSignUpEmailProps = KeepUpTheFightSectionProps & EmailTemplateProps
 
 InitialSignUpEmail.subjectLine = 'Thanks for joining SWC!'
+InitialSignUpEmail.campaign = 'initial_signup'
 
 export default function InitialSignUpEmail({
   previewText,
@@ -21,7 +22,7 @@ export default function InitialSignUpEmail({
   ...keepUpTheFightSectionProps
 }: InitialSignUpEmailProps) {
   const hydratedHrefSearchParams = {
-    utm_campaign: 'initial_signup',
+    utm_campaign: InitialSignUpEmail.campaign,
     ...hrefSearchParams,
     ...session,
   }

--- a/src/utils/server/email/templates/nftArrived.tsx
+++ b/src/utils/server/email/templates/nftArrived.tsx
@@ -21,6 +21,7 @@ type NFTArrivedEmailProps = KeepUpTheFightSectionProps &
   }
 
 NFTArrivedEmail.subjectLine = 'Your NFT has arrived!'
+NFTArrivedEmail.campaign = 'nft_arrived'
 
 export default function NFTArrivedEmail({
   previewText,
@@ -32,7 +33,7 @@ export default function NFTArrivedEmail({
   ...keepUpTheFightSectionProps
 }: NFTArrivedEmailProps) {
   const hydratedHrefSearchParams = {
-    utm_campaign: 'nft_arrived',
+    utm_campaign: NFTArrivedEmail.campaign,
     ...hrefSearchParams,
     ...session,
   }

--- a/src/utils/server/email/templates/nftOnTheWay.tsx
+++ b/src/utils/server/email/templates/nftOnTheWay.tsx
@@ -20,6 +20,7 @@ type NFTOnTheWayEmailProps = KeepUpTheFightSectionProps &
   }
 
 NFTOnTheWayEmail.subjectLine = 'Your NFT is on the way!'
+NFTOnTheWayEmail.campaign = 'nft_on_the_way'
 
 export default function NFTOnTheWayEmail({
   previewText,
@@ -31,7 +32,7 @@ export default function NFTOnTheWayEmail({
   ...keepUpTheFightSectionProps
 }: NFTOnTheWayEmailProps) {
   const hydratedHrefSearchParams = {
-    utm_campaign: 'nft_on_the_way',
+    utm_campaign: NFTOnTheWayEmail.campaign,
     ...hrefSearchParams,
     ...session,
   }

--- a/src/utils/server/email/templates/phoneNumberReminder.tsx
+++ b/src/utils/server/email/templates/phoneNumberReminder.tsx
@@ -14,6 +14,7 @@ import { buildTemplateInternalUrl } from '@/utils/server/email/utils/buildTempla
 type PhoneNumberReminderEmailProps = KeepUpTheFightSectionProps & EmailTemplateProps
 
 PhoneNumberReminderEmail.subjectLine = 'Get text updates from SWC'
+PhoneNumberReminderEmail.campaign = 'phone_number_reminder'
 
 export default function PhoneNumberReminderEmail({
   previewText,
@@ -22,7 +23,7 @@ export default function PhoneNumberReminderEmail({
   ...keepUpTheFightSectionProps
 }: PhoneNumberReminderEmailProps) {
   const hydratedHrefSearchParams = {
-    utm_campaign: 'phone_number_reminder',
+    utm_campaign: PhoneNumberReminderEmail.campaign,
     ...hrefSearchParams,
     ...session,
   }

--- a/src/utils/server/email/templates/reactivationReminder.tsx
+++ b/src/utils/server/email/templates/reactivationReminder.tsx
@@ -13,6 +13,7 @@ import { buildTemplateInternalUrl } from '@/utils/server/email/utils/buildTempla
 type ReactivationReminderProps = KeepUpTheFightSectionProps & EmailTemplateProps
 
 ReactivationReminder.subjectLine = 'Connect with SWC'
+ReactivationReminder.campaign = 'reactivation_reminder'
 
 export default function ReactivationReminder({
   previewText,
@@ -21,7 +22,7 @@ export default function ReactivationReminder({
   ...keepUpTheFightSectionProps
 }: ReactivationReminderProps) {
   const hydratedHrefSearchParams = {
-    utm_campaign: 'reactivation_reminder',
+    utm_campaign: ReactivationReminder.campaign,
     ...hrefSearchParams,
     ...session,
   }

--- a/src/utils/server/email/templates/registerToVoteReminder.tsx
+++ b/src/utils/server/email/templates/registerToVoteReminder.tsx
@@ -17,6 +17,7 @@ import { buildTemplateInternalUrl } from '@/utils/server/email/utils/buildTempla
 type RegisterToVoteReminderEmailProps = KeepUpTheFightSectionProps & EmailTemplateProps
 
 RegisterToVoteReminderEmail.subjectLine = 'Register to vote and get a free NFT'
+RegisterToVoteReminderEmail.campaign = 'register_to_vote_reminder'
 
 export default function RegisterToVoteReminderEmail({
   previewText,
@@ -25,7 +26,7 @@ export default function RegisterToVoteReminderEmail({
   ...keepUpTheFightSectionProps
 }: RegisterToVoteReminderEmailProps) {
   const hydratedHrefSearchParams = {
-    utm_campaign: 'register_to_vote_reminder',
+    utm_campaign: RegisterToVoteReminderEmail.campaign,
     ...hrefSearchParams,
     ...session,
   }

--- a/src/utils/server/nft/claimNFT.tsx
+++ b/src/utils/server/nft/claimNFT.tsx
@@ -239,6 +239,7 @@ async function sendNFTOnTheWayEmail(userAction: UserActionToClaim) {
       userId: user.id,
       userActionId: userAction.id,
       actionType: userAction.actionType,
+      campaign: NFTOnTheWayEmail.campaign,
     },
   }).catch(err => {
     Sentry.captureException(err, {


### PR DESCRIPTION
## What changed? Why?

While building mixpanel dashboards we noticed we didn't have a way to group url by origin, that caused a lot of versions of the same url to be visible, this fixes it and adds a new field to help identify which campaign that click is coming from (redundant field in some cases, but useful in others)

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
