### PR TITLE
refactor: use headers alongside cookies for session

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,7 +11,11 @@ import {
 import { isCypress } from '@/utils/shared/executionEnvironment'
 import { getLogger } from '@/utils/shared/logger'
 import { USER_ID_COOKIE_NAME } from '@/utils/shared/userId'
-import { generateUserSessionId, USER_SESSION_ID_COOKIE_NAME } from '@/utils/shared/userSessionId'
+import {
+  generateUserSessionId,
+  USER_SESSION_ID_COOKIE_NAME,
+  USER_SESSION_ID_HEADER_NAME,
+} from '@/utils/shared/userSessionId'
 
 const logger = getLogger('middleware')
 // taken from https://i18nexus.com/tutorials/nextjs/react-intl
@@ -50,6 +54,7 @@ export function middleware(request: NextRequest) {
       sameSite: 'lax',
       secure: true,
     })
+    i18nParsedResponse.headers.set(USER_SESSION_ID_HEADER_NAME, sessionId)
   }
 
   const urlUserId = request.nextUrl.searchParams.get('userId')

--- a/src/utils/server/serverUserSessionId.ts
+++ b/src/utils/server/serverUserSessionId.ts
@@ -1,22 +1,28 @@
 import * as Sentry from '@sentry/nextjs'
 import { cookies, headers } from 'next/headers'
 
-import { USER_SESSION_ID_COOKIE_NAME } from '@/utils/shared/userSessionId'
+import {
+  USER_SESSION_ID_COOKIE_NAME,
+  USER_SESSION_ID_HEADER_NAME,
+} from '@/utils/shared/userSessionId'
 
 export function getUserSessionIdThatMightNotExist() {
   const userCookies = cookies()
-  const sessionId = userCookies.get(USER_SESSION_ID_COOKIE_NAME)
-  return sessionId?.value
+  const requestHeaders = headers()
+  return (
+    requestHeaders.get(USER_SESSION_ID_HEADER_NAME) ||
+    userCookies.get(USER_SESSION_ID_COOKIE_NAME)?.value
+  )
 }
 
 export function getUserSessionId() {
   const userCookies = cookies()
   const sessionId = getUserSessionIdThatMightNotExist()
   if (!sessionId) {
-    Sentry.captureMessage(`getUserSessionIdOnAppRouter: cookie not set`, {
+    Sentry.captureMessage(`getUserSessionIdOnAppRouter: cookie/header not set`, {
       extra: { headers: headers(), cookies: userCookies.getAll() },
     })
-    throw new Error('user session cookie not set')
+    throw new Error('user session cookie/header not set')
   }
   return sessionId
 }

--- a/src/utils/shared/userSessionId.ts
+++ b/src/utils/shared/userSessionId.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from 'uuid'
 
 export const USER_SESSION_ID_COOKIE_NAME = 'SWC_UNAUTHENTICATED_SESSION_ID'
+export const USER_SESSION_ID_HEADER_NAME = 'Swc-Unauthenticated-Session-Id'
 
 export function generateUserSessionId() {
   return uuidv4()


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged --> https://github.com/Stand-With-Crypto/swc-web/issues/1490

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

Use headers so we may have it available immediately on new requests if cookies ever fail to be parsed. I think this is resolved when we migrate to next 15 https://nextjs.org/docs/app/api-reference/functions/cookies as the cookies API become async by default

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [X] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
