### PR TITLE
fix: use spread to return the correct failedPhoneNumbers payload

### DIFF
--- a/src/inngest/functions/sms/enqueueMessages.ts
+++ b/src/inngest/functions/sms/enqueueMessages.ts
@@ -194,9 +194,10 @@ export async function enqueueMessages(
 
         if (error instanceof SendSMSError) {
           if (error.isTooManyRequests) {
-            return update(failedPhoneNumbers, [error.phoneNumber], (current = []) =>
-              current.push(message),
-            )
+            return update(failedPhoneNumbers, [error.phoneNumber], (current = []) => [
+              ...current,
+              message,
+            ])
           }
           if (error.isInvalidPhoneNumber) {
             return invalidPhoneNumbers.push(error.phoneNumber)


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

We were returning the result of a .push call instead of the actual array with new elements to the failedPhoneNumbers hash map

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
