### PR TITLE
Changes action success screen message

### DIFF
--- a/src/components/app/userActionFormSuccessScreen/constants.ts
+++ b/src/components/app/userActionFormSuccessScreen/constants.ts
@@ -1,13 +1,18 @@
 import { UserActionType } from '@prisma/client'
+import Cookies from 'js-cookie'
 
 import type { UserActionFormSuccessScreenFeedbackProps } from '@/components/app/userActionFormSuccessScreen/UserActionFormSuccessScreenFeedback'
 import { ActiveClientUserActionType } from '@/utils/shared/activeUserAction'
+import { THIRDWEB_AUTH_TOKEN_COOKIE_PREFIX } from '@/utils/shared/thirdwebAuthToken'
+
+const isLoggedinWithThirdweb = Cookies.get(THIRDWEB_AUTH_TOKEN_COOKIE_PREFIX)
 
 export const DEFAULT_USER_ACTION_FORM_SUCCESS_SCREEN_INFO = {
   WITHOUT_NFT:
     'Keep up the good work! Complete the actions below to continue your progress as a crypto advocate.',
-  WITH_NFT:
-    '... and got a free NFT for doing so! Complete the actions below to continue your progress as a crypto advocate.',
+  WITH_NFT: isLoggedinWithThirdweb
+    ? '... and got a free NFT for doing so! Complete the actions below to continue your progress as a crypto advocate.'
+    : 'Complete the actions below to continue your progress as a crypto advocate.',
 }
 
 export const USER_ACTION_FORM_SUCCESS_SCREEN_INFO: Record<

--- a/src/components/app/userActionFormSuccessScreen/smsOptIn.tsx
+++ b/src/components/app/userActionFormSuccessScreen/smsOptIn.tsx
@@ -8,7 +8,7 @@ export function SMSOptInContent(props: SMSOptInContentProps) {
   return (
     <div className="mx-auto flex h-full max-w-lg flex-col items-center gap-6 text-center">
       <UserActionFormSuccessScreenFeedback
-        description="This is an important year for crypto. Sign up for occasional text updates on important legislation, elections, and events in your area."
+        description="Sign up for occasional text updates on important legislation, elections, and events in your area."
         title="Nice work!"
       />
 

--- a/src/components/app/userActionFormSuccessScreen/smsOptIn.tsx
+++ b/src/components/app/userActionFormSuccessScreen/smsOptIn.tsx
@@ -8,7 +8,7 @@ export function SMSOptInContent(props: SMSOptInContentProps) {
   return (
     <div className="mx-auto flex h-full max-w-lg flex-col items-center gap-6 text-center">
       <UserActionFormSuccessScreenFeedback
-        description="Sign up for occasional text updates on important legislation, elections, and events in your area."
+        description="This is an important time for crypto. Sign up for occasional text updates on important legislation, elections, and events in your area."
         title="Nice work!"
       />
 


### PR DESCRIPTION
closes #1362 

## What changed? Why?

This PR updates the success screen description based on the authentication state, ensuring we do not state that the user will receive the NFT if they are not logged in with Thirdweb.

## How has it been tested?

- x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
