### PR TITLE
Style/dialog overflow

### DIFF
--- a/src/components/app/authentication/thirdwebLoginContent.tsx
+++ b/src/components/app/authentication/thirdwebLoginContent.tsx
@@ -99,9 +99,9 @@ export function ThirdwebLoginContent({
         domain: 'ThirdwebLoginContent',
       }}
     >
-      <DialogBody className="-mt-8">
+      <DialogBody>
         <div className="mx-auto flex max-w-[460px] flex-col items-center gap-2">
-          <div className="flex flex-col items-center space-y-6 pt-6">
+          <div className="flex flex-col items-center space-y-6">
             <NextImage
               alt="Stand With Crypto Logo"
               height={80}

--- a/src/components/app/homepageDialogDeeplinkLayout.tsx
+++ b/src/components/app/homepageDialogDeeplinkLayout.tsx
@@ -10,6 +10,7 @@ import {
   dialogOverlayStyles,
 } from '@/components/ui/dialog/styles'
 import { InternalLink } from '@/components/ui/link'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import { getAdvocatesMapData } from '@/data/pageSpecific/getAdvocatesMapData'
 import { getHomepageTopLevelMetrics } from '@/data/pageSpecific/getHomepageData'
 import { PageProps } from '@/types'
@@ -50,7 +51,7 @@ export async function HomepageDialogDeeplinkLayout({
           dialogContentClassName,
         )}
       >
-        {children}
+        <ScrollArea className="overflow-auto md:max-h-[90vh]">{children}</ScrollArea>
         <InternalLink className={dialogCloseStyles} href={urls.home()} replace>
           <X size={20} />
           <span className="sr-only">Close</span>

--- a/src/components/ui/dialog/index.tsx
+++ b/src/components/ui/dialog/index.tsx
@@ -12,6 +12,7 @@ import {
   dialogFooterCTAStyles,
   dialogOverlayStyles,
 } from '@/components/ui/dialog/styles'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import { VisuallyHidden } from '@/components/ui/visually-hidden'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { cn } from '@/utils/web/cn'
@@ -84,8 +85,7 @@ const DialogContent = React.forwardRef<
             <DialogPrimitive.Description>{props['aria-describedby']}</DialogPrimitive.Description>
             <DialogTitle>{a11yTitle}</DialogTitle>
           </VisuallyHidden>
-
-          {children}
+          <ScrollArea className="overflow-auto px-4 py-6 md:max-h-[88vh]">{children}</ScrollArea>
           <DialogPrimitive.Close className={cn(dialogCloseStyles, closeClassName)} tabIndex={-1}>
             <X size={20} />
             <span className="sr-only">Close</span>

--- a/src/components/ui/dialog/index.tsx
+++ b/src/components/ui/dialog/index.tsx
@@ -85,7 +85,7 @@ const DialogContent = React.forwardRef<
             <DialogPrimitive.Description>{props['aria-describedby']}</DialogPrimitive.Description>
             <DialogTitle>{a11yTitle}</DialogTitle>
           </VisuallyHidden>
-          <ScrollArea className="overflow-auto px-4 py-6 md:max-h-[88vh]">{children}</ScrollArea>
+          <ScrollArea className="overflow-auto md:max-h-[90vh]">{children}</ScrollArea>
           <DialogPrimitive.Close className={cn(dialogCloseStyles, closeClassName)} tabIndex={-1}>
             <X size={20} />
             <span className="sr-only">Close</span>

--- a/src/components/ui/dialog/styles.tsx
+++ b/src/components/ui/dialog/styles.tsx
@@ -9,7 +9,7 @@ export const dialogOverlayStyles = twNoop(
   'fixed inset-0 z-50 bg-foreground/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
 )
 export const dialogContentStyles = twNoop(
-  'fixed max-md:h-screen max-md:w-screen left-[50%] top-[50%] z-50  max-h-dvh lg:max-h-[88vh] w-11/12 md:w-full max-w-vw max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] md:rounded-3xl',
+  'overflow-hidden fixed max-md:h-screen max-md:w-screen left-[50%] top-[50%] z-50  max-h-dvh lg:max-h-[88vh] w-11/12 md:w-full max-w-vw max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] md:rounded-3xl',
 )
 
 export const dialogContentPaddingXStyles = twNoop('px-4 md:px-6')
@@ -31,4 +31,4 @@ export const dialogButtonStyles = twNoop(
   'absolute top-2 rounded-sm p-2 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground',
 )
 
-export const dialogCloseStyles = cn(dialogButtonStyles, 'right-2 rounded-full bg-background z-50')
+export const dialogCloseStyles = cn(dialogButtonStyles, 'right-2 rounded-full bg-transparent z-50')

--- a/src/components/ui/dialog/styles.tsx
+++ b/src/components/ui/dialog/styles.tsx
@@ -9,7 +9,7 @@ export const dialogOverlayStyles = twNoop(
   'fixed inset-0 z-50 bg-foreground/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
 )
 export const dialogContentStyles = twNoop(
-  'overflow-hidden fixed max-md:h-screen max-md:w-screen left-[50%] top-[50%] z-50  max-h-dvh lg:max-h-[88vh] w-11/12 md:w-full max-w-vw max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] md:rounded-3xl',
+  'overflow-hidden fixed max-md:h-screen max-md:w-screen left-[50%] top-[50%] z-50  max-h-dvh lg:max-h-[90vh] w-11/12 md:w-full max-w-vw max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] md:rounded-3xl',
 )
 
 export const dialogContentPaddingXStyles = twNoop('px-4 md:px-6')

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -10,11 +10,14 @@ const ScrollArea = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
 >(({ className, children, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
-    className={cn('relative overflow-hidden', className)}
+    className={cn('relative h-full overflow-hidden', className)}
     ref={ref}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport
+      className="h-full w-full rounded-[inherit]"
+      data-scroll-area-viewport
+    >
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/src/globals.css
+++ b/src/globals.css
@@ -126,3 +126,7 @@ select[id='countries'] {
   pointer-events: none;
   opacity: 0.6;
 }
+
+div[data-scroll-area-viewport] > div:first-child {
+  height: 100%;
+}


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged --> https://github.com/Stand-With-Crypto/swc-web/issues/954

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

adjust dialogs throughout the project, mostly the scrollbar:

from: 
![image](https://github.com/user-attachments/assets/097f668d-b6b1-45ce-8912-88a29bdfb4e0)

to:
![image](https://github.com/user-attachments/assets/29f4810c-1dd4-4284-be17-88a919d1834c)

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
