### PR TITLE
fix: twilio errors flooding sentry

### DIFF
--- a/src/app/api/public/sms/events/status/route.ts
+++ b/src/app/api/public/sms/events/status/route.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 
 import { User, UserCommunication, UserCommunicationJourney } from '@prisma/client'
-import * as Sentry from '@sentry/nextjs'
+// import * as Sentry from '@sentry/nextjs'
 import { waitUntil } from '@vercel/functions'
 import { NextRequest, NextResponse } from 'next/server'
 
@@ -76,13 +76,15 @@ export const POST = withRouteMiddleware(async (request: NextRequest) => {
   }
 
   if (!userCommunication) {
-    Sentry.captureMessage(`Received message status update but couldn't find user_communication`, {
-      extra: { body },
-      tags: {
-        domain: 'smsMessageStatusWebhook',
-      },
-    })
-    return new NextResponse('not found', { status: 404 })
+    // TODO: Uncomment this when we fix this problem https://github.com/Stand-With-Crypto/swc-internal/issues/260
+    // Sentry.captureMessage(`Received message status update but couldn't find user_communication`, {
+    //   extra: { body },
+    //   tags: {
+    //     domain: 'smsMessageStatusWebhook',
+    //   },
+    // })
+    // If we return 4xx or 5xx Twilio will trigger our fails webhook with this warning -> https://www.twilio.com/docs/api/errors/11200 and it's flooding Sentry
+    return new NextResponse('success', { status: 200 })
   }
 
   const user = userCommunication?.userCommunicationJourney.user


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes [PROD-SWC-WEB-4CR](https://stand-with-crypto.sentry.io/issues/5669084486/events/3fe546327ca94d2e95c62e1a7419e459/)

## What changed? Why?

Some Twilio errors are flooding Sentry, so this PR is:
- Filtering errors related to the mobile carrier when sending SMS errors to Sentry
- Returning 200 even when we couldn't find the userCommunication on the status webhook
- Commenting the error related to not finding the userCommunication, because we'll fix it in [#260](https://github.com/Stand-With-Crypto/swc-internal/issues/260)

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
