### PR TITLE
Fix: Dtsi images breaking homepage on dev

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -208,6 +208,7 @@ const nextConfig = {
       },
       // dotheysupportit image cdn
       { protocol: 'https', hostname: 'db0prh5pvbqwd.cloudfront.net' },
+      { protocol: 'https', hostname: 'testing.dotheysupportit.com' },
       // builder.io image cdn
       {
         protocol: 'https',


### PR DESCRIPTION
## What changed? Why?

This PR fixes the following error when acessing the homepage on dev:

`Error: Invalid src prop (https://testing.dotheysupportit.com/_next/image?url=https%3A%2F%2Fdb0prh5pvbqwd.cloudfront.net%2Fadmin-uploads%2Fproduction%2Fperson_profile_picture_urls%2F20240501-013312-cynthialummis.png&w=640&q=75) on 'next/image', hostname "testing.dotheysupportit.com" is not configured under images in your 'next.config.js'
See more info: https://nextjs.org/docs/messages/next-image-unconfigured-host
    at Array.map (<anonymous>)
digest: "359521064"`

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
