### PR TITLE
fix: update WELCOME_MESSAGE to include resource browsing instead of voting link

### DIFF
--- a/src/utils/server/sms/messages.ts
+++ b/src/utils/server/sms/messages.ts
@@ -1,6 +1,6 @@
 import { fullUrl } from '@/utils/shared/urls'
 
-export const WELCOME_MESSAGE = `Thanks for subscribing to Stand With Crypto! You can expect news, opportunities to engage, and critical updates on crypto policy. The most important thing you can do NOW is to learn where your politicians stand on crypto and get ready to vote at ${fullUrl('/w/vote/<%= sessionId %>')} \n\nMessage & data rates may apply. Message frequency varies. Reply HELP for help or STOP to opt out.`
+export const WELCOME_MESSAGE = `Thanks for subscribing to Stand With Crypto! You can expect news, opportunities to engage, and critical updates on crypto policy. Browse our resources and research where your elected officials stand on crypto at ${fullUrl('')} \n\nMessage & data rates may apply. Message frequency varies. Reply HELP for help or STOP to opt out.`
 
 export const GOODBYE_MESSAGE = `You have opted out and will no longer receive texts from Stand With Crypto. Text START to receive texts from SWC.`
 


### PR DESCRIPTION
## What changed? Why?

This PR updates the welcome sms message to a more generic message and removes the link to the voter guide

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
