### PR TITLE
Changes prisma logging args to improve visibility

### DIFF
--- a/prisma/extensions/logQuery.ts
+++ b/prisma/extensions/logQuery.ts
@@ -1,0 +1,19 @@
+import { Prisma } from '@prisma/client'
+
+export default Prisma.defineExtension(client => {
+  return client.$extends({
+    name: 'logQuery',
+    query: {
+      $allModels: {
+        async $allOperations({ operation, model, args, query }) {
+          const start = performance.now()
+          const result = await query(args)
+          const end = performance.now()
+          const time = end - start
+          console.log({ model, operation, args, time: `${time}ms` })
+          return result
+        },
+      },
+    },
+  })
+})

--- a/prisma/extensions/logQuery.ts
+++ b/prisma/extensions/logQuery.ts
@@ -10,7 +10,7 @@ export default Prisma.defineExtension(client => {
           const result = await query(args)
           const end = performance.now()
           const time = end - start
-          console.log({ model, operation, args, time: `${time}ms` })
+          console.log({ model, operation, args: JSON.stringify(args), time: `${time}ms` })
           return result
         },
       },


### PR DESCRIPTION
## What changed? Why?

This PR changes prisma log to use JSON.stringify to help improve all arguments visibility

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
