### PR TITLE
Revert "fix: hide endorsed candidates page (#1723)"

### DIFF
--- a/src/app/[locale]/races/endorsed/page.tsx
+++ b/src/app/[locale]/races/endorsed/page.tsx
@@ -1,0 +1,31 @@
+import { Metadata } from 'next'
+
+import { PageEndorsedCandidates } from '@/components/app/pageEndorsedCandidates'
+import { queryDTSIEndorsedCandidates } from '@/data/dtsi/queries/queryDTSIEndorsedCandidates'
+import { PageProps } from '@/types'
+import { generateMetadataDetails } from '@/utils/server/metadataUtils'
+import { ENDORSED_DTSI_PERSON_SLUGS } from '@/utils/shared/locationSpecificPages'
+
+export const revalidate = 600 // 10 minutes
+export const dynamic = 'error'
+
+const title = 'Stand With Crypto PAC 2024 House and Senate Endorsements'
+const description =
+  '2024 will be a monumental election year and Congress holds the power to shape the future of crypto in the U.S. Stand With Crypto is committed to supporting pro-crypto candidates and we are proud to endorse the candidates on this page.'
+export const metadata: Metadata = {
+  ...generateMetadataDetails({
+    description,
+    title,
+  }),
+}
+
+export default async function AboutPage(props: PageProps) {
+  const params = await props.params
+
+  const { locale } = params
+
+  const { people } = await queryDTSIEndorsedCandidates({
+    endorsedDTSISlugs: ENDORSED_DTSI_PERSON_SLUGS,
+  })
+  return <PageEndorsedCandidates {...{ locale, people }} />
+}

--- a/src/components/app/navbar/index.tsx
+++ b/src/components/app/navbar/index.tsx
@@ -45,6 +45,10 @@ export function Navbar({ locale }: { locale: SupportedLocale }) {
       text: 'Politician scores',
     },
     {
+      href: urls.endorsedCandidates(),
+      text: 'Endorsed candidates',
+    },
+    {
       href: urls.events(),
       text: 'Events',
     },

--- a/src/components/app/pageEndorsedCandidates/dtsiPersonHeroCardDonateButton.tsx
+++ b/src/components/app/pageEndorsedCandidates/dtsiPersonHeroCardDonateButton.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { openWindow } from '@/utils/shared/openWindow'
+
+export function DTSIPersonHeroCardDonateButton({ donationUrl }: { donationUrl: string }) {
+  return (
+    <div className="sm:p-4">
+      <Button
+        // we can't have nested <a> tags so doing this the non-semantic way. We may want to further refactor the parent component to fix this later on
+        className="sm:w-full"
+        onClick={e => {
+          e.preventDefault()
+          openWindow(donationUrl)
+        }}
+        variant="secondary"
+      >
+        Donate
+      </Button>
+    </div>
+  )
+}

--- a/src/components/app/pageEndorsedCandidates/index.tsx
+++ b/src/components/app/pageEndorsedCandidates/index.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { DarkHeroSection } from '@/components/app/darkHeroSection'
+import { DTSIPersonHeroCard } from '@/components/app/dtsiPersonHeroCard'
+import { DTSIPersonHeroCardRow } from '@/components/app/dtsiPersonHeroCard/dtsiPersonHeroCardRow'
+import { MaybeDonateButton } from '@/components/app/maybeDonateButton'
+import { PACFooter } from '@/components/app/pacFooter'
+import { DTSIPersonHeroCardDonateButton } from '@/components/app/pageEndorsedCandidates/dtsiPersonHeroCardDonateButton'
+import { InternalLink } from '@/components/ui/link'
+import { PageTitle } from '@/components/ui/pageTitleText'
+import { DTSI_EndorsedCandidatesQuery } from '@/data/dtsi/generated'
+import { SupportedLocale } from '@/intl/locales'
+import { getIntlUrls } from '@/utils/shared/urls'
+
+interface LocationStateSpecificProps extends DTSI_EndorsedCandidatesQuery {
+  locale: SupportedLocale
+}
+
+export function PageEndorsedCandidates({ people, locale }: LocationStateSpecificProps) {
+  const urls = getIntlUrls(locale)
+
+  return (
+    <div className="space-y-20">
+      <DarkHeroSection>
+        <div className="container space-y-4 text-center">
+          <h2>
+            <InternalLink className="text-gray-400" href={urls.endorsedCandidates()}>
+              United States
+            </InternalLink>{' '}
+            / <span>Endorsements</span>
+          </h2>
+          <PageTitle as="h1" size="lg">
+            Stand With Crypto PAC 2024 House and Senate Endorsements
+          </PageTitle>
+          <h3 className="font-mono text-xl font-light">
+            2024 will be a monumental election year and Congress holds the power to shape the future
+            of crypto in the US. SWC is committed to supporting pro-crypto candidates and we are
+            proud to endorse the candidates below. You can support the candidates directly by
+            clicking on their links.
+          </h3>
+
+          <MaybeDonateButton
+            donationUrl="https://commerce.coinbase.com/checkout/f1fa8e95-d8d9-45e4-8329-e11ad95f5c34"
+            variant="secondary"
+          >
+            Donate to all candidates
+          </MaybeDonateButton>
+        </div>
+      </DarkHeroSection>
+
+      <DTSIPersonHeroCardRow className="mx-auto max-lg:max-w-2xl">
+        {people.map(person => (
+          <DTSIPersonHeroCard
+            footer={
+              person?.donationUrl ? (
+                <DTSIPersonHeroCardDonateButton donationUrl={person.donationUrl} />
+              ) : null
+            }
+            key={person.id}
+            locale={locale}
+            person={person}
+            subheader="role-w-state"
+          />
+        ))}
+      </DTSIPersonHeroCardRow>
+
+      <PACFooter className="container" />
+    </div>
+  )
+}

--- a/src/utils/shared/urls/index.ts
+++ b/src/utils/shared/urls/index.ts
@@ -61,6 +61,7 @@ export const getIntlUrls = (
     profile: () => `${localePrefix}/profile`,
     updateProfile: () => `${localePrefix}/profile?hasOpenUpdateUserProfileForm=true`,
     internalHomepage: () => `${localePrefix}/internal`,
+    endorsedCandidates: () => `${localePrefix}/races/endorsed/`,
     becomeMember: () => `${localePrefix}/action/become-member`,
     community: () => `${localePrefix}/community`,
     events: () => `${localePrefix}/events`,


### PR DESCRIPTION
This reverts commit 0c55d43342a246c01aeb48c4e6cb9de0d3f530f6.

closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
