### PR TITLE
fix: revert rate limit to 750

### DIFF
--- a/src/utils/server/sms/messagingClient.ts
+++ b/src/utils/server/sms/messagingClient.ts
@@ -5,6 +5,6 @@ import { requiredEnv } from '@/utils/shared/requiredEnv'
 const TWILIO_ACCOUNT_SID = requiredEnv(process.env.TWILIO_ACCOUNT_SID, 'TWILIO_ACCOUNT_SID')
 const TWILIO_AUTH_TOKEN = requiredEnv(process.env.TWILIO_AUTH_TOKEN, 'TWILIO_AUTH_TOKEN')
 
-export const TWILIO_RATE_LIMIT = 1000
+export const TWILIO_RATE_LIMIT = 750
 
 export const messagingClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

Reverted Twilio rate limit from 1000 to 750, because with 1000 messages Vercel is timing out

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
