### PR TITLE
fix: init mixpanel on cookie consent

### DIFF
--- a/src/components/app/cookieConsent/useCookieConsent.ts
+++ b/src/components/app/cookieConsent/useCookieConsent.ts
@@ -7,6 +7,7 @@ import {
   CookieConsentPermissions,
   serializeCookieConsent,
 } from '@/utils/shared/cookieConsent'
+import { maybeInitClientAnalytics } from '@/utils/web/clientAnalytics'
 import { setClientCookieConsent } from '@/utils/web/clientCookieConsent'
 
 const REJECTED_VALUES = {
@@ -24,6 +25,7 @@ export function useCookieConsent() {
     typeof window !== 'undefined' && !!window.navigator?.globalPrivacyControl
 
   const toggleProviders = React.useCallback((permissions: CookieConsentPermissions) => {
+    maybeInitClientAnalytics()
     if (!permissions.targeting) {
       mixpanel.opt_out_tracking()
     }


### PR DESCRIPTION
closes #1541 

fixes [PROD-SWC-WEB-4ZM](https://stand-with-crypto.sentry.io/issues/5963833040/events/b94d04c50a0c4112a3f757750e2d9d80/)

## What changed? Why?

Sometimes Mixpanel isn't loaded when the user accepts or rejects our cookies, so we need to attempt to initialize the analytics client each time the user interacts with cookies.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
