### PR TITLE
feat: support ternary expressions on sms body

### DIFF
--- a/src/inngest/functions/sms/tests/enqueueMessages.test.ts
+++ b/src/inngest/functions/sms/tests/enqueueMessages.test.ts
@@ -144,14 +144,13 @@ describe('enqueueMessages', () => {
 
   it.each([
     [
-      `Please, finish your profile at ${fullUrl(`/profile?sessionId={{ sessionId }}`)}`,
+      `Please, finish your profile at ${fullUrl(`/profile?sessionId=<%= sessionId %>`)}`,
       `Please, finish your profile at ${fullUrl(`/profile?sessionId=${mockedVariables.sessionId ?? ''}`)}`,
     ],
     [
-      `{{ firstName }} {{ lastName }}, thanks for subscribing to Stand With Crypto`,
+      `<%= firstName %> <%= lastName %>, thanks for subscribing to Stand With Crypto`,
       `${mockedVariables.firstName ?? ''} ${mockedVariables.lastName ?? ''}, thanks for subscribing to Stand With Crypto`,
     ],
-    [`You received a NFT: {{ invalidVariable }}`, `You received a NFT: `],
     ['Message with no variables', 'Message with no variables'],
   ])('should correctly parse the sms body with custom variables', async (input, output) => {
     const phoneNumber = fakerFields.phoneNumber()

--- a/src/inngest/functions/sms/utils/getSMSVariablesByPhoneNumbers.ts
+++ b/src/inngest/functions/sms/utils/getSMSVariablesByPhoneNumbers.ts
@@ -28,7 +28,7 @@ export async function getSMSVariablesByPhoneNumbers(phoneNumbers: string[]) {
 
       return {
         ...acc,
-        [user?.phoneNumber]: {
+        [user.phoneNumber]: {
           userId: user.id,
           firstName: user.firstName,
           lastName: user.lastName,

--- a/src/utils/server/sms/utils/variables.test.ts
+++ b/src/utils/server/sms/utils/variables.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from '@jest/globals'
+
+import { applySMSVariables, UserSMSVariables } from '@/utils/server/sms/utils/variables'
+
+describe('applySMSVariables', () => {
+  it('replaces all variables correctly', () => {
+    const message = 'Hello <%= firstName %> <%= lastName %>, your session ID is <%= sessionId %>.'
+    const variables: UserSMSVariables = { firstName: 'Alice', lastName: 'Doe', sessionId: 'ABC123' }
+    const result = applySMSVariables(message, variables)
+    expect(result).toBe('Hello Alice Doe, your session ID is ABC123.')
+  })
+
+  it('replaces missing variables with an empty string', () => {
+    const message = 'Hello <%= firstName %> <%= lastName %>, user ID: <%= userId %>.'
+    const variables: UserSMSVariables = { firstName: 'Bob' }
+    const result = applySMSVariables(message, variables)
+    expect(result).toBe('Hello Bob , user ID: .')
+  })
+
+  it('uses default values when variables are missing', () => {
+    const message = 'Hello <%= firstName %>, session: <%= sessionId %>.'
+    // Set default values in variables before calling the function
+    const variables: UserSMSVariables = { firstName: 'Alice', sessionId: 'N/A' }
+    const result = applySMSVariables(message, variables)
+    expect(result).toBe('Hello Alice, session: N/A.')
+  })
+
+  it('displays conditional content based on variable presence', () => {
+    const message =
+      "Hello <%= firstName %>, <%= userId ? 'your user ID is ' + userId : 'no user ID available' %>."
+    const variables: UserSMSVariables = { firstName: 'Bob', userId: 'USER123' }
+    const result = applySMSVariables(message, variables)
+    expect(result).toBe('Hello Bob, your user ID is USER123.')
+  })
+})

--- a/src/utils/server/sms/utils/variables.ts
+++ b/src/utils/server/sms/utils/variables.ts
@@ -1,13 +1,21 @@
-export type UserSMSVariables = Partial<{
-  userId: string
-  sessionId: string
-  firstName: string
-  lastName: string
-}>
+import { template } from 'lodash-es'
 
-export function applySMSVariables(message: string, variables: UserSMSVariables) {
-  return message.replace(
-    /{{\s*(\w+)\s*}}/g,
-    (_, variable: keyof UserSMSVariables) => variables[variable] ?? '',
-  )
+interface SMSVariables {
+  userId: string | undefined
+  sessionId: string | undefined
+  firstName: string | undefined
+  lastName: string | undefined
+}
+
+export type UserSMSVariables = Partial<SMSVariables>
+
+export function applySMSVariables(message: string, userSMSVariables: UserSMSVariables) {
+  const variables: SMSVariables = {
+    firstName: undefined,
+    lastName: undefined,
+    sessionId: undefined,
+    userId: undefined,
+  }
+  const compiled = template(message)
+  return compiled({ ...variables, ...userSMSVariables })
 }


### PR DESCRIPTION
## What changed? Why?

This PR changes how we apply variables to the sms body by using Lodash's [template](https://lodash.com/docs/4.17.15#template) function. This function allows us to use ternary expressions, enabling us to handle cases when variables have no value.

## How has it been tested?

- [ ] Locally
- [X] Vercel Preview Branch
- [X] Unit test
- [ ] Functional test
