### PR TITLE
fix: parse requests without search params

### DIFF
--- a/src/inngest/functions/backfillUserCommunicationMessageStatus/index.ts
+++ b/src/inngest/functions/backfillUserCommunicationMessageStatus/index.ts
@@ -28,7 +28,7 @@ export const backfillUserCommunicationMessageStatus = inngest.createFunction(
   async ({ step, logger }) => {
     let updatedCommunications = 0
     let hasMoreMessages = true
-    while (!hasMoreMessages) {
+    while (hasMoreMessages) {
       const userCommunicationIds = await step.run('fetch-user-communication', () =>
         prismaClient.userCommunication
           .findMany({


### PR DESCRIPTION
fixes PROD-SWC-WEB-4CR

## What changed? Why?

We're currently receiving requests without query parameters. In these cases, we should attempt to find the user_communication. Only if it isn't found should we throw an error.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
