### PR TITLE
feat: election night sms vanity URL

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -340,6 +340,11 @@ const nextConfig = {
         permanent: false,
       },
       // SMS shortlinks
+      {
+        source: '/election',
+        destination: '/races?utm_source=swc&utm_medium=sms&utm_campaign=election-results-2024',
+        permanent: true,
+      },
       // The usage of the next redirect is documented in the SWC Voter Turnout Plan document
       {
         source: '/vg/:campaignId/:sessionId*',


### PR DESCRIPTION
## What changed? Why?

Vanity URL for this message https://docs.google.com/document/d/10rbmu692hXuYezVsGgR9lL21TtoWO6d3f872Rb823t8/edit?tab=t.0#heading=h.jl0h8qz5t82d

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
