### PR TITLE
fix: remove where from recent activities query so that it uses the correct index

### DIFF
--- a/src/data/recentActivity/getPublicRecentActivity.ts
+++ b/src/data/recentActivity/getPublicRecentActivity.ts
@@ -16,43 +16,44 @@ interface RecentActivityConfig {
 }
 
 const fetchFromPrisma = async (config: RecentActivityConfig) => {
-  return prismaClient.userAction.findMany({
-    orderBy: {
-      datetimeCreated: 'desc',
-    },
-    take: config.restrictToUS ? 1000 : config.limit,
-    skip: config.offset,
-    where: {
-      user: {
-        internalStatus: UserInternalStatus.VISIBLE,
+  return prismaClient.userAction
+    .findMany({
+      orderBy: {
+        datetimeCreated: 'desc',
       },
-    },
-    include: {
-      user: {
-        include: { primaryUserCryptoAddress: true, address: true },
-      },
-      userActionEmail: {
-        include: {
-          userActionEmailRecipients: true,
+      take: config.restrictToUS ? 1000 : config.limit,
+      skip: config.offset,
+      include: {
+        user: {
+          include: { primaryUserCryptoAddress: true, address: true },
         },
-      },
-      nftMint: true,
-      userActionCall: true,
-      userActionDonation: true,
-      userActionOptIn: true,
-      userActionVoterRegistration: true,
-      userActionTweetAtPerson: true,
-      userActionVoterAttestation: true,
-      userActionRsvpEvent: true,
-      userActionViewKeyRaces: true,
-      userActionVotingInformationResearched: {
-        include: {
-          address: true,
+        userActionEmail: {
+          include: {
+            userActionEmailRecipients: true,
+          },
         },
+        nftMint: true,
+        userActionCall: true,
+        userActionDonation: true,
+        userActionOptIn: true,
+        userActionVoterRegistration: true,
+        userActionTweetAtPerson: true,
+        userActionVoterAttestation: true,
+        userActionRsvpEvent: true,
+        userActionViewKeyRaces: true,
+        userActionVotingInformationResearched: {
+          include: {
+            address: true,
+          },
+        },
+        userActionVotingDay: true,
       },
-      userActionVotingDay: true,
-    },
-  })
+    })
+    .then(userActions =>
+      userActions.filter(
+        ({ user: { internalStatus } }) => internalStatus === UserInternalStatus.VISIBLE,
+      ),
+    )
 }
 
 export const getPublicRecentActivity = async (config: RecentActivityConfig) => {


### PR DESCRIPTION
closes [#309](https://github.com/Stand-With-Crypto/swc-internal/issues/309)

## What changed? Why?

We noticed that this query was not using the correct index, and to fix it we need to remove `internalStatus` from `where`.

Query with `where`:
![image](https://github.com/user-attachments/assets/a324d484-0c6f-4748-bad3-e482e27f186a)

Query without `where`:
![image](https://github.com/user-attachments/assets/71cf7b9f-6908-4945-9187-76d79b2ecaa6)

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
