### PR TITLE
fix: indexing message status

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -532,6 +532,7 @@ model UserCommunication {
   datetimeUpdated            DateTime?                  @updatedAt @map("datetime_updated")
 
   @@index([messageId])
+  @@index([status])
   @@index([userCommunicationJourneyId])
   @@map("user_communication")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -506,7 +506,7 @@ model UserCommunicationJourney {
   userCommunications UserCommunication[]
   campaignName       String?                      @map("campaign_name")
 
-  @@index([userId, journeyType, campaignName])
+  @@index([userId])
   @@map("user_communication_journey")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -506,7 +506,7 @@ model UserCommunicationJourney {
   userCommunications UserCommunication[]
   campaignName       String?                      @map("campaign_name")
 
-  @@index([userId])
+  @@index([userId, journeyType, campaignName])
   @@map("user_communication_journey")
 }
 

--- a/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
+++ b/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
@@ -370,11 +370,13 @@ async function getPhoneNumberList(options: GetPhoneNumberOptions) {
               every: {
                 OR: [
                   {
+                    journeyType: UserCommunicationJourneyType.BULK_SMS,
                     campaignName: {
                       not: options.campaignName,
                     },
                   },
                   {
+                    journeyType: UserCommunicationJourneyType.BULK_SMS,
                     campaignName: options.campaignName,
                     userCommunications: {
                       every: {

--- a/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
+++ b/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
@@ -370,13 +370,11 @@ async function getPhoneNumberList(options: GetPhoneNumberOptions) {
               every: {
                 OR: [
                   {
-                    journeyType: UserCommunicationJourneyType.BULK_SMS,
                     campaignName: {
                       not: options.campaignName,
                     },
                   },
                   {
-                    journeyType: UserCommunicationJourneyType.BULK_SMS,
                     campaignName: options.campaignName,
                     userCommunications: {
                       every: {


### PR DESCRIPTION
Bulk sms query with new status index
![image](https://github.com/user-attachments/assets/3504d86b-1204-48ca-974a-7ac4b94a28d4)

Bulk sms query without the status index
![image](https://github.com/user-attachments/assets/f143effd-725b-4a01-b304-e9eda83a31b6)


## PlanetScale deploy request

[#77](https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/77)

## How has it been tested?

- [ ] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
