### PR TITLE
feat: change policymaker contacts to voter actions count

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -309,6 +309,7 @@ model UserAction {
   @@index([datetimeCreated])
   @@index([userId, nftMintId])
   @@index([userId, actionType, campaignName])
+  @@index([actionType, userId])
   @@index([actionType, campaignName])
   @@index([userCryptoAddressId])
   @@index([userSessionId])

--- a/src/components/app/homepageDialogDeeplinkLayout.tsx
+++ b/src/components/app/homepageDialogDeeplinkLayout.tsx
@@ -30,7 +30,7 @@ export async function HomepageDialogDeeplinkLayout({
   dialogContentClassName,
 }: HomepageDialogDeeplinkLayoutProps) {
   const urls = getIntlUrls(pageParams.locale)
-  const [{ sumDonations, countUsers, countPolicymakerContacts }] = await Promise.all([
+  const [{ sumDonations, countUsers, countVoterActions }] = await Promise.all([
     getHomepageTopLevelMetrics(),
   ])
   const advocatePerStateDataProps = await getAdvocatesMapData()
@@ -65,7 +65,7 @@ export async function HomepageDialogDeeplinkLayout({
         {...{
           sumDonations,
           countUsers,
-          countPolicymakerContacts,
+          countVoterActions,
         }}
         advocatePerStateDataProps={advocatePerStateDataProps}
       />

--- a/src/components/app/pageHome/index.tsx
+++ b/src/components/app/pageHome/index.tsx
@@ -26,7 +26,7 @@ export function PageHome({
   params,
   sumDonations,
   countUsers,
-  countPolicymakerContacts,
+  countVoterActions,
   actions,
   sumDonationsByUser,
   dtsiHomepagePeople,
@@ -59,7 +59,7 @@ export function PageHome({
         </div>
       </section>
       <div className="container">
-        <TopLevelMetrics {...{ sumDonations, locale, countUsers, countPolicymakerContacts }} />
+        <TopLevelMetrics {...{ sumDonations, locale, countUsers, countVoterActions }} />
 
         <section className="mb-16 md:mb-36">
           <PageTitle as="h3" className="mb-6 !text-[32px]">

--- a/src/components/app/pageHome/topLevelMetrics.tsx
+++ b/src/components/app/pageHome/topLevelMetrics.tsx
@@ -14,7 +14,7 @@ import { intlNumberFormat } from '@/utils/web/intlNumberFormat'
 
 type Props = Pick<
   Awaited<ReturnType<typeof getHomepageData>>,
-  'countPolicymakerContacts' | 'countUsers' | 'sumDonations'
+  'countVoterActions' | 'countUsers' | 'sumDonations'
 > & { locale: SupportedLocale }
 
 const mockDecreaseInValuesOnInitialLoadSoWeCanAnimateIncrease = (
@@ -27,20 +27,7 @@ const mockDecreaseInValuesOnInitialLoadSoWeCanAnimateIncrease = (
   countUsers: {
     count: roundDownNumberToAnimateIn(initial.countUsers.count, 100),
   },
-  countPolicymakerContacts: {
-    countUserActionCalls: roundDownNumberToAnimateIn(
-      initial.countPolicymakerContacts.countUserActionCalls,
-      100,
-    ),
-    countUserActionEmails: roundDownNumberToAnimateIn(
-      initial.countPolicymakerContacts.countUserActionEmails,
-      100,
-    ),
-    hardcodedCountSum: roundDownNumberToAnimateIn(
-      initial.countPolicymakerContacts.hardcodedCountSum,
-      100,
-    ),
-  },
+  countVoterActions: roundDownNumberToAnimateIn(initial.countVoterActions, 100),
 })
 
 export function TopLevelMetrics({ locale, ...data }: Props & { locale: SupportedLocale }) {
@@ -86,11 +73,7 @@ export function TopLevelMetrics({ locale, ...data }: Props & { locale: Supported
         count: intlNumberFormat(locale).format(values.countUsers.count),
       },
       countPolicymakerContacts: {
-        count: intlNumberFormat(locale).format(
-          values.countPolicymakerContacts.countUserActionEmails +
-            values.countPolicymakerContacts.countUserActionCalls +
-            values.countPolicymakerContacts.hardcodedCountSum,
-        ),
+        count: intlNumberFormat(locale).format(values.countVoterActions),
       },
     }
   }, [formatCurrency, values, locale])
@@ -98,6 +81,16 @@ export function TopLevelMetrics({ locale, ...data }: Props & { locale: Supported
   return (
     <section className="mb-16 flex flex-col gap-3 text-center md:mb-24 md:flex-row md:gap-0">
       {[
+        {
+          label: 'Crypto advocates',
+          value: <AnimatedNumericOdometer size={35} value={formatted.countUsers.count} />,
+        },
+        {
+          label: 'Advocates researched voting options',
+          value: (
+            <AnimatedNumericOdometer size={35} value={formatted.countPolicymakerContacts.count} />
+          ),
+        },
         {
           label: 'Donated by crypto advocates',
           value: (
@@ -122,16 +115,6 @@ export function TopLevelMetrics({ locale, ...data }: Props & { locale: Supported
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-          ),
-        },
-        {
-          label: 'Crypto advocates',
-          value: <AnimatedNumericOdometer size={35} value={formatted.countUsers.count} />,
-        },
-        {
-          label: 'Policymaker contacts',
-          value: (
-            <AnimatedNumericOdometer size={35} value={formatted.countPolicymakerContacts.count} />
           ),
         },
       ].map(({ label, value }, index) => (

--- a/src/data/aggregations/getCountVoterActions.ts
+++ b/src/data/aggregations/getCountVoterActions.ts
@@ -7,12 +7,12 @@ import { prismaClient } from '@/utils/server/prismaClient'
 export async function getCountVoterActions() {
   // `prismaClient.count` doesn't support distinct, that's why we're using a raw query here
   // see https://github.com/prisma/prisma/issues/4228
-  return prismaClient.$queryRaw`
-    select count(DISTINCT user_id) from user_action where action_type in (
+  return prismaClient.$queryRaw<{ count: number }[]>`
+    select count(DISTINCT user_id) as count from user_action where action_type in (
       ${UserActionType.VOTER_REGISTRATION},
       ${UserActionType.VOTER_ATTESTATION},
       ${UserActionType.VOTING_INFORMATION_RESEARCHED},
-      ${UserActionType.VIEW_KEY_RACES},
+      ${UserActionType.VIEW_KEY_RACES}
     )
-  `
+  `.then(res => Number(res[0].count))
 }

--- a/src/data/aggregations/getCountVoterActions.ts
+++ b/src/data/aggregations/getCountVoterActions.ts
@@ -5,16 +5,14 @@ import { UserActionType } from '@prisma/client'
 import { prismaClient } from '@/utils/server/prismaClient'
 
 export async function getCountVoterActions() {
-  return prismaClient.userAction.count({
-    where: {
-      actionType: {
-        in: [
-          UserActionType.VOTER_REGISTRATION,
-          UserActionType.VOTER_ATTESTATION,
-          UserActionType.VOTING_INFORMATION_RESEARCHED,
-          UserActionType.VIEW_KEY_RACES,
-        ],
-      },
-    },
-  })
+  // `prismaClient.count` doesn't support distinct, that's why we're using a raw query here
+  // see https://github.com/prisma/prisma/issues/4228
+  return prismaClient.$queryRaw`
+    select count(DISTINCT user_id) from user_action where action_type in (
+      ${UserActionType.VOTER_REGISTRATION},
+      ${UserActionType.VOTER_ATTESTATION},
+      ${UserActionType.VOTING_INFORMATION_RESEARCHED},
+      ${UserActionType.VIEW_KEY_RACES},
+    )
+  `
 }

--- a/src/data/aggregations/getCountVoterActions.ts
+++ b/src/data/aggregations/getCountVoterActions.ts
@@ -1,0 +1,20 @@
+import 'server-only'
+
+import { UserActionType } from '@prisma/client'
+
+import { prismaClient } from '@/utils/server/prismaClient'
+
+export async function getCountVoterActions() {
+  return prismaClient.userAction.count({
+    where: {
+      actionType: {
+        in: [
+          UserActionType.VOTER_REGISTRATION,
+          UserActionType.VOTER_ATTESTATION,
+          UserActionType.VOTING_INFORMATION_RESEARCHED,
+          UserActionType.VIEW_KEY_RACES,
+        ],
+      },
+    },
+  })
+}

--- a/src/data/pageSpecific/getHomepageData.ts
+++ b/src/data/pageSpecific/getHomepageData.ts
@@ -1,22 +1,22 @@
 import 'server-only'
 
-import { getCountPolicymakerContacts } from '@/data/aggregations/getCountPolicymakerContacts'
 import { getCountUsers } from '@/data/aggregations/getCountUsers'
+import { getCountVoterActions } from '@/data/aggregations/getCountVoterActions'
 import { getSumDonations } from '@/data/aggregations/getSumDonations'
 import { getSumDonationsByUser } from '@/data/aggregations/getSumDonationsByUser'
 import { queryDTSIHomepagePeople } from '@/data/dtsi/queries/queryDTSIHomepagePeople'
 import { getPublicRecentActivity } from '@/data/recentActivity/getPublicRecentActivity'
 
 export async function getHomepageTopLevelMetrics() {
-  const [sumDonations, countUsers, countPolicymakerContacts] = await Promise.all([
+  const [sumDonations, countUsers, countVoterActions] = await Promise.all([
     getSumDonations(),
     getCountUsers(),
-    getCountPolicymakerContacts(),
+    getCountVoterActions(),
   ])
   return {
     sumDonations,
     countUsers,
-    countPolicymakerContacts,
+    countVoterActions,
   }
 }
 export type GetHomepageTopLevelMetricsResponse = Awaited<
@@ -30,7 +30,7 @@ interface GetHomePageDataProps {
 
 export async function getHomepageData(props?: GetHomePageDataProps) {
   const [
-    { sumDonations, countUsers, countPolicymakerContacts },
+    { sumDonations, countUsers, countVoterActions },
     actions,
     dtsiHomepagePeople,
     sumDonationsByUser,
@@ -46,7 +46,7 @@ export async function getHomepageData(props?: GetHomePageDataProps) {
   return {
     sumDonations,
     countUsers,
-    countPolicymakerContacts,
+    countVoterActions,
     actions,
     sumDonationsByUser,
     dtsiHomepagePeople,


### PR DESCRIPTION
closes #272 

## What changed? Why?

This is replacing the Policymaker box on the `TopLevelMetrics` cart to a new metric that counts voter actions we have, top level metrics are any of the following:
- VOTER_REGISTRATION
- VOTER_ATTESTATION
- VOTING_INFORMATION_RESEARCHED
-  VIEW_KEY_RACES

## PlanetScale Deploy Request

https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/73

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
