### PR TITLE
refactor: restructure ErrorBoundary usage in homepage dialog deeplinks

### DIFF
--- a/src/app/[locale]/(homepageDialogDeeplink)/action/call/page.tsx
+++ b/src/app/[locale]/(homepageDialogDeeplink)/action/call/page.tsx
@@ -13,23 +13,23 @@ export const dynamic = 'error'
 export default async function UserActionCallCongresspersonDeepLink(props: PageProps) {
   const params = await props.params
   return (
-    <ErrorBoundary
-      extras={{
-        action: {
-          isDeeplink: true,
-          actionType: UserActionType.CALL,
-        },
-      }}
-      severityLevel="error"
-      tags={{
-        domain: 'UserActionCallCongresspersonDeepLink',
-      }}
-    >
-      <HomepageDialogDeeplinkLayout pageParams={params}>
-        <div className={cn('max-md:h-full', dialogContentPaddingStyles)}>
+    <HomepageDialogDeeplinkLayout pageParams={params}>
+      <div className={cn('max-md:h-full', dialogContentPaddingStyles)}>
+        <ErrorBoundary
+          extras={{
+            action: {
+              isDeeplink: true,
+              actionType: UserActionType.CALL,
+            },
+          }}
+          severityLevel="error"
+          tags={{
+            domain: 'UserActionCallCongresspersonDeepLink',
+          }}
+        >
           <UserActionFormCallCongresspersonDeeplinkWrapper />
-        </div>
-      </HomepageDialogDeeplinkLayout>
-    </ErrorBoundary>
+        </ErrorBoundary>
+      </div>
+    </HomepageDialogDeeplinkLayout>
   )
 }

--- a/src/app/[locale]/(homepageDialogDeeplink)/action/email-debate/page.tsx
+++ b/src/app/[locale]/(homepageDialogDeeplink)/action/email-debate/page.tsx
@@ -12,22 +12,22 @@ export const dynamic = 'error'
 export default async function UserActionEmailDebateDeepLink(props: PageProps) {
   const params = await props.params
   return (
-    <ErrorBoundary
-      extras={{
-        action: {
-          isDeeplink: true,
-          actionType: UserActionType.EMAIL,
-          campaignName: UserActionEmailCampaignName.ABC_PRESIDENTIAL_DEBATE_2024,
-        },
-      }}
-      severityLevel="error"
-      tags={{
-        domain: 'UserActionEmailDebateDeepLink',
-      }}
-    >
-      <HomepageDialogDeeplinkLayout pageParams={params}>
+    <HomepageDialogDeeplinkLayout pageParams={params}>
+      <ErrorBoundary
+        extras={{
+          action: {
+            isDeeplink: true,
+            actionType: UserActionType.EMAIL,
+            campaignName: UserActionEmailCampaignName.ABC_PRESIDENTIAL_DEBATE_2024,
+          },
+        }}
+        severityLevel="error"
+        tags={{
+          domain: 'UserActionEmailDebateDeepLink',
+        }}
+      >
         <UserActionFormEmailDebateDeeplinkWrapper />
-      </HomepageDialogDeeplinkLayout>
-    </ErrorBoundary>
+      </ErrorBoundary>
+    </HomepageDialogDeeplinkLayout>
   )
 }

--- a/src/app/[locale]/(homepageDialogDeeplink)/action/email/page.tsx
+++ b/src/app/[locale]/(homepageDialogDeeplink)/action/email/page.tsx
@@ -11,21 +11,21 @@ export const dynamic = 'error'
 export default async function UserActionEmailCongresspersonDeepLink(props: PageProps) {
   const params = await props.params
   return (
-    <ErrorBoundary
-      extras={{
-        action: {
-          isDeeplink: true,
-          actionType: UserActionType.EMAIL,
-        },
-      }}
-      severityLevel="error"
-      tags={{
-        domain: 'UserActionEmailCongresspersonDeepLink',
-      }}
-    >
-      <HomepageDialogDeeplinkLayout pageParams={params}>
+    <HomepageDialogDeeplinkLayout pageParams={params}>
+      <ErrorBoundary
+        extras={{
+          action: {
+            isDeeplink: true,
+            actionType: UserActionType.EMAIL,
+          },
+        }}
+        severityLevel="error"
+        tags={{
+          domain: 'UserActionEmailCongresspersonDeepLink',
+        }}
+      >
         <UserActionFormEmailCongresspersonDeeplinkWrapper />
-      </HomepageDialogDeeplinkLayout>
-    </ErrorBoundary>
+      </ErrorBoundary>
+    </HomepageDialogDeeplinkLayout>
   )
 }

--- a/src/app/[locale]/(homepageDialogDeeplink)/action/live-event/[slug]/page.tsx
+++ b/src/app/[locale]/(homepageDialogDeeplink)/action/live-event/[slug]/page.tsx
@@ -43,24 +43,24 @@ export default async function UserActionLiveEventDeepLink(props: Props) {
   }
 
   return (
-    <ErrorBoundary
-      extras={{
-        action: {
-          isDeeplink: true,
-          actionType: UserActionType.LIVE_EVENT,
-          campaignName: slug,
-        },
-      }}
-      severityLevel="error"
-      tags={{
-        domain: 'UserActionLiveEventDeepLink',
-      }}
-    >
-      <HomepageDialogDeeplinkLayout pageParams={params}>
-        <div className={dialogContentPaddingStyles}>
+    <HomepageDialogDeeplinkLayout pageParams={params}>
+      <div className={dialogContentPaddingStyles}>
+        <ErrorBoundary
+          extras={{
+            action: {
+              isDeeplink: true,
+              actionType: UserActionType.LIVE_EVENT,
+              campaignName: slug,
+            },
+          }}
+          severityLevel="error"
+          tags={{
+            domain: 'UserActionLiveEventDeepLink',
+          }}
+        >
           <UserActionFormLiveEventDeeplinkWrapper slug={slug as UserActionLiveEventCampaignName} />
-        </div>
-      </HomepageDialogDeeplinkLayout>
-    </ErrorBoundary>
+        </ErrorBoundary>
+      </div>
+    </HomepageDialogDeeplinkLayout>
   )
 }

--- a/src/app/[locale]/(homepageDialogDeeplink)/action/nft-mint/page.tsx
+++ b/src/app/[locale]/(homepageDialogDeeplink)/action/nft-mint/page.tsx
@@ -13,28 +13,28 @@ export const dynamic = 'error'
 export default async function UserActionNFTMintDeepLink(props: PageProps) {
   const params = await props.params
   return (
-    <ErrorBoundary
-      extras={{
-        action: {
-          isDeeplink: true,
-          actionType: UserActionType.NFT_MINT,
-        },
-      }}
-      severityLevel="error"
-      tags={{
-        domain: 'UserActionNFTMintDeepLink',
-      }}
-    >
-      <HomepageDialogDeeplinkLayout pageParams={params}>
-        <div
-          className={cn(
-            'flex flex-col items-center justify-center max-md:h-full',
-            dialogContentPaddingStyles,
-          )}
+    <HomepageDialogDeeplinkLayout pageParams={params}>
+      <div
+        className={cn(
+          'flex flex-col items-center justify-center max-md:h-full',
+          dialogContentPaddingStyles,
+        )}
+      >
+        <ErrorBoundary
+          extras={{
+            action: {
+              isDeeplink: true,
+              actionType: UserActionType.NFT_MINT,
+            },
+          }}
+          severityLevel="error"
+          tags={{
+            domain: 'UserActionNFTMintDeepLink',
+          }}
         >
           <HomepageDialogDeeplinkNFTMintWrapper />
-        </div>
-      </HomepageDialogDeeplinkLayout>
-    </ErrorBoundary>
+        </ErrorBoundary>
+      </div>
+    </HomepageDialogDeeplinkLayout>
   )
 }

--- a/src/app/[locale]/(homepageDialogDeeplink)/action/share/page.tsx
+++ b/src/app/[locale]/(homepageDialogDeeplink)/action/share/page.tsx
@@ -7,21 +7,21 @@ import { ErrorBoundary } from '@/utils/web/errorBoundary'
 
 export default function UserActionShareOnTwitterDeepLink() {
   return (
-    <ErrorBoundary
-      extras={{
-        action: {
-          isDeeplink: true,
-          actionType: UserActionType.TWEET,
-        },
-      }}
-      severityLevel="error"
-      tags={{
-        domain: 'UserActionShareOnTwitterDeepLink',
-      }}
-    >
-      <div className={cn(dialogContentPaddingStyles, 'h-full')}>
+    <div className={cn(dialogContentPaddingStyles, 'h-full')}>
+      <ErrorBoundary
+        extras={{
+          action: {
+            isDeeplink: true,
+            actionType: UserActionType.TWEET,
+          },
+        }}
+        severityLevel="error"
+        tags={{
+          domain: 'UserActionShareOnTwitterDeepLink',
+        }}
+      >
         <UserActionFormShareOnTwitterDeeplinkWrapper />
-      </div>
-    </ErrorBoundary>
+      </ErrorBoundary>
+    </div>
   )
 }

--- a/src/app/[locale]/(homepageDialogDeeplink)/action/tweet-at-person/[slug]/page.tsx
+++ b/src/app/[locale]/(homepageDialogDeeplink)/action/tweet-at-person/[slug]/page.tsx
@@ -50,26 +50,26 @@ export default async function UserActionTweetAtPersonDeepLink(props: Props) {
   }
 
   return (
-    <ErrorBoundary
-      extras={{
-        action: {
-          isDeeplink: true,
-          actionType: UserActionType.TWEET_AT_PERSON,
-          campaignName: slug,
-        },
-      }}
-      severityLevel="error"
-      tags={{
-        domain: 'UserActionTweetAtPersonDeepLink',
-      }}
-    >
-      <HomepageDialogDeeplinkLayout pageParams={params}>
-        <div className={cn(dialogContentPaddingStyles, 'max-md:h-full')}>
+    <HomepageDialogDeeplinkLayout pageParams={params}>
+      <div className={cn(dialogContentPaddingStyles, 'max-md:h-full')}>
+        <ErrorBoundary
+          extras={{
+            action: {
+              isDeeplink: true,
+              actionType: UserActionType.TWEET_AT_PERSON,
+              campaignName: slug,
+            },
+          }}
+          severityLevel="error"
+          tags={{
+            domain: 'UserActionTweetAtPersonDeepLink',
+          }}
+        >
           <UserActionFormTweetToPersonDeeplinkWrapper
             slug={slug as UserActionTweetAtPersonCampaignName}
           />
-        </div>
-      </HomepageDialogDeeplinkLayout>
-    </ErrorBoundary>
+        </ErrorBoundary>
+      </div>
+    </HomepageDialogDeeplinkLayout>
   )
 }


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged --> https://github.com/Stand-With-Crypto/swc-web/issues/1694

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

- Moved ErrorBoundary component to wrap the content inside HomepageDialogDeeplinkLayout for better error handling.
- Updated all relevant action pages: call, email, email-debate, live-event, nft-mint, share, and tweet-at-person.
- Ensured consistent structure across all deeplink actions to improve maintainability and readability.


<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
