### PR TITLE
chore: restores e2e tests after election

### DIFF
--- a/cypress/e2e/06-donation-card-redirect.cy.ts
+++ b/cypress/e2e/06-donation-card-redirect.cy.ts
@@ -1,9 +1,9 @@
 /// <reference types="cypress" />
 
-it.skip('donation card redirects to donation page', () => {
+it('donation card redirects to donation page', () => {
   cy.visit('/')
 
-  cy.contains('Donate to Stand With Crypto').click()
+  cy.contains('Make a donation').click()
   cy.url().should('include', '/donate')
   cy.get('h1').contains('Protect the future of crypto')
 })

--- a/cypress/e2e/12-action-join-stand-with-crypto.cy.ts
+++ b/cypress/e2e/12-action-join-stand-with-crypto.cy.ts
@@ -3,7 +3,7 @@
 describe('action - join stand with crypto', () => {
   // Temporarily skipping this test because we need to update a Thirdweb API key configuration
   // and the person responsible for this is OOO
-  it.skip('should join stand with crypto, ask for profile update and then logout', () => {
+  it('should join stand with crypto, ask for profile update and then logout', () => {
     cy.visit('/')
 
     cy.get('button').contains('Join Stand With Crypto').click()
@@ -16,7 +16,8 @@ describe('action - join stand with crypto', () => {
     cy.get('[role="dialog"]').find('button').contains('Close').click({ force: true })
 
     // asserts that join with crypto is done and not clickable
-    cy.contains('Join Stand With Crypto').should('exist').should('not.be.enabled')
+
+    cy.get('button[data-testid="e2e-test-login"]').should('not.exist')
 
     cy.waitForLogout()
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -120,7 +120,9 @@ Cypress.Commands.add('waitForLogin', trigger => {
 })
 
 Cypress.Commands.add('waitForProfileCreation', (customUser = mockRandomUser) => {
-  cy.contains(/Finish your profile|Create an account. Get an NFT./g).should('be.visible')
+  cy.contains(/Finish your profile|Create an account. Get an NFT./g, { timeout: 30000 }).should(
+    'be.visible',
+  )
 
   cy.typeIntoInput({
     selector: 'input[placeholder="First name"]',


### PR DESCRIPTION
closes #1598 

## What changed? Why?

This PR restores some E2E tests for actions that were restored after the election

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
