### PR TITLE
refactor: remove Suspense wrapper from DTSIClientPersonDataTable for …

### DIFF
--- a/src/components/app/dtsiClientPersonDataTable/index.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useMemo } from 'react'
+import { useMemo } from 'react'
 import { filterFns } from '@tanstack/react-table'
 import useSWR, { SWRConfiguration } from 'swr'
 
@@ -55,32 +55,30 @@ export function DTSIClientPersonDataTable({
   const tableColumns = useMemo(() => getDTSIClientPersonDataTableColumns({ locale }), [locale])
 
   return (
-    <Suspense>
-      <DataTable
-        columns={tableColumns}
-        data={passedData}
-        globalFilterFn={(row, _, filterValue, addMeta) => {
-          const matchesFullName = filterFns.includesString(row, 'fullName', filterValue, addMeta)
-          if (matchesFullName) {
-            return true
-          }
+    <DataTable
+      columns={tableColumns}
+      data={passedData}
+      globalFilterFn={(row, _, filterValue, addMeta) => {
+        const matchesFullName = filterFns.includesString(row, 'fullName', filterValue, addMeta)
+        if (matchesFullName) {
+          return true
+        }
 
-          const state = row.original.primaryRole?.primaryState ?? ''
-          if (!state) {
-            return false
-          }
+        const state = row.original.primaryRole?.primaryState ?? ''
+        if (!state) {
+          return false
+        }
 
-          const parsedState = parseString(state)
-          const parsedFilterValue = parseString(filterValue)
-          return (
-            parsedState.includes(parsedFilterValue) ||
-            getUSStateNameFromStateCode(state)?.toLowerCase().includes(parsedFilterValue)
-          )
-        }}
-        key={data?.people ? 'loaded' : 'static'}
-        loadState={data?.people ? 'loaded' : 'static'}
-        locale={locale}
-      />
-    </Suspense>
+        const parsedState = parseString(state)
+        const parsedFilterValue = parseString(filterValue)
+        return (
+          parsedState.includes(parsedFilterValue) ||
+          getUSStateNameFromStateCode(state)?.toLowerCase().includes(parsedFilterValue)
+        )
+      }}
+      key={data?.people ? 'loaded' : 'static'}
+      loadState={data?.people ? 'loaded' : 'static'}
+      locale={locale}
+    />
   )
 }


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged --> https://github.com/Stand-With-Crypto/swc-web/issues/1688

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

- Eliminated the Suspense component surrounding the DataTable to streamline the rendering process.

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
