### PR TITLE
chore: removes endorsed candidates who lost the election

### DIFF
--- a/src/utils/shared/locationSpecificPages.ts
+++ b/src/utils/shared/locationSpecificPages.ts
@@ -36,16 +36,15 @@ export const ENDORSED_DTSI_PERSON_SLUGS = [
   'jake---auchincloss',
   'suhas---subramanyam',
   'jasmine---crockett',
-  'jim---costa',
+  'jim---costa', // CALIFORNIA 21 - EM ABERTO
   'jared---moskowitz',
   'marsha---blackburn',
   'ted---cruz',
-  'john--deaton',
   'shomari--figures',
   'troy---downing',
   'jim---banks',
   'jim--justice',
-  'yadira---caraveo',
+  'yadira---caraveo', // COLORADO 8 - EM ABERTO
   'steven---horsford',
   'patrick---ryan',
   'timothy---kennedy',
@@ -55,11 +54,9 @@ export const ENDORSED_DTSI_PERSON_SLUGS = [
   'donald---davis',
   'brian--jack',
   'michael---lawler',
-  'marcus---molinaro',
-  'lori---chavez-deremer',
+  'lori---chavez-deremer', // OREGON 5 - EM ABERTO
   'young---kim',
   'zach---nunn',
-  'anthony---desposito',
   'kirsten---gillibrand',
   'rick---scott',
 ]

--- a/src/utils/shared/locationSpecificPages.ts
+++ b/src/utils/shared/locationSpecificPages.ts
@@ -36,7 +36,7 @@ export const ENDORSED_DTSI_PERSON_SLUGS = [
   'jake---auchincloss',
   'suhas---subramanyam',
   'jasmine---crockett',
-  'jim---costa', // CALIFORNIA 21 - EM ABERTO
+  'jim---costa',
   'jared---moskowitz',
   'marsha---blackburn',
   'ted---cruz',
@@ -44,7 +44,6 @@ export const ENDORSED_DTSI_PERSON_SLUGS = [
   'troy---downing',
   'jim---banks',
   'jim--justice',
-  'yadira---caraveo', // COLORADO 8 - EM ABERTO
   'steven---horsford',
   'patrick---ryan',
   'timothy---kennedy',
@@ -54,7 +53,6 @@ export const ENDORSED_DTSI_PERSON_SLUGS = [
   'donald---davis',
   'brian--jack',
   'michael---lawler',
-  'lori---chavez-deremer', // OREGON 5 - EM ABERTO
   'young---kim',
   'zach---nunn',
   'kirsten---gillibrand',


### PR DESCRIPTION
closes #1595 

## What changed? Why?

This PR removes all candidates who lost the 2024 election from the endorsed candidates page

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
