### PR TITLE
fix: increase retry timeout time on sms status webhook

### DIFF
--- a/src/app/api/public/sms/events/status/route.ts
+++ b/src/app/api/public/sms/events/status/route.ts
@@ -25,6 +25,8 @@ interface SMSStatusEvent {
   AccountSid: string
 }
 
+export const maxDuration = 30
+
 const MAX_RETRY_COUNT = 3
 
 type UserCommunicationWithRelations =

--- a/src/app/api/public/sms/events/status/route.ts
+++ b/src/app/api/public/sms/events/status/route.ts
@@ -46,7 +46,7 @@ export const POST = withRouteMiddleware(async (request: NextRequest) => {
 
   let userCommunication: UserCommunicationWithRelations = null
 
-  for (let i = 0; i < MAX_RETRY_COUNT; i += 1) {
+  for (let i = 1; i <= MAX_RETRY_COUNT; i += 1) {
     userCommunication = await prismaClient.userCommunication.findFirst({
       where: {
         messageId: body.MessageSid,
@@ -69,7 +69,7 @@ export const POST = withRouteMiddleware(async (request: NextRequest) => {
 
     // Calls to this webhook are being received before the messages are registered in our database. Therefore, we need to implement a retry mechanism for fetching the messages.
     if (!userCommunication) {
-      await sleep(1000)
+      await sleep(1000 * (i * i))
     }
   }
 


### PR DESCRIPTION
fixes [PROD-SWC-WEB-4PP](https://stand-with-crypto.sentry.io/issues/5759605772/events/ed4f22dd54aa4dc78da63744299f93b2/), [PROD-SWC-WEB-4CR](https://stand-with-crypto.sentry.io/issues/5669084486/events/d8e5af6ce225454493acd7a2ad441fc2/)

## What changed? Why?

This PR increases the timeout between retries for getting user communication

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
