### PR TITLE
fix: set max-retry-count to 1 in bulk-sms

### DIFF
--- a/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
+++ b/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
@@ -41,7 +41,7 @@ export interface BulkSMSPayload {
   currentSegmentsInQueue?: number
 }
 
-const MAX_RETRY_COUNT = 0
+const MAX_RETRY_COUNT = 1
 const DATABASE_QUERY_LIMIT = Number(process.env.DATABASE_QUERY_LIMIT) || undefined
 
 // This constants are specific to our twilio phone number type


### PR DESCRIPTION
## What changed? Why?

Sometimes bulk SMS fails due to Inngest errors, so by increasing the retry count, we make it more resilient to these issues. We also don’t need to worry about sending duplicate messages because, during the next retry, we filter out phone numbers that have already received that communication under the same campaign name

## How has it been tested?

- [ ] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
