### PR TITLE
fix: remove p2p from voter guide sms utm_medium

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -332,8 +332,9 @@ const nextConfig = {
       },
       // SMS shortlinks
       {
-        source: '/voter-guide-1',
-        destination: '/vote?utm_source=swc&utm_medium=sms&utm_campaign=voter-guide-1',
+        source: '/voter-guide-1/:sessionId*',
+        destination:
+          '/vote?utm_source=swc&utm_medium=sms&utm_campaign=voter-guide-1&sessionId=:sessionId*',
         permanent: true,
       },
       {

--- a/next.config.js
+++ b/next.config.js
@@ -333,7 +333,7 @@ const nextConfig = {
       // SMS shortlinks
       {
         source: '/voter-guide-1',
-        destination: '/vote?utm_source=swc&utm_medium=p2p-sms&utm_campaign=vg-1',
+        destination: '/vote?utm_source=swc&utm_medium=sms&utm_campaign=voter-guide-1',
         permanent: true,
       },
       {


### PR DESCRIPTION
## What changed? Why?

Change the voter guide vanity url because we'll be sending this communication via Twilio and not P2P anymore

## How has it been tested?

- [ ] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
