### PR TITLE
fix: add redirect for The Block News URL

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -196,7 +196,7 @@ const V1_ACTION_REDIRECTS = ACTION_REDIRECTS.map(({ destination, queryKey, query
   destination,
   has: [
     {
-      type: 'query',
+      type: 'query' as const,
       key: queryKey,
       value: queryValue,
     },
@@ -333,6 +333,12 @@ const nextConfig: NextConfig = {
         permanent: false,
       },
       // SMS shortlinks
+      {
+        source: '/theblocknews',
+        destination:
+          'https://www.theblock.co/post/331309/stand-with-crypto-advocates-flood-senate-with-107000-emails-opposing-sec-crenshaws-renomination',
+        permanent: false,
+      },
       {
         source: '/secvote-2/:sessionId*',
         destination:


### PR DESCRIPTION
## What changed? Why?

Vanity URL for the victory lap [SMS](https://docs.google.com/document/d/1CLY7WZswo9lsHhNFR_LnJ33s9GjhuqBs8D9WCEgUKds/edit?tab=t.0#heading=h.k1imdll89s23)

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
