### PR TITLE
fix: increase max enqueueMessages max retry attempt and return 0 if limit exceeded instead of throwing a NonRetriableError

### DIFF
--- a/src/inngest/functions/sms/enqueueMessages.ts
+++ b/src/inngest/functions/sms/enqueueMessages.ts
@@ -56,8 +56,11 @@ export const enqueueSMS = inngest.createFunction(
     }
 
     // This function has a built-in mechanism that retries only failed messages
-    if (attempt >= 4) {
-      throw new NonRetriableError(`SMS queuing attempt limit exceeded`)
+    if (attempt >= 5) {
+      return {
+        queuedMessages: 0,
+        segmentsSent: 0,
+      }
     }
 
     // This mechanism reuses previous variables to save an Inngest step


### PR DESCRIPTION
fixes [PROD-SWC-WEB-530](https://stand-with-crypto.sentry.io/issues/6034042741/events/727f120a50fa4921acf7cf1fd42fa8fb/)

## What changed? Why?

If we exceed the attempt limit, we shouldn't stop the function's execution; instead, we should move to the next step and continue sending messages.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
