### PR TITLE
fix: politician page scroll

### DIFF
--- a/cypress/e2e/09-page-politician-details.cy.ts
+++ b/cypress/e2e/09-page-politician-details.cy.ts
@@ -6,9 +6,7 @@ describe('page - politician details', () => {
 
     cy.get('h2').contains('Candidate questionnaire')
 
-    cy.wait(3000)
-
-    cy.get('[data-testid="questionnaire-trigger"]').click()
+    cy.get('[data-testid="questionnaire-trigger"]').click({ force: true })
 
     cy.get('div')
       .should(

--- a/cypress/e2e/09-page-politician-details.cy.ts
+++ b/cypress/e2e/09-page-politician-details.cy.ts
@@ -6,6 +6,8 @@ describe('page - politician details', () => {
 
     cy.get('h2').contains('Candidate questionnaire')
 
+    cy.wait(3000)
+
     cy.get('[data-testid="questionnaire-trigger"]').click()
 
     cy.get('div')

--- a/cypress/e2e/09-page-politician-details.cy.ts
+++ b/cypress/e2e/09-page-politician-details.cy.ts
@@ -6,7 +6,7 @@ describe('page - politician details', () => {
 
     cy.get('h2').contains('Candidate questionnaire')
 
-    cy.contains('Responses (8)').click()
+    cy.get('[data-testid="questionnaire-trigger"]').click()
 
     cy.get('div')
       .should(

--- a/src/components/app/pagePoliticianDetails/index.tsx
+++ b/src/components/app/pagePoliticianDetails/index.tsx
@@ -4,11 +4,11 @@ import { Globe } from 'lucide-react'
 
 import { DTSIStanceDetails } from '@/components/app/dtsiStanceDetails'
 import {
-  QUESTIONNAIRE_HASH_KEY,
+  // QUESTIONNAIRE_HASH_KEY,
   QuestionnaireAccordion,
 } from '@/components/app/pagePoliticianDetails/questionnaireAccordion'
 import { ScoreExplainer } from '@/components/app/pagePoliticianDetails/scoreExplainer'
-import { ScrollToTopOnRender } from '@/components/app/scrollToTopOnRender'
+// import { ScrollToTopOnRender } from '@/components/app/scrollToTopOnRender'
 import { Button } from '@/components/ui/button'
 import { MaybeNextImg, NextImage } from '@/components/ui/image'
 import { InitialsAvatar } from '@/components/ui/initialsAvatar'

--- a/src/components/app/pagePoliticianDetails/index.tsx
+++ b/src/components/app/pagePoliticianDetails/index.tsx
@@ -149,7 +149,7 @@ export function PagePoliticianDetails({
           ))}
         </div>
       </section>
-      <ScrollToTopOnRender blockedHashes={[QUESTIONNAIRE_HASH_KEY]} />
+      {/* <ScrollToTopOnRender blockedHashes={[QUESTIONNAIRE_HASH_KEY]} /> */}
     </div>
   )
 }

--- a/src/components/app/pagePoliticianDetails/index.tsx
+++ b/src/components/app/pagePoliticianDetails/index.tsx
@@ -5,6 +5,7 @@ import { Globe } from 'lucide-react'
 import { DTSIStanceDetails } from '@/components/app/dtsiStanceDetails'
 import { QuestionnaireAccordion } from '@/components/app/pagePoliticianDetails/questionnaireAccordion'
 import { ScoreExplainer } from '@/components/app/pagePoliticianDetails/scoreExplainer'
+import { ScrollToTopOnRender } from '@/components/app/scrollToTopOnRender'
 import { Button } from '@/components/ui/button'
 import { MaybeNextImg, NextImage } from '@/components/ui/image'
 import { InitialsAvatar } from '@/components/ui/initialsAvatar'
@@ -46,6 +47,7 @@ export function PagePoliticianDetails({
 
   return (
     <div className="standard-spacing-from-navbar container max-w-3xl">
+      <ScrollToTopOnRender />
       <section>
         {person.profilePictureUrl ? (
           <div

--- a/src/components/app/pagePoliticianDetails/index.tsx
+++ b/src/components/app/pagePoliticianDetails/index.tsx
@@ -50,7 +50,6 @@ export function PagePoliticianDetails({
 
   return (
     <div className="standard-spacing-from-navbar container max-w-3xl">
-      <ScrollToTopOnRender blockedHashes={[QUESTIONNAIRE_HASH_KEY]} />
       <section>
         {person.profilePictureUrl ? (
           <div
@@ -150,6 +149,7 @@ export function PagePoliticianDetails({
           ))}
         </div>
       </section>
+      <ScrollToTopOnRender blockedHashes={[QUESTIONNAIRE_HASH_KEY]} />
     </div>
   )
 }

--- a/src/components/app/pagePoliticianDetails/index.tsx
+++ b/src/components/app/pagePoliticianDetails/index.tsx
@@ -3,7 +3,10 @@ import { orderBy } from 'lodash-es'
 import { Globe } from 'lucide-react'
 
 import { DTSIStanceDetails } from '@/components/app/dtsiStanceDetails'
-import { QuestionnaireAccordion } from '@/components/app/pagePoliticianDetails/questionnaireAccordion'
+import {
+  QUESTIONNAIRE_HASH_KEY,
+  QuestionnaireAccordion,
+} from '@/components/app/pagePoliticianDetails/questionnaireAccordion'
 import { ScoreExplainer } from '@/components/app/pagePoliticianDetails/scoreExplainer'
 import { ScrollToTopOnRender } from '@/components/app/scrollToTopOnRender'
 import { Button } from '@/components/ui/button'
@@ -47,7 +50,7 @@ export function PagePoliticianDetails({
 
   return (
     <div className="standard-spacing-from-navbar container max-w-3xl">
-      <ScrollToTopOnRender />
+      <ScrollToTopOnRender blockedHashes={[QUESTIONNAIRE_HASH_KEY]} />
       <section>
         {person.profilePictureUrl ? (
           <div

--- a/src/components/app/pagePoliticianDetails/index.tsx
+++ b/src/components/app/pagePoliticianDetails/index.tsx
@@ -4,11 +4,11 @@ import { Globe } from 'lucide-react'
 
 import { DTSIStanceDetails } from '@/components/app/dtsiStanceDetails'
 import {
-  // QUESTIONNAIRE_HASH_KEY,
+  QUESTIONNAIRE_HASH_KEY,
   QuestionnaireAccordion,
 } from '@/components/app/pagePoliticianDetails/questionnaireAccordion'
 import { ScoreExplainer } from '@/components/app/pagePoliticianDetails/scoreExplainer'
-// import { ScrollToTopOnRender } from '@/components/app/scrollToTopOnRender'
+import { ScrollToTopOnRender } from '@/components/app/scrollToTopOnRender'
 import { Button } from '@/components/ui/button'
 import { MaybeNextImg, NextImage } from '@/components/ui/image'
 import { InitialsAvatar } from '@/components/ui/initialsAvatar'
@@ -149,7 +149,7 @@ export function PagePoliticianDetails({
           ))}
         </div>
       </section>
-      {/* <ScrollToTopOnRender blockedHashes={[QUESTIONNAIRE_HASH_KEY]} /> */}
+      <ScrollToTopOnRender blockedHashes={[QUESTIONNAIRE_HASH_KEY]} />
     </div>
   )
 }

--- a/src/components/app/pagePoliticianDetails/questionnaireAccordion.tsx
+++ b/src/components/app/pagePoliticianDetails/questionnaireAccordion.tsx
@@ -60,7 +60,9 @@ export function QuestionnaireAccordion({ questionnaire }: QuestionnaireAccordion
 
       <Accordion collapsible onValueChange={setAccordionValue} type="single" value={accordionValue}>
         <AccordionItem value="questionnaire">
-          <AccordionTrigger>Responses ({answersAmount})</AccordionTrigger>
+          <AccordionTrigger data-testid="questionnaire-trigger">
+            Responses ({answersAmount})
+          </AccordionTrigger>
 
           <AccordionContent className="pb-0">
             <div className="px-6 last:*:border-none">

--- a/src/components/app/pagePoliticianDetails/questionnaireAccordion.tsx
+++ b/src/components/app/pagePoliticianDetails/questionnaireAccordion.tsx
@@ -20,7 +20,7 @@ interface QuestionnaireAccordionProps {
   questionnaire: SWCQuestionnaireAnswers
 }
 
-const QUESTIONNAIRE_HASH_KEY = 'questionnaire'
+export const QUESTIONNAIRE_HASH_KEY = 'questionnaire'
 
 export function QuestionnaireAccordion({ questionnaire }: QuestionnaireAccordionProps) {
   const [accordionValue, setAccordionValue] = useState('')

--- a/src/components/app/scrollToTopOnRender.tsx
+++ b/src/components/app/scrollToTopOnRender.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export function ScrollToTopOnRender() {
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
+
+  return null
+}

--- a/src/components/app/scrollToTopOnRender.tsx
+++ b/src/components/app/scrollToTopOnRender.tsx
@@ -1,11 +1,31 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffectOnce } from '@/hooks/useEffectOnce'
+import { useUrlHash } from '@/hooks/useUrlHash'
 
-export function ScrollToTopOnRender() {
-  useEffect(() => {
+interface ScrollToTopOnRenderProps {
+  blockedHashes?: string[]
+}
+
+/**
+ * This component scrolls the page to the top when rendered.
+ * You can prevent this behavior by providing a list of URL hashes that should bypass the scroll-to-top action.
+ * It's particularly useful in server-rendered pages where you want to ensure the user starts at the top of the page upon rendering.
+ *
+ *
+ * @param blockedHashes - optional - A list of hashes that should not trigger the scroll to top
+ * @example <ScrollToTopOnRender blockedHashes={["questionnaire"]} />
+ * @returns null
+ */
+export function ScrollToTopOnRender({ blockedHashes }: ScrollToTopOnRenderProps) {
+  const urlHash = useUrlHash()
+
+  useEffectOnce(() => {
+    const shouldNotScrollToTop = blockedHashes && blockedHashes.some(hash => urlHash === hash)
+    if (shouldNotScrollToTop) return
+
     window.scrollTo(0, 0)
-  }, [])
+  })
 
   return null
 }


### PR DESCRIPTION
closes #814 

## What changed? Why?

This PR addresses a long-standing issue where, on mobile devices in production, if you visit a politician's page, scroll down, then navigate back and to a different politician's page, the scroll position from the previous page is unexpectedly carried over to the new page. This requires the user to manually scroll back to the top.

I've tested various approaches to fix this, including [enabling and disabling scroll behavior on router.push](https://nextjs.org/docs/app/api-reference/functions/use-router#disabling-scroll-to-top), but this didn’t resolve the issue. I also tried adding an ID to the politician photo section and appending it to the router's pathname, but that approach didn't work either. Given that all politician page components are server-side rendered and useEffect can’t be used to handle scrolling, I created a new component that ensures the page scrolls to the top upon render. This solution can also be reused in other server-side components.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

## Before the fix

https://github.com/user-attachments/assets/d6b55c44-1638-4947-9447-a03e6998586c

## After the fix

https://github.com/user-attachments/assets/125f142c-4637-43ad-8ee2-8cfb5bba5ec8


