### PR TITLE
feat: updates `COMMON_ERROR_MESSAGES_TO_GROUP` errors

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -32,6 +32,13 @@ const COMMON_ERROR_MESSAGES_TO_GROUP = [
   'TLS connection',
   'Unexpected end of',
   'Unknown root exit status',
+  'Non-Error promise rejection captured with value',
+  'Unexpected token',
+  'fetch failed',
+  'undefined is not an object',
+  'null is not an object',
+  'Unknown root exit status',
+  'Connection closed',
 ]
 
 const COMMON_TRANSACTION_NAMES_TO_GROUP = ['node_modules/@thirdweb-dev', 'maps/api/js']


### PR DESCRIPTION
## What changed? Why?

This PR adds new common error messages from frequent Sentry error logs that do not have a clear indicator of the problem or reason.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
