### PR TITLE
fix: add loading async query param to solve warning

### DIFF
--- a/src/hooks/useGoogleMapsScript.ts
+++ b/src/hooks/useGoogleMapsScript.ts
@@ -11,7 +11,7 @@ const NEXT_PUBLIC_GOOGLE_PLACES_API_KEY = requiredEnv(
  * Check possibility of adding &loading=async https://github.com/Tintef/react-google-places-autocomplete/issues/342 to resolve warning
  */
 function getGoogleMapsScriptSrc() {
-  return `https://maps.googleapis.com/maps/api/js?key=${NEXT_PUBLIC_GOOGLE_PLACES_API_KEY}&libraries=places&callback=Function.prototype`
+  return `https://maps.googleapis.com/maps/api/js?key=${NEXT_PUBLIC_GOOGLE_PLACES_API_KEY}&loading=async&libraries=places&callback=Function.prototype`
 }
 
 export function useGoogleMapsScript() {

--- a/src/utils/server/getGooglePlaceIdFromAddress.ts
+++ b/src/utils/server/getGooglePlaceIdFromAddress.ts
@@ -10,7 +10,7 @@ const GOOGLE_PLACES_BACKEND_API_KEY = requiredEnv(
 
 export async function getGooglePlaceIdFromAddress(address: string) {
   const response = await fetchReq(
-    `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${encodeURIComponent(address)}&language=en&key=${GOOGLE_PLACES_BACKEND_API_KEY}`,
+    `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${encodeURIComponent(address)}&loading=async&language=en&key=${GOOGLE_PLACES_BACKEND_API_KEY}`,
     {
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
closes #1431 

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?
![image](https://github.com/user-attachments/assets/66290c62-2543-413f-bc82-bbd01a8dcb52)

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
