### PR TITLE
feat: creates synthetic tests clean up cron job

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -20,6 +20,7 @@ import { emailViaCapitolCanaryWithInngest } from '@/inngest/functions/capitolCan
 import { upsertAdvocateInCapitolCanaryWithInngest } from '@/inngest/functions/capitolCanary/upsertAdvocateInCapitolCanary'
 import { cleanupNFTMintsWithInngest } from '@/inngest/functions/cleanupNFTMints'
 import { cleanupPostalCodesWithInngest } from '@/inngest/functions/cleanupPostalCodes'
+import { cleanupDatadogSyntheticTestsWithInngest } from '@/inngest/functions/datadog/cleanup'
 import {
   fetchPresidentialRacesData,
   fetchPresidentialRacesDataCron,
@@ -83,5 +84,6 @@ export const { GET, POST, PUT } = serve({
     backfillUserCommunicationMessageStatus,
     updateMetricsCacheInngestCronJob,
     backfillOptedOutUsers,
+    cleanupDatadogSyntheticTestsWithInngest,
   ],
 })

--- a/src/inngest/functions/datadog/cleanup/index.ts
+++ b/src/inngest/functions/datadog/cleanup/index.ts
@@ -17,8 +17,7 @@ export const cleanupDatadogSyntheticTestsWithInngest = inngest.createFunction(
   },
   { cron: 'TZ=America/New_York 0 3 * * *' }, // Every day - 3AM EST
   async ({ step }) => {
-    const users = await step.run('script.getSyntheticTestUsers', async () => {
-      return prismaClient.user.findMany({
+    const users = await step.run('script.getSyntheticTestUsers', () => prismaClient.user.findMany({
         where: {
           userEmailAddresses: {
             some: {

--- a/src/inngest/functions/datadog/cleanup/index.ts
+++ b/src/inngest/functions/datadog/cleanup/index.ts
@@ -52,9 +52,7 @@ export const cleanupDatadogSyntheticTestsWithInngest = inngest.createFunction(
       })
     })
 
-    await step.run('script.removeUserActions', async () => {
-      await Promise.all(userActionRemovalPromises)
-    })
+    await step.run('script.removeUserActions', () => Promise.all(userActionRemovalPromises))
 
     const userEmailRemovalPromises = filteredUsers.map(user => {
       const userEmailIds = user.userEmailAddresses.map(userEmail => userEmail.id)

--- a/src/inngest/functions/datadog/cleanup/index.ts
+++ b/src/inngest/functions/datadog/cleanup/index.ts
@@ -37,6 +37,12 @@ export const cleanupDatadogSyntheticTestsWithInngest = inngest.createFunction(
 
     const filteredUsers = uniqBy(users, user => user.id)
 
+    if (filteredUsers.length === 0) {
+      return {
+        usersFound: 0,
+      }
+    }
+
     const userActionRemovalPromises = filteredUsers.map(user => {
       const filteredUserActions = user.userActions.filter(
         userAction => userAction.actionType !== UserActionType.OPT_IN,

--- a/src/inngest/functions/datadog/cleanup/index.ts
+++ b/src/inngest/functions/datadog/cleanup/index.ts
@@ -1,0 +1,96 @@
+import { UserActionType } from '@prisma/client'
+import { uniqBy } from 'lodash-es'
+
+import { inngest } from '@/inngest/inngest'
+import { onScriptFailure } from '@/inngest/onScriptFailure'
+import { prismaClient } from '@/utils/server/prismaClient'
+
+const CLEANUP_DATADOG_SYNTHETIC_TESTS_FUNCTION_ID = 'script.cleanup-datadog-synthetic-tests'
+
+const DATADOG_SYNTHETIC_TESTS_EMAIL_DOMAIN = '@synthetics.dtdg.co'
+
+export const cleanupDatadogSyntheticTestsWithInngest = inngest.createFunction(
+  {
+    id: CLEANUP_DATADOG_SYNTHETIC_TESTS_FUNCTION_ID,
+    retries: 0,
+    onFailure: onScriptFailure,
+  },
+  { cron: 'TZ=America/New_York 0 3 * * *' }, // Every day - 3AM EST
+  async ({ step }) => {
+    const users = await step.run('script.getSyntheticTestUsers', async () => {
+      return prismaClient.user.findMany({
+        where: {
+          userEmailAddresses: {
+            some: {
+              emailAddress: {
+                contains: DATADOG_SYNTHETIC_TESTS_EMAIL_DOMAIN,
+              },
+            },
+          },
+        },
+        include: {
+          userEmailAddresses: true,
+          userActions: true,
+        },
+      })
+    })
+
+    const filteredUsers = uniqBy(users, user => user.id)
+
+    const userActionRemovalPromises = filteredUsers.map(user => {
+      const filteredUserActions = user.userActions.filter(
+        userAction => userAction.actionType !== UserActionType.OPT_IN,
+      )
+
+      const userActionIds = filteredUserActions.map(userAction => userAction.id)
+
+      return prismaClient.userAction.deleteMany({
+        where: {
+          id: {
+            in: userActionIds,
+          },
+        },
+      })
+    })
+
+    await step.run('script.removeUserActions', async () => {
+      await Promise.all(userActionRemovalPromises)
+    })
+
+    const userEmailRemovalPromises = filteredUsers.map(user => {
+      const userEmailIds = user.userEmailAddresses.map(userEmail => userEmail.id)
+
+      return prismaClient.userEmailAddress.deleteMany({
+        where: {
+          id: {
+            in: userEmailIds,
+          },
+        },
+      })
+    })
+
+    await step.run('script.removeUserEmails', async () => {
+      await Promise.all(userEmailRemovalPromises)
+    })
+
+    const usersToUpdatePromises = filteredUsers.map(user => {
+      return prismaClient.user.update({
+        where: {
+          id: user.id,
+        },
+        data: {
+          primaryUserEmailAddressId: null,
+        },
+      })
+    })
+
+    await step.run('script.updateUsers', async () => {
+      await Promise.all(usersToUpdatePromises)
+    })
+
+    return {
+      usersFound: filteredUsers.length,
+      usersIds: filteredUsers.map(user => user.id).join(', '),
+    }
+  },
+)

--- a/src/inngest/functions/datadog/cleanup/index.ts
+++ b/src/inngest/functions/datadog/cleanup/index.ts
@@ -17,24 +17,22 @@ export const cleanupDatadogSyntheticTestsWithInngest = inngest.createFunction(
   },
   { cron: 'TZ=America/New_York 0 3 * * *' }, // Every day - 3AM EST
   async ({ step }) => {
-    const users = await step.run(
-      'script.getSyntheticTestUsers',
-      async () =>
-        await prismaClient.user.findMany({
-          where: {
-            userEmailAddresses: {
-              some: {
-                emailAddress: {
-                  contains: DATADOG_SYNTHETIC_TESTS_EMAIL_DOMAIN,
-                },
+    const users = await step.run('script.getSyntheticTestUsers', () =>
+      prismaClient.user.findMany({
+        where: {
+          userEmailAddresses: {
+            some: {
+              emailAddress: {
+                contains: DATADOG_SYNTHETIC_TESTS_EMAIL_DOMAIN,
               },
             },
           },
-          include: {
-            userEmailAddresses: true,
-            userActions: true,
-          },
-        }),
+        },
+        include: {
+          userEmailAddresses: true,
+          userActions: true,
+        },
+      }),
     )
 
     const filteredUsers = uniqBy(users, user => user.id)
@@ -55,10 +53,7 @@ export const cleanupDatadogSyntheticTestsWithInngest = inngest.createFunction(
       })
     })
 
-    await step.run(
-      'script.removeUserActions',
-      async () => await Promise.all(userActionRemovalPromises),
-    )
+    await step.run('script.removeUserActions', () => Promise.all(userActionRemovalPromises))
 
     const userEmailRemovalPromises = filteredUsers.map(user => {
       const userEmailIds = user.userEmailAddresses.map(userEmail => userEmail.id)
@@ -72,10 +67,7 @@ export const cleanupDatadogSyntheticTestsWithInngest = inngest.createFunction(
       })
     })
 
-    await step.run(
-      'script.removeUserEmails',
-      async () => await Promise.all(userEmailRemovalPromises),
-    )
+    await step.run('script.removeUserEmails', () => Promise.all(userEmailRemovalPromises))
 
     const usersToUpdatePromises = filteredUsers.map(user => {
       return prismaClient.user.update({
@@ -88,7 +80,7 @@ export const cleanupDatadogSyntheticTestsWithInngest = inngest.createFunction(
       })
     })
 
-    await step.run('script.updateUsers', async () => await Promise.all(usersToUpdatePromises))
+    await step.run('script.updateUsers', () => Promise.all(usersToUpdatePromises))
 
     return {
       usersFound: filteredUsers.length,


### PR DESCRIPTION
## What changed? Why?

To ensure we don't store unnecessary data, it's important to clean up any information generated by synthetic tests in the production environment, especially since we need to go through login and complete user actions during testing.

This PR deletes all user actions and email addresses related to synthetic test users.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
