### PR TITLE
feat: add backfill script to opt out users who weren't opted out correctly

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -29,6 +29,7 @@ import { initialSignUpUserCommunicationJourney } from '@/inngest/functions/initi
 import { monitorBaseETHBalances } from '@/inngest/functions/monitorBaseETHBalances'
 import { setPrimaryCryptoAddressOfUserWithInngest } from '@/inngest/functions/setPrimaryCryptoAddressOfUser'
 import {
+  backfillOptedOutUsers,
   backfillPhoneNumberValidation,
   bulkSMSCommunicationJourney,
   enqueueSMS,
@@ -81,5 +82,6 @@ export const { GET, POST, PUT } = serve({
     enqueueSMS,
     backfillUserCommunicationMessageStatus,
     updateMetricsCacheInngestCronJob,
+    backfillOptedOutUsers,
   ],
 })

--- a/src/inngest/functions/sms/backfillOptedOutUsers.ts
+++ b/src/inngest/functions/sms/backfillOptedOutUsers.ts
@@ -1,22 +1,25 @@
 import { SMSStatus } from '@prisma/client'
+import { addDays, format, isBefore, isEqual, parseISO, startOfDay } from 'date-fns'
+import { NonRetriableError } from 'inngest'
+import { chunk } from 'lodash-es'
 
 import { inngest } from '@/inngest/inngest'
 import { prismaClient } from '@/utils/server/prismaClient'
-import { messagingClient } from '@/utils/server/sms'
+import { messagingClient, TWILIO_LIST_MESSAGES_QUERY_LIMIT } from '@/utils/server/sms'
 import { identifyIncomingKeyword } from '@/utils/server/sms/identifyIncomingKeyword'
+import { Logger } from '@/utils/shared/logger'
 
 const BACKFILL_OPTED_OUT_USERS_FUNCTION_ID = 'script.backfill-sms-opted-out-users'
 const BACKFILL_OPTED_OUT_USERS_EVENT_NAME = 'script/backfill.sms.opted.out.users'
 
 const TWILIO_PHONE_NUMBER = process.env.TWILIO_PHONE_NUMBER
-const YEAR = 2024
+const TWILIO_GO_LIVE_DATE = parseISO('2024-08-01')
 
 export interface BackfillOptedOutUsersSchema {
   name: typeof BACKFILL_OPTED_OUT_USERS_EVENT_NAME
   data: {
     persist: boolean
-    startingMonth?: number
-    startingDay?: number
+    startingDate?: string
   }
 }
 
@@ -29,87 +32,149 @@ export const backfillOptedOutUsers = inngest.createFunction(
     event: BACKFILL_OPTED_OUT_USERS_EVENT_NAME,
   },
   async ({ step, logger, event }) => {
-    const { persist, startingMonth, startingDay } = event.data
+    const { persist, startingDate } = event.data
 
     let optedOutUsers = 0
 
-    for (let month = startingMonth ?? 1; month <= 12; month += 1) {
-      for (let day = month === (startingMonth ?? 1) ? (startingDay ?? 1) : 1; day <= 31; day += 1) {
-        const dateString = `${YEAR}-${month}-${day}`
-        const date = new Date(YEAR, month - 1, day)
+    const today = startOfDay(new Date())
+    let queryDate = startingDate ? parseISO(startingDate) : TWILIO_GO_LIVE_DATE
 
-        if (Number.isNaN(date.getDay())) {
-          continue
-        }
+    let optedOutPhoneNumbers: string[] = []
 
-        logger.info(`Fetching ${dateString}`)
-
-        const optedOutPhoneNumbers = await step.run(`fetch-opted-out-users-${dateString}`, () =>
-          getOptedOutPhoneNumbers(date),
-        )
-
-        logger.info(`Opted out phone numbers: ${optedOutPhoneNumbers.length}`)
-
-        if (optedOutPhoneNumbers.length > 0 && persist) {
-          const { count } = await step.run(`opt-out-users`, async () =>
-            prismaClient.user.updateMany({
-              where: {
-                phoneNumber: {
-                  in: optedOutPhoneNumbers,
-                },
-              },
-              data: {
-                smsStatus: SMSStatus.OPTED_OUT,
-              },
-            }),
+    while (isBefore(queryDate, today)) {
+      // This step takes more than 3 minutes to fetch all messages for 2024-11-01,
+      // so we need to split it into two time ranges to avoid timeouts.
+      if (isEqual(queryDate, parseISO('2024-11-01'))) {
+        for (const time of [
+          { start: '00:00:00', end: '18:00:00' },
+          { start: '18:00:00', end: '23:59:59' },
+        ]) {
+          const phoneNumbers = await step.run(
+            `fetch-opted-out-users-${format(queryDate, 'yyyy-MM-dd')}-${time.start}-${time.end}`,
+            () =>
+              getOptedOutPhoneNumbers({
+                dateSentAfter: new Date(`${format(queryDate, 'yyyy-MM-dd')}T${time.start}`),
+                dateSentBefore: new Date(`${format(queryDate, 'yyyy-MM-dd')}T${time.end}`),
+                logger,
+              }),
           )
 
-          optedOutUsers += count
-        } else {
-          optedOutUsers += optedOutPhoneNumbers.length
+          optedOutPhoneNumbers.push(...phoneNumbers)
         }
+      } else {
+        const phoneNumbers = await step.run(
+          `fetch-opted-out-users-${format(queryDate, 'yyyy-MM-dd')}`,
+          () => getOptedOutPhoneNumbers({ dateSent: queryDate, logger }),
+        )
+
+        optedOutPhoneNumbers.push(...phoneNumbers)
       }
+
+      queryDate = addDays(queryDate, 1)
+    }
+
+    const optedBackInPhoneNumbers: string[] = []
+
+    for (const phoneNumberChunk of chunk(optedOutPhoneNumbers, TWILIO_LIST_MESSAGES_QUERY_LIMIT)) {
+      const optedBackInPhoneNumbersChunk = await step.run(
+        `filter-opted-back-in-users-${phoneNumberChunk.length}`,
+        async () => findOptedBackInUsers(phoneNumberChunk, logger),
+      )
+
+      optedBackInPhoneNumbers.push(...optedBackInPhoneNumbersChunk)
+
+      await step.sleep('await-twilio-timeout', '30s')
+    }
+
+    optedOutPhoneNumbers = optedOutPhoneNumbers.filter(
+      phoneNumber => !optedBackInPhoneNumbers.includes(phoneNumber),
+    )
+
+    if (optedOutPhoneNumbers.length > 0 && persist) {
+      const { count } = await step.run(`opt-out-users`, async () =>
+        prismaClient.user.updateMany({
+          where: {
+            phoneNumber: {
+              in: optedOutPhoneNumbers,
+            },
+          },
+          data: {
+            smsStatus: SMSStatus.OPTED_OUT,
+          },
+        }),
+      )
+
+      optedOutUsers += count
     }
 
     return `Opted out ${optedOutUsers} users`
   },
 )
 
-const invalidStopMessages = [
-  'STOP ',
-  ' STOP',
-  'STOP\n',
-  ' STOP ',
-  `Stop
-  `,
-  `Stop 
-  `,
-] as const
+type TwilioListMessagesData = Parameters<typeof messagingClient.messages.list>[0]
 
-async function getOptedOutPhoneNumbers(date: Date) {
+interface GetOptedOutPhoneNumbersParams extends Omit<TwilioListMessagesData, 'to'> {
+  logger: Logger
+}
+
+async function getOptedOutPhoneNumbers({ logger, ...params }: GetOptedOutPhoneNumbersParams) {
   const phoneNumbers = new Set<string>()
 
   if (!TWILIO_PHONE_NUMBER) return []
 
-  console.log('Fetching...', date)
+  logger.info(`Fetching messages`, params)
 
   const messages = await messagingClient.messages.list({
-    dateSent: date,
     to: TWILIO_PHONE_NUMBER,
+    ...params,
   })
 
-  console.log('Filtering...', messages.length)
+  logger.info(`Filtering ${messages.length} message`)
 
   for (const message of messages) {
     const body = message.body.toUpperCase()
 
-    if (invalidStopMessages.includes(body)) {
+    const keyword = identifyIncomingKeyword(body)
+
+    if (keyword?.isOptOutKeyword && keyword.value !== body) {
       phoneNumbers.add(message.from)
-    }
-    if (identifyIncomingKeyword(body)?.isUnstopKeyword) {
-      phoneNumbers.delete(message.from)
     }
   }
 
+  logger.info(`Found ${phoneNumbers.size} invalid opt out messages`)
+
   return Array.from(phoneNumbers)
+}
+
+async function findOptedBackInUsers(phoneNumbers: string[], logger: Logger) {
+  if (phoneNumbers.length > TWILIO_LIST_MESSAGES_QUERY_LIMIT) {
+    throw new NonRetriableError(
+      'findOptedBackInUsers - phoneNumbers.length > TWILIO_LIST_MESSAGES_QUERY_LIMIT',
+    )
+  }
+
+  const optedBackInPhoneNumbers = new Set<string>()
+
+  await Promise.all(
+    phoneNumbers.map(async phoneNumber => {
+      const messages = await messagingClient.messages.list({
+        from: phoneNumber,
+      })
+
+      messages.forEach(({ body }) => {
+        const keyword = identifyIncomingKeyword(body)
+
+        if (keyword?.isUnstopKeyword) {
+          optedBackInPhoneNumbers.add(phoneNumber)
+        } else if (keyword?.isOptOutKeyword) {
+          // If the last message of the user was STOP, we don't want to opt them back in
+          optedBackInPhoneNumbers.delete(phoneNumber)
+        }
+      })
+    }),
+  )
+
+  logger.info(`Found ${optedBackInPhoneNumbers.size} users who opted back in`)
+
+  return Array.from(optedBackInPhoneNumbers)
 }

--- a/src/inngest/functions/sms/backfillOptedOutUsers.ts
+++ b/src/inngest/functions/sms/backfillOptedOutUsers.ts
@@ -1,0 +1,115 @@
+import { SMSStatus } from '@prisma/client'
+
+import { inngest } from '@/inngest/inngest'
+import { prismaClient } from '@/utils/server/prismaClient'
+import { messagingClient } from '@/utils/server/sms'
+import { identifyIncomingKeyword } from '@/utils/server/sms/identifyIncomingKeyword'
+
+const BACKFILL_OPTED_OUT_USERS_FUNCTION_ID = 'script.backfill-sms-opted-out-users'
+const BACKFILL_OPTED_OUT_USERS_EVENT_NAME = 'script/backfill.sms.opted.out.users'
+
+const TWILIO_PHONE_NUMBER = process.env.TWILIO_PHONE_NUMBER
+const YEAR = 2024
+
+export interface BackfillOptedOutUsersSchema {
+  name: typeof BACKFILL_OPTED_OUT_USERS_EVENT_NAME
+  data: {
+    persist: boolean
+    startingMonth?: number
+    startingDay?: number
+  }
+}
+
+export const backfillOptedOutUsers = inngest.createFunction(
+  {
+    id: BACKFILL_OPTED_OUT_USERS_FUNCTION_ID,
+    retries: 0,
+  },
+  {
+    event: BACKFILL_OPTED_OUT_USERS_EVENT_NAME,
+  },
+  async ({ step, logger, event }) => {
+    const { persist, startingMonth, startingDay } = event.data
+
+    let optedOutUsers = 0
+
+    for (let month = startingMonth ?? 1; month <= 12; month += 1) {
+      for (let day = month === (startingMonth ?? 1) ? (startingDay ?? 1) : 1; day <= 31; day += 1) {
+        const dateString = `${YEAR}-${month}-${day}`
+        const date = new Date(YEAR, month - 1, day)
+
+        if (Number.isNaN(date.getDay())) {
+          continue
+        }
+
+        logger.info(`Fetching ${dateString}`)
+
+        const optedOutPhoneNumbers = await step.run(`fetch-opted-out-users-${dateString}`, () =>
+          getOptedOutPhoneNumbers(date),
+        )
+
+        logger.info(`Opted out phone numbers: ${optedOutPhoneNumbers.length}`)
+
+        if (optedOutPhoneNumbers.length > 0 && persist) {
+          const { count } = await step.run(`opt-out-users`, async () =>
+            prismaClient.user.updateMany({
+              where: {
+                phoneNumber: {
+                  in: optedOutPhoneNumbers,
+                },
+              },
+              data: {
+                smsStatus: SMSStatus.OPTED_OUT,
+              },
+            }),
+          )
+
+          optedOutUsers += count
+        } else {
+          optedOutUsers += optedOutPhoneNumbers.length
+        }
+      }
+    }
+
+    return `Opted out ${optedOutUsers} users`
+  },
+)
+
+const invalidStopMessages = [
+  'STOP ',
+  ' STOP',
+  'STOP\n',
+  ' STOP ',
+  `Stop
+  `,
+  `Stop 
+  `,
+] as const
+
+async function getOptedOutPhoneNumbers(date: Date) {
+  const phoneNumbers = new Set<string>()
+
+  if (!TWILIO_PHONE_NUMBER) return []
+
+  console.log('Fetching...', date)
+
+  const messages = await messagingClient.messages.list({
+    dateSent: date,
+    to: TWILIO_PHONE_NUMBER,
+  })
+
+  console.log('Filtering...', messages.length)
+
+  for (const message of messages) {
+    const body = message.body.toUpperCase()
+
+    if (invalidStopMessages.includes(body)) {
+      phoneNumbers.add(message.from)
+    }
+    if (identifyIncomingKeyword(body)?.isUnstopKeyword) {
+      phoneNumbers.delete(message.from)
+    }
+  }
+
+  return Array.from(phoneNumbers)
+}

--- a/src/inngest/functions/sms/index.ts
+++ b/src/inngest/functions/sms/index.ts
@@ -1,3 +1,4 @@
+export { backfillOptedOutUsers } from './backfillOptedOutUsers'
 export { backfillPhoneNumberValidation } from './backfillPhoneNumberValidation'
 export { bulkSMSCommunicationJourney } from './bulkSMSCommunicationJourney'
 export { enqueueSMS } from './enqueueMessages'

--- a/src/inngest/types.ts
+++ b/src/inngest/types.ts
@@ -21,10 +21,11 @@ import type { FetchPresidentialRacesInngestEventSchema } from '@/inngest/functio
 import type { InitialSignupUserCommunicationSchema } from '@/inngest/functions/initialSignupUserCommunicationJourney/initialSignupUserCommunicationJourney'
 import type { MonitorBaseEthBalancesInngestEventSchema } from '@/inngest/functions/monitorBaseETHBalances'
 import type { SetCryptoAddressOfUserInngestEventSchema } from '@/inngest/functions/setPrimaryCryptoAddressOfUser'
+import type { BackfillOptedOutUsersSchema } from '@/inngest/functions/sms/backfillOptedOutUsers'
 import type { BackfillPhoneNumberValidationInngestEventSchema } from '@/inngest/functions/sms/backfillPhoneNumberValidation'
 import type { BulkSmsCommunicationJourneyInngestEventSchema } from '@/inngest/functions/sms/bulkSMSCommunicationJourney'
 import type { EnqueueSMSInngestEventSchema } from '@/inngest/functions/sms/enqueueMessages'
-import { UpdateMetricsCounterCacheCronJobSchema } from '@/inngest/functions/updateMeyticsCacheCronJob'
+import type { UpdateMetricsCounterCacheCronJobSchema } from '@/inngest/functions/updateMeyticsCacheCronJob'
 import type { DeleteUserActionsInngestEventSchema } from '@/inngest/functions/user/deleteUserActions'
 import type { AuditUserBatchEventSchema } from '@/inngest/functions/usersTotalDonationAmountUsd/audit'
 import type {
@@ -60,5 +61,6 @@ type EventTypes =
   | EnqueueSMSInngestEventSchema
   | BackfillUserCommunicationMessageStatusSchema
   | UpdateMetricsCounterCacheCronJobSchema
+  | BackfillOptedOutUsersSchema
 
 export const INNGEST_SCHEMAS = new EventSchemas().fromUnion<EventTypes>()

--- a/src/utils/server/sms/identifyIncomingKeyword.test.ts
+++ b/src/utils/server/sms/identifyIncomingKeyword.test.ts
@@ -6,22 +6,18 @@ describe('identifyIncomingKeyword', () => {
   it.each(['STOP', 'Stop', 'Stop\n', 'stop ', '\nSTOPALL', '   STop'])(
     'should identify opt-out keyword: %s',
     keyword => {
-      expect(identifyIncomingKeyword(keyword)).toEqual({
-        isOptOutKeyword: true,
-        isHelpKeyword: false,
-        isUnstopKeyword: false,
-      })
+      expect(identifyIncomingKeyword(keyword)?.isOptOutKeyword).toBe(true)
+      expect(identifyIncomingKeyword(keyword)?.isHelpKeyword).toBe(false)
+      expect(identifyIncomingKeyword(keyword)?.isUnstopKeyword).toBe(false)
     },
   )
 
   it.each(['HELP', 'Help', 'help ', '\nHELP', '   Help'])(
     'should identify help keyword: %s',
     keyword => {
-      expect(identifyIncomingKeyword(keyword)).toEqual({
-        isOptOutKeyword: false,
-        isHelpKeyword: true,
-        isUnstopKeyword: false,
-      })
+      expect(identifyIncomingKeyword(keyword)?.isHelpKeyword).toBe(true)
+      expect(identifyIncomingKeyword(keyword)?.isOptOutKeyword).toBe(false)
+      expect(identifyIncomingKeyword(keyword)?.isUnstopKeyword).toBe(false)
     },
   )
 
@@ -36,10 +32,8 @@ describe('identifyIncomingKeyword', () => {
     '\nUNSTOP',
     '   Unstop',
   ])('should identify unstop keyword: %s', keyword => {
-    expect(identifyIncomingKeyword(keyword)).toEqual({
-      isOptOutKeyword: false,
-      isHelpKeyword: false,
-      isUnstopKeyword: true,
-    })
+    expect(identifyIncomingKeyword(keyword)?.isUnstopKeyword).toBe(true)
+    expect(identifyIncomingKeyword(keyword)?.isOptOutKeyword).toBe(false)
+    expect(identifyIncomingKeyword(keyword)?.isHelpKeyword).toBe(false)
   })
 })

--- a/src/utils/server/sms/identifyIncomingKeyword.ts
+++ b/src/utils/server/sms/identifyIncomingKeyword.ts
@@ -8,6 +8,7 @@ export function identifyIncomingKeyword(keyword: string | undefined) {
   const normalizedKeyword = keyword?.toUpperCase().trim()
 
   return {
+    value: normalizedKeyword,
     isOptOutKeyword: optOutKeywords.includes(normalizedKeyword),
     isHelpKeyword: helpKeywords.includes(normalizedKeyword),
     isUnstopKeyword: unstopKeywords.includes(normalizedKeyword),

--- a/src/utils/server/sms/index.ts
+++ b/src/utils/server/sms/index.ts
@@ -1,3 +1,7 @@
-export { messagingClient, TWILIO_RATE_LIMIT } from './messagingClient'
+export {
+  messagingClient,
+  TWILIO_LIST_MESSAGES_QUERY_LIMIT,
+  TWILIO_RATE_LIMIT,
+} from './messagingClient'
 export { sendSMS } from './sendSMS'
 export { SendSMSError } from './SendSMSError'

--- a/src/utils/server/sms/messagingClient.ts
+++ b/src/utils/server/sms/messagingClient.ts
@@ -6,5 +6,6 @@ const TWILIO_ACCOUNT_SID = requiredEnv(process.env.TWILIO_ACCOUNT_SID, 'TWILIO_A
 const TWILIO_AUTH_TOKEN = requiredEnv(process.env.TWILIO_AUTH_TOKEN, 'TWILIO_AUTH_TOKEN')
 
 export const TWILIO_RATE_LIMIT = 750
+export const TWILIO_LIST_MESSAGES_QUERY_LIMIT = 100
 
 export const messagingClient = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)


### PR DESCRIPTION
closes [#1618](https://github.com/Stand-With-Crypto/swc-web/issues/1618)

## What changed? Why?

This PR adds a backfill script to opt out users who tried to opt out with a break line or empty space after the STOP keyword

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
