### PR TITLE
fix: remove all calls to the DB in the sms status webhook

### DIFF
--- a/src/inngest/functions/sms/enqueueMessages.ts
+++ b/src/inngest/functions/sms/enqueueMessages.ts
@@ -15,6 +15,7 @@ import { optOutUser } from '@/utils/server/sms/actions'
 import { countSegments, getUserByPhoneNumber } from '@/utils/server/sms/utils'
 import { applySMSVariables, UserSMSVariables } from '@/utils/server/sms/utils/variables'
 import { getLogger } from '@/utils/shared/logger'
+import { apiUrls, fullUrl } from '@/utils/shared/urls'
 
 export const ENQUEUE_SMS_INNGEST_EVENT_NAME = 'app/enqueue.sms'
 const ENQUEUE_SMS_INNGEST_FUNCTION_ID = 'app.enqueue-sms'
@@ -163,6 +164,13 @@ export async function enqueueMessages(
             body: applySMSVariables(body, phoneNumberVariables),
             to: phoneNumber,
             media,
+            statusCallbackUrl: fullUrl(
+              apiUrls.smsStatusCallback({
+                journeyType,
+                campaignName,
+                userId: phoneNumberVariables.userId,
+              }),
+            ),
           })
 
           if (queuedMessage) {

--- a/src/utils/server/sms/sendSMS.ts
+++ b/src/utils/server/sms/sendSMS.ts
@@ -3,7 +3,6 @@ import { z } from 'zod'
 import { isPhoneNumberSupported } from '@/utils/server/sms/utils'
 import { requiredEnv } from '@/utils/shared/requiredEnv'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
-import { apiUrls, fullUrl } from '@/utils/shared/urls'
 
 import { messagingClient } from './messagingClient'
 import { SendSMSError } from './SendSMSError'
@@ -17,6 +16,7 @@ const zodSendSMSSchema = z.object({
   to: z.string(),
   body: z.string(),
   media: z.array(z.string()).optional(),
+  statusCallbackUrl: z.string().optional(),
 })
 
 export type SendSMSPayload = z.infer<typeof zodSendSMSSchema>
@@ -28,7 +28,7 @@ export const sendSMS = async (payload: SendSMSPayload) => {
     throw new Error('Invalid sendSMS payload')
   }
 
-  const { body, to, media } = validatedInput.data
+  const { body, to, media, statusCallbackUrl } = validatedInput.data
 
   if (!isPhoneNumberSupported(to)) {
     return
@@ -42,7 +42,7 @@ export const sendSMS = async (payload: SendSMSPayload) => {
     const message = await messagingClient.messages.create({
       messagingServiceSid: TWILIO_MESSAGING_SERVICE_SID,
       body,
-      statusCallback: fullUrl(apiUrls.smsStatusCallback()),
+      statusCallback: statusCallbackUrl,
       to,
       mediaUrl: media,
     })

--- a/src/utils/server/sms/utils/variables.test.ts
+++ b/src/utils/server/sms/utils/variables.test.ts
@@ -5,22 +5,32 @@ import { applySMSVariables, UserSMSVariables } from '@/utils/server/sms/utils/va
 describe('applySMSVariables', () => {
   it('replaces all variables correctly', () => {
     const message = 'Hello <%= firstName %> <%= lastName %>, your session ID is <%= sessionId %>.'
-    const variables: UserSMSVariables = { firstName: 'Alice', lastName: 'Doe', sessionId: 'ABC123' }
+    const variables: UserSMSVariables = {
+      firstName: 'Alice',
+      lastName: 'Doe',
+      sessionId: 'ABC123',
+      userId: 'USER123',
+    }
     const result = applySMSVariables(message, variables)
     expect(result).toBe('Hello Alice Doe, your session ID is ABC123.')
   })
 
   it('replaces missing variables with an empty string', () => {
     const message = 'Hello <%= firstName %> <%= lastName %>, user ID: <%= userId %>.'
-    const variables: UserSMSVariables = { firstName: 'Bob' }
+    const variables: UserSMSVariables = {
+      firstName: 'Bob',
+      lastName: '',
+      sessionId: 'ABC123',
+      userId: 'USER123',
+    }
     const result = applySMSVariables(message, variables)
-    expect(result).toBe('Hello Bob , user ID: .')
+    expect(result).toBe('Hello Bob , user ID: USER123.')
   })
 
   it('uses default values when variables are missing', () => {
-    const message = 'Hello <%= firstName %>, session: <%= sessionId %>.'
+    const message = 'Hello <%= firstName %>, session: <%= sessionId ? sessionId : "N/A" %>.'
     // Set default values in variables before calling the function
-    const variables: UserSMSVariables = { firstName: 'Alice', sessionId: 'N/A' }
+    const variables: UserSMSVariables = { firstName: 'Alice', lastName: '', userId: 'USER123' }
     const result = applySMSVariables(message, variables)
     expect(result).toBe('Hello Alice, session: N/A.')
   })
@@ -28,7 +38,7 @@ describe('applySMSVariables', () => {
   it('displays conditional content based on variable presence', () => {
     const message =
       "Hello <%= firstName %>, <%= userId ? 'your user ID is ' + userId : 'no user ID available' %>."
-    const variables: UserSMSVariables = { firstName: 'Bob', userId: 'USER123' }
+    const variables: UserSMSVariables = { firstName: 'Bob', userId: 'USER123', lastName: '' }
     const result = applySMSVariables(message, variables)
     expect(result).toBe('Hello Bob, your user ID is USER123.')
   })

--- a/src/utils/server/sms/utils/variables.ts
+++ b/src/utils/server/sms/utils/variables.ts
@@ -1,21 +1,19 @@
 import { template } from 'lodash-es'
 
-interface SMSVariables {
-  userId: string | undefined
-  sessionId: string | undefined
-  firstName: string | undefined
-  lastName: string | undefined
+export interface UserSMSVariables {
+  userId: string
+  sessionId?: string
+  firstName: string
+  lastName: string
 }
 
-export type UserSMSVariables = Partial<SMSVariables>
-
-export function applySMSVariables(message: string, userSMSVariables: UserSMSVariables) {
-  const variables: SMSVariables = {
-    firstName: undefined,
-    lastName: undefined,
-    sessionId: undefined,
-    userId: undefined,
-  }
+export function applySMSVariables(message: string, variables: UserSMSVariables) {
   const compiled = template(message)
-  return compiled({ ...variables, ...userSMSVariables })
+  return compiled(
+    // All variables within the template must be defined in the variables object. If they’re not, a ReferenceError will be thrown.
+    Object.assign<UserSMSVariables, UserSMSVariables>(
+      { firstName: '', lastName: '', userId: '', sessionId: undefined },
+      variables,
+    ),
+  )
 }

--- a/src/utils/shared/urls/index.ts
+++ b/src/utils/shared/urls/index.ts
@@ -141,5 +141,14 @@ export const apiUrls = {
     stateCode: string
     district: number
   }) => `/api/public/dtsi/races/usa/${stateCode}/${district}`,
-  smsStatusCallback: () => `/api/public/sms/events/status`,
+  smsStatusCallback: ({
+    campaignName,
+    journeyType,
+    userId,
+  }: {
+    campaignName: string
+    journeyType: string
+    userId: string
+  }) =>
+    `/api/public/sms/events/status?campaignName=${campaignName}&journeyType=${journeyType}&userId=${userId}`,
 }


### PR DESCRIPTION
fixes [PROD-SWC-WEB-4GJ](https://stand-with-crypto.sentry.io/issues/5712266764/events/4656f7c7e63b4fd8b99ff9fd3f6b5589/)

## What changed? Why?

The SMS Status webhook is receiving too many calls and exhausting our database resources. This PR removes all database calls within the webhook and instead uses search parameters to log events in Mixpanel.

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
