### PR TITLE
fix: datadog synthetic tests emails not being deleted

### DIFF
--- a/src/inngest/functions/datadog/cleanup/index.ts
+++ b/src/inngest/functions/datadog/cleanup/index.ts
@@ -5,7 +5,7 @@ import {
   UserCryptoAddress,
   UserEmailAddress,
 } from '@prisma/client'
-import { differenceInHours } from 'date-fns'
+import { differenceInMinutes } from 'date-fns'
 import { difference, flatten, uniqBy } from 'lodash-es'
 
 import { inngest } from '@/inngest/inngest'
@@ -60,7 +60,7 @@ export const cleanupDatadogSyntheticTestsWithInngest = inngest.createFunction(
             .filter(
               userEmail =>
                 userEmail.emailAddress.includes(DATADOG_SYNTHETIC_TESTS_EMAIL_DOMAIN) &&
-                differenceInHours(new Date(), userEmail.datetimeCreated.getTime()) > 1,
+                differenceInMinutes(new Date(), userEmail.datetimeCreated.getTime()) <= 60,
             )
             .map(userEmail => userEmail.id)
         }),


### PR DESCRIPTION
## What changed? Why?

This PR updates the condition for deleting emails. Previously, it only deleted emails created within the last hour. The new version will delete all emails created more than one hour prior to the execution of the Inngest function.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
