### PR TITLE
Docs: Updates create action and multiple campaigns doc

### DIFF
--- a/docs/Add a new user action.md
+++ b/docs/Add a new user action.md
@@ -191,6 +191,12 @@ export default function UserActionActionNameDeepLink({ params }: PageProps) {
 
 Unit tests can be added in the same folder as where new UI components are created, and E2E tests are stored in the `cypress` folder.
 
+### Action Card - CTA
+
+To add a call-to-action (CTA) for the new user action, you need to create a new object within `USER_ACTION_CTAS_FOR_GRID_DISPLAY`, including all the required fields. For details about each field, please refer to `src/components/app/userActionGridCTAs/types/index.ts`.
+
+Additionally, **the order of the objects determines how the CTAs will be displayed to users**, so please keep this in mind.
+
 ### Having two or more campaigns active at the same time
 
 If you ever need to run multiple campaigns simultaneously, please refer to [this documentation](/docs/Working%20with%20two%20or%20more%20campaigns%20active.md) for guidance on how to add multiple campaigns and how to disable them later.

--- a/docs/Working with two or more campaigns active.md
+++ b/docs/Working with two or more campaigns active.md
@@ -22,43 +22,9 @@ export enum UserActionTweetAtPersonCampaignName {
 }
 ```
 
-- Now update the `USER_ACTIONS_WITH_ADDITIONAL_CAMPAIGN` array that is inside the same file(`src/utils/shared/userActionCampaigns.ts`) with the new campaign:
-
-```javascript
-/// userActionCampaigns.ts
-
-export const USER_ACTIONS_WITH_ADDITIONAL_CAMPAIGN: Partial<UserActionAdditionalCampaigns> = {
-  [UserActionType.TWEET_AT_PERSON]: [ // note that the campaign should be added as an array
-    UserActionTweetAtPersonCampaignName.2024_05_22_PIZZA_DAY,
-  ],
-}
-```
-
 ## Change CTAs priority order
 
-- Next, you’ll need to specify the position of this new campaign in the CTAs list. You can do this by editing `USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN` in `src/utils/web/userActionUtils.ts`. e.g.:
-
-```javascript
-/// userActionUtils.ts
-
-export const USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN: ReadonlyArray<{
-  action: ActiveClientUserActionType
-  campaign: UserActionCampaignName
-}> = [
-  { action: UserActionType.EMAIL, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.EMAIL },
-  { action: UserActionType.OPT_IN, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.OPT_IN },
-  {
-    action: UserActionType.VOTER_REGISTRATION,
-    campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.VOTER_REGISTRATION,
-  },
-  { action: UserActionType.CALL, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.CALL },
-  { action: UserActionType.TWEET, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.TWEET },
-  { action: UserActionType.DONATION, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.DONATION },
-  { action: UserActionType.TWEET_AT_PERSON, campaign: UserActionTweetAtPersonCampaignName.2024_05_22_PIZZA_DAY }, // new campaign will be presented after donation CTA and before the nft mint CTA
-  { action: UserActionType.NFT_MINT, campaign: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.NFT_MINT },
-]
-
-```
+- The order of action cards is determined by the arrangement of action objects within `USER_ACTION_CTAS_FOR_GRID_DISPLAY` (`src/components/app/userActionGridCTAs/constants/ctas.tsx`). This applies similarly to each action campaign array. If you need to change the order of campaigns or actions, you can easily do so by repositioning the relevant action or campaign within the respective actions object or campaigns array.
 
 ## Create the corresponding modules for the campaign
 
@@ -66,28 +32,23 @@ export const USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN: ReadonlyArray<{
 
 ## Create the campaign CTA
 
-- You need to define the new campaign CTA(image, title and subtitle). To do so, edit `USER_ACTION_ROW_CTA_INFO_FROM_CAMPAIGN` in `src/components/app/userActionRowCTA/constants.tsx` with the corresponding information. e.g.:
+- To define the new campaign CTA, update the related action campaigns array in `USER_ACTION_CTAS_FOR_GRID_DISPLAY`(`src/components/app/userActionGridCTAs/constants/ctas.tsx`) with the new campaign:
 
 ```javascript
+/// ctas.tsx
 
-export const USER_ACTION_ROW_CTA_INFO_FROM_CAMPAIGN: Record<
-  string,
-  Omit<UserActionRowCTAProps, 'state'>
-> = {
-  [UserActionEmailCampaignName.CNN_PRESIDENTIAL_DEBATE_2024]: {
-    actionType: UserActionType.EMAIL,
-    image: {
-      src: '/actionTypeIcons/email-cnn.svg',
-    },
-    text: 'Ask CNN to include crypto questions at the Presidential Debate',
-    subtext: 'Send an email to CNN and tell them we need the candidates’ stance on crypto',
-    shortText: 'Email CNN to ask about crypto',
-    shortSubtext: 'Send an email to CNN and tell them we need the candidates’ stance on crypto.',
-    canBeTriggeredMultipleTimes: true,
-    WrapperComponent: UserActionFormEmailCNNDialog, // This is the dialog component related to your new campaign
-  },
-}
+{
+  actionType: UserActionType.EMAIL,
+  campaignName: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP.EMAIL,
+  isCampaignActive: false,
+  title: `Email your ${getYourPoliticianCategoryShortDisplayName(EMAIL_FLOW_POLITICIANS_CATEGORY)}`,
+  description: 'Make your voice heard. We make it easy.',
+  canBeTriggeredMultipleTimes: true,
+  WrapperComponent: UserActionFormEmailCongresspersonDialog,
+},
 ```
+
+For details about each field, please refer to `src/components/app/userActionGridCTAs/types/index.ts`.
 
 ## Update the deeplink URL for our internal deeplink page
 
@@ -109,17 +70,21 @@ export const USER_ACTION_WITH_CAMPAIGN_DEEPLINK_MAP: {
 
 ## Update the variantRecentActivityRow
 
-- If there is a specific activity row for the campaign, you will need to update `VariantRecentActivityRow` in `src/components/app/recentActivityRow/variantRecentActivityRow.tsx` for the corresponding campaign case. e.g.: _You sent a CNN presidential debate email._
+- If there is a specific activity row for the campaign, you will need to update `VariantRecentActivityRow` in `src/components/app/recentActivityRow/variantRecentActivityRow.tsx` for the corresponding campaign case. e.g.: \_You sent a CNN presidential debate email.
 
-## Create a new card to display when the campaign is deactivated.
-
-- Please update the `DISABLED_USER_ACTION_CAMPAIGNS` in `src/components/app/pageUserProfile/disabledUserActionCampaigns.ts` to ensure that the new campaign is displayed as a completed action once it is disabled, provided the user has completed it previously. This is crucial for accurately showcasing all user actions campaigns completed, including those that are no longer active.
-
-## How to remove the campaign after it is not necessary anymore
+## How to disable the campaign after it is not necessary anymore
 
 - Delete all files related to the campaign that are no longer needed, including UI components, the deeplink page, server actions, and any other associated components.
-- Ensure there is a card displayed when the campaign is deactivated. Refer to [this section for guidance](#create-a-new-card-to-display-when-the-campaign-is-deactivated)
-- Remove the campaign from `USER_ACTIONS_WITH_ADDITIONAL_CAMPAIGN` in `src/utils/shared/userActionCampaigns.ts`.
-- Remove the campaign from `USER_ACTION_TYPE_CTA_PRIORITY_ORDER_WITH_CAMPAIGN` in `src/utils/web/userActionUtils.ts`.
-- Remove the campaign from `USER_ACTION_WITH_CAMPAIGN_DEEPLINK_MAP` in `src/utils/shared/urlsDeeplinkUserActions.ts`
-- Remove the campaign from `USER_ACTION_ROW_CTA_INFO_FROM_CAMPAIGN` in `src/components/app/userActionRowCTA/constants.tsx`
+- Locate the campaign object in `USER_ACTION_CTAS_FOR_GRID_DISPLAY` (`src/components/app/userActionGridCTAs/constants/ctas.tsx`). Set `isCampaignActive` to `false`, and update `WrapperComponent` to `WrapperComponent: () => null.`
+
+```javascript
+{
+  actionType: UserActionType.EMAIL,
+  campaignName: UserActionEmailCampaignName.CNN_PRESIDENTIAL_DEBATE_2024,
+  isCampaignActive: false, // This disables the campaign
+  title: 'CNN Presidential Debate 2024',
+  description: "You emailed CNN and asked them to include the candidates' stance on crypto.",
+  canBeTriggeredMultipleTimes: true,
+  WrapperComponent: () => null, // Changing the Wrapper component to return null will enable you to delete all campaign files.
+}
+```


### PR DESCRIPTION
closes #1470 

## What changed? Why?

This PR updates the documentation for `Create New Action` and `Working with Multiple Campaigns` to reflect the recent changes introduced by the new grid action CTAs that we implemented in the past few weeks.

<img width="1147" alt="image" src="https://github.com/user-attachments/assets/d456584f-48de-4be2-a72a-cea8f8b37341">
