### PR TITLE
fix: revert order on top level metrics

### DIFF
--- a/src/components/app/pageHome/topLevelMetrics.tsx
+++ b/src/components/app/pageHome/topLevelMetrics.tsx
@@ -82,16 +82,6 @@ export function TopLevelMetrics({ locale, ...data }: Props & { locale: Supported
     <section className="mb-16 flex flex-col gap-3 text-center md:mb-24 md:flex-row md:gap-0">
       {[
         {
-          label: 'Crypto advocates',
-          value: <AnimatedNumericOdometer size={35} value={formatted.countUsers.count} />,
-        },
-        {
-          label: 'Advocates researched voting options',
-          value: (
-            <AnimatedNumericOdometer size={35} value={formatted.countPolicymakerContacts.count} />
-          ),
-        },
-        {
           label: 'Donated by crypto advocates',
           value: (
             <TooltipProvider delayDuration={0}>
@@ -115,6 +105,16 @@ export function TopLevelMetrics({ locale, ...data }: Props & { locale: Supported
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
+          ),
+        },
+        {
+          label: 'Crypto advocates',
+          value: <AnimatedNumericOdometer size={35} value={formatted.countUsers.count} />,
+        },
+        {
+          label: 'Advocates researched voting options',
+          value: (
+            <AnimatedNumericOdometer size={35} value={formatted.countPolicymakerContacts.count} />
           ),
         },
       ].map(({ label, value }, index) => (


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
