### PR TITLE
Fix double profile modal

### DIFF
--- a/src/components/app/pageUserProfile/index.tsx
+++ b/src/components/app/pageUserProfile/index.tsx
@@ -82,11 +82,7 @@ export function PageUserProfile({ params, user }: PageUserProfile) {
             </div>
           </div>
 
-          {!isMobile && (
-            <div className="hidden lg:flex">
-              <ProfileAndNFTButtons user={user} />
-            </div>
-          )}
+          {!isMobile && <ProfileAndNFTButtons user={user} />}
         </div>
         <div className="grid grid-cols-3 rounded-3xl bg-secondary p-3 text-center sm:p-6">
           {[
@@ -130,11 +126,7 @@ export function PageUserProfile({ params, user }: PageUserProfile) {
         </div>
       </section>
 
-      {isMobile && (
-        <div className="w-full lg:hidden">
-          <ProfileAndNFTButtons user={user} />
-        </div>
-      )}
+      {isMobile && <ProfileAndNFTButtons user={user} />}
 
       <section>
         <PageTitle className="mb-4" size="md">

--- a/src/components/app/pageUserProfile/index.tsx
+++ b/src/components/app/pageUserProfile/index.tsx
@@ -17,6 +17,7 @@ import { PageSubTitle } from '@/components/ui/pageSubTitle'
 import { PageTitle } from '@/components/ui/pageTitleText'
 import { Progress } from '@/components/ui/progress'
 import { useApiResponseForUserFullProfileInfo } from '@/hooks/useApiResponseForUserFullProfileInfo'
+import { useIsMobile } from '@/hooks/useIsMobile'
 import { useSession } from '@/hooks/useSession'
 import { PageProps } from '@/types'
 import { SupportedFiatCurrencyCodes } from '@/utils/shared/currency'
@@ -32,6 +33,10 @@ interface PageUserProfile extends PageProps {
 
 export function PageUserProfile({ params, user }: PageUserProfile) {
   const { locale } = params
+
+  const isMobile = useIsMobile({
+    defaultState: true,
+  })
 
   const { data } = useApiResponseForUserFullProfileInfo()
 
@@ -76,9 +81,12 @@ export function PageUserProfile({ params, user }: PageUserProfile) {
               </div>
             </div>
           </div>
-          <div className="hidden lg:flex">
-            <ProfileAndNFTButtons user={user} />
-          </div>
+
+          {!isMobile && (
+            <div className="hidden lg:flex">
+              <ProfileAndNFTButtons user={user} />
+            </div>
+          )}
         </div>
         <div className="grid grid-cols-3 rounded-3xl bg-secondary p-3 text-center sm:p-6">
           {[
@@ -122,9 +130,11 @@ export function PageUserProfile({ params, user }: PageUserProfile) {
         </div>
       </section>
 
-      <div className="w-full lg:hidden">
-        <ProfileAndNFTButtons user={user} />
-      </div>
+      {isMobile && (
+        <div className="w-full lg:hidden">
+          <ProfileAndNFTButtons user={user} />
+        </div>
+      )}
 
       <section>
         <PageTitle className="mb-4" size="md">


### PR DESCRIPTION
closes #1665 

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

The UpateProfileForm shows twice due to two instances being mounted on the page (1 mobile & 1 desktop). The solution is to use javascript to conditionally mount the components.

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
