### PR TITLE
fix: change how we parse the url before registering the mixpanel event

### DIFF
--- a/src/app/api/public/sendgrid/events/route.ts
+++ b/src/app/api/public/sendgrid/events/route.ts
@@ -61,7 +61,7 @@ async function processEventChunk(messageId: string, events: EmailEvent[]) {
       'Sendgrid Message Id': messageId,
       'Sendgrid Event Id': eventEntry.sg_event_id,
       ...(eventEntry.useragent && { 'User Agent': eventEntry.useragent }),
-      ...(eventEntry.url && { Url: new URL(eventEntry.url)?.origin }),
+      ...(eventEntry.url && { Url: removeSearchParamsFromURL(eventEntry.url) }),
       ...(eventEntry.variant && { Variant: eventEntry.variant }),
       ...(eventEntry.category && { Category: eventEntry.category }),
       ...(eventEntry.campaign && { Campaign: eventEntry.campaign }),
@@ -123,5 +123,15 @@ async function getServerAnalyticsFromEvent(emailEvent: EmailEvent) {
   return {
     analytics: getServerAnalytics({ userId: user.id, localUser: getLocalUserFromUser(user) }),
     user,
+  }
+}
+
+function removeSearchParamsFromURL(url: string) {
+  try {
+    const urlObj = new URL(url)
+    urlObj.search = ''
+    return urlObj.toString()
+  } catch {
+    return null
   }
 }


### PR DESCRIPTION
## What changed? Why?

On a recent change we added a parse to the url before registering an email event, this removed the pathname information from it. This solves it

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
