### PR TITLE
fix: prevent primary user email from being deleted

### DIFF
--- a/src/inngest/functions/datadog/cleanup/index.ts
+++ b/src/inngest/functions/datadog/cleanup/index.ts
@@ -131,15 +131,20 @@ async function removeUserEmails(
   user: UserWithRelations,
   emailAddressesCreatedInLast1HourIds: string[],
 ) {
+  const primaryUserEmailAddressId = user.primaryUserEmailAddressId
+
   const userEmailIds = user.userEmailAddresses.map(userEmail => userEmail.id)
 
   // We only want to delete emails that were created more than 1 hour ago
   // This approach prevents any potential bugs from deleting emails while the synthetic tests are running.
   const emailIdsToRemove = difference(userEmailIds, emailAddressesCreatedInLast1HourIds)
 
+  // Remove the primary email id from the list of emails to remove
+  const filteredIds = emailIdsToRemove.filter(id => id !== primaryUserEmailAddressId)
+
   return prismaClient.userEmailAddress.deleteMany({
     where: {
-      id: { in: emailIdsToRemove },
+      id: { in: filteredIds },
     },
   })
 }


### PR DESCRIPTION
closes #1660 

## What changed? Why?

This PR filters out the primary user email from the email address ID list to prevent the following error:


```
PrismaClientKnownRequestError: 
Invalid `prisma.userEmailAddress.deleteMany()` invocation:


The change you are trying to make would violate the required relation 'asPrimaryUserEmailAddress' between the `User` and `UserEmailAddress` models.
    at _n.handleRequestError (/var/task/node_modules/@prisma/client/runtime/library.js:121:7749)
    at _n.handleAndLogRequestError (/var/task/node_modules/@prisma/client/runtime/library.js:121:7057)
    at _n.request (/var/task/node_modules/@prisma/client/runtime/library.js:121:6741)
    at async l (/var/task/node_modules/@prisma/client/runtime/library.js:130:9355)
    at async Promise.all (index 0)
```
