### PR TITLE
feat: implement keyword identification for SMS responses and add tests

### DIFF
--- a/src/app/api/public/sms/events/messages/route.ts
+++ b/src/app/api/public/sms/events/messages/route.ts
@@ -49,7 +49,7 @@ export const POST = withRouteMiddleware(async (request: NextRequest) => {
       extra: {
         ...body,
       },
-      level: 'info',
+      level: 'warning',
       tags: {
         domain: 'smsEventsMessagesRoute',
       },

--- a/src/app/api/public/sms/events/messages/route.ts
+++ b/src/app/api/public/sms/events/messages/route.ts
@@ -49,6 +49,7 @@ export const POST = withRouteMiddleware(async (request: NextRequest) => {
       extra: {
         ...body,
       },
+      level: 'info',
       tags: {
         domain: 'smsEventsMessagesRoute',
       },
@@ -72,6 +73,7 @@ export const POST = withRouteMiddleware(async (request: NextRequest) => {
       extra: {
         ...body,
       },
+      level: 'info',
       tags: {
         domain: 'smsEventsMessagesRoute',
       },

--- a/src/utils/server/sms/identifyIncomingKeyword.test.ts
+++ b/src/utils/server/sms/identifyIncomingKeyword.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from '@jest/globals'
+
+import { identifyIncomingKeyword } from '@/utils/server/sms/identifyIncomingKeyword'
+
+describe('identifyIncomingKeyword', () => {
+  it.each(['STOP', 'Stop', 'Stop\n', 'stop ', '\nSTOPALL', '   STop'])(
+    'should identify opt-out keyword: %s',
+    keyword => {
+      expect(identifyIncomingKeyword(keyword)).toEqual({
+        isOptOutKeyword: true,
+        isHelpKeyword: false,
+        isUnstopKeyword: false,
+      })
+    },
+  )
+
+  it.each(['HELP', 'Help', 'help ', '\nHELP', '   Help'])(
+    'should identify help keyword: %s',
+    keyword => {
+      expect(identifyIncomingKeyword(keyword)).toEqual({
+        isOptOutKeyword: false,
+        isHelpKeyword: true,
+        isUnstopKeyword: false,
+      })
+    },
+  )
+
+  it.each([
+    'YES',
+    'Yes',
+    'yes ',
+    'start ',
+    '\nSTART',
+    '   Start',
+    'CONTINUE',
+    '\nUNSTOP',
+    '   Unstop',
+  ])('should identify unstop keyword: %s', keyword => {
+    expect(identifyIncomingKeyword(keyword)).toEqual({
+      isOptOutKeyword: false,
+      isHelpKeyword: false,
+      isUnstopKeyword: true,
+    })
+  })
+})

--- a/src/utils/server/sms/identifyIncomingKeyword.ts
+++ b/src/utils/server/sms/identifyIncomingKeyword.ts
@@ -1,0 +1,15 @@
+const optOutKeywords = ['STOPALL', 'UNSUBSCRIBE', 'CANCEL', 'END', 'QUIT', 'STOP']
+const helpKeywords = ['HELP']
+const unstopKeywords = ['YES', 'START', 'CONTINUE', 'UNSTOP']
+
+export function identifyIncomingKeyword(keyword: string | undefined) {
+  if (!keyword || keyword.length === 0) return
+
+  const normalizedKeyword = keyword?.toUpperCase().trim()
+
+  return {
+    isOptOutKeyword: optOutKeywords.includes(normalizedKeyword),
+    isHelpKeyword: helpKeywords.includes(normalizedKeyword),
+    isUnstopKeyword: unstopKeywords.includes(normalizedKeyword),
+  }
+}


### PR DESCRIPTION
closes [#1613](https://github.com/Stand-With-Crypto/swc-web/issues/1613)

## What changed? Why?

This pull request introduces a new function to identify incoming SMS keywords and refactors the existing keyword identification logic to improve readability and maintainability. It also includes corresponding unit tests for the new function.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [X] Unit test
- [ ] Functional test
