### PR TITLE
feat: divide complex login query with OR operator for multiple smaller queries done in paralellel

### DIFF
--- a/src/utils/server/thirdweb/onLogin.ts
+++ b/src/utils/server/thirdweb/onLogin.ts
@@ -951,13 +951,15 @@ async function getExistingUsers({
       })
     : null
 
-  const existingUsersQueries = compact([
-    existingUsersWithCryptoAddressNotVerifiedViaAuth,
-    existingUsersWithCurrentUserSessionId,
-    existingUsersWithEmailVerifiedEqualToEmbeddedWalletEmail,
-    existingUsersWithEmailNotVerifiedFromInitialBackfill,
-    existingUsersWithOptedInPhoneEqualToEmbeddedWalletPhone,
-  ])
+  const existingUsers = await Promise.all(
+    compact([
+      existingUsersWithCryptoAddressNotVerifiedViaAuth,
+      existingUsersWithCurrentUserSessionId,
+      existingUsersWithEmailVerifiedEqualToEmbeddedWalletEmail,
+      existingUsersWithEmailNotVerifiedFromInitialBackfill,
+      existingUsersWithOptedInPhoneEqualToEmbeddedWalletPhone,
+    ]),
+  )
 
-  return (await Promise.all(existingUsersQueries)).flat()
+  return existingUsers.flat()
 }


### PR DESCRIPTION
closes #1507 

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

`existingUsers` query takes too long to complete. We tried to index every field and that did not solve the issue, so our best bet is that the OR operator makes it hard for prisma to optimize the query properly. To solve this, we are dividing this query into multiple queries done in parallel so we have smaller and optimized queries instead of a big complex query.

To test it out we made this query on production database, that took more than 3s to complete:
```sql
SELECT user.id, user.datetime_updated,
  user.datetime_created, user.first_name, user.last_name,
  user.phone_number, user.address_id,
  user.information_visiblity, user.primary_user_email_address_id,
  user.primary_user_crypto_address_id, user.has_opted_in_to_emails,
  user.has_opted_in_to_membership, user.has_valid_phone_number,
  user.internal_status, user.data_creation_method,
  user.total_donation_amount_usd, user.referral_id,
  user.acquisition_referer, user.acquisition_source,
  user.acquisition_medium, user.acquisition_campaign,
  user.capitol_canary_advocate_id, user.capitol_canary_instance,
  user.sms_status
FROM user
WHERE (
  (user.id) IN (
    SELECT t1.user_id
    FROM user_crypto_address AS t1
    WHERE (
      t1.crypto_address = ? AND t1.has_been_verified_via_auth = FALSE AND t1.user_id IS NOT NULL
    )
  ) OR (user.id) IN (
    SELECT t2.user_id
    FROM user_session AS t2
    WHERE (
      t2.id = ? AND t2.user_id IS NOT NULL
    )
  ) OR (user.id) IN (
    SELECT t3.user_id
    FROM user_email_address AS t3
    WHERE (
      t3.email_address = ? AND t3.is_verified = TRUE AND t3.user_id IS NOT NULL
    )
  ) OR (user.id) IN (
    SELECT t4.user_id
    FROM user_email_address AS t4
    WHERE (
      t4.email_address = ? AND t4.is_verified = FALSE AND t4.data_creation_method = "INITIAL_BACKFILL" AND
        t4.user_id IS NOT NULL
    )
  )
)
```
<img width="142" alt="image" src="https://github.com/user-attachments/assets/9dcdc0f2-5cb7-40a8-b693-7b71c3273a4b">

While changing it to 4 different queries took less than 200ms each:
```sql
SELECT ...
FROM user
WHERE ((user.id) IN (
    SELECT t3.user_id
    FROM user_email_address AS t3
    WHERE (
      t3.email_address = ? AND t3.is_verified = TRUE AND t3.user_id IS NOT NULL
    )
  )
)

SELECT ...
FROM user
WHERE (
  (user.id) IN (
    SELECT t1.user_id
    FROM user_crypto_address AS t1
    WHERE (
      t1.crypto_address = ? AND t1.has_been_verified_via_auth = FALSE AND t1.user_id IS NOT NULL
    )
  ) 
)

SELECT ...
FROM user
WHERE (
  (user.id) IN (
    SELECT t2.user_id
    FROM user_session AS t2
    WHERE (
      t2.id = ? AND t2.user_id IS NOT NULL
    )
  )
)

SELECT ...
FROM user
WHERE (
  (user.id) IN (
    SELECT t4.user_id
    FROM user_email_address AS t4
    WHERE (
      t4.email_address = ? AND t4.is_verified = FALSE AND t4.data_creation_method = "INITIAL_BACKFILL" AND t4.user_id IS NOT NULL
    )
  )
)
```
<img width="178" alt="image" src="https://github.com/user-attachments/assets/14db8428-f62c-4a84-a401-179ff69823f6">
<img width="112" alt="image" src="https://github.com/user-attachments/assets/f7a8d223-cb8d-4d86-84ab-354f7a36057a">
<img width="116" alt="image" src="https://github.com/user-attachments/assets/314fbad3-6e16-4cd1-8a4e-fcef3e0505f9">
<img width="122" alt="image" src="https://github.com/user-attachments/assets/cbb6de14-3962-40c3-8835-6b52bf09278f">


## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
