### PR TITLE
feat: adds new logging prisma extension

### DIFF
--- a/prisma/extensions/logQuery.ts
+++ b/prisma/extensions/logQuery.ts
@@ -1,0 +1,19 @@
+import { Prisma } from '@prisma/client'
+
+export default Prisma.defineExtension(client => {
+  return client.$extends({
+    name: 'logQuery',
+    query: {
+      $allModels: {
+        async $allOperations({ operation, model, args, query }) {
+          const start = performance.now()
+          const result = await query(args)
+          const end = performance.now()
+          const time = end - start
+          console.log({ model, operation, args, time: `${time}ms` })
+          return result
+        },
+      },
+    },
+  })
+})


### PR DESCRIPTION
## What changed? Why?

This PR adds a new database logging extension to help get query execution time metric.

## Example:

![image](https://github.com/user-attachments/assets/ba3708ae-cc6a-455b-a995-f62c6f5992bf)

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
