### PR TITLE
feat: add voter guide p2p sms vanity url

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -330,6 +330,11 @@ const nextConfig = {
       },
       // SMS shortlinks
       {
+        source: '/voter-guide-1',
+        destination: '/vote?utm_source=swc&utm_medium=p2p-sms&utm_campaign=vg-1',
+        permanent: true,
+      },
+      {
         source: '/w/vote/:sessionId*',
         destination:
           '/vote?utm_source=swc&utm_medium=sms&utm_campaign=welcome_sms&utm_id=sst&utm_content=v1&sessionId=:sessionId*',


### PR DESCRIPTION
## What changed? Why?

Vanity URL for https://docs.google.com/document/d/10rbmu692hXuYezVsGgR9lL21TtoWO6d3f872Rb823t8/edit#heading=h.7wlfos2ex7fp

## How has it been tested?

- [ ] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
