### PR TITLE
feat: add SMS shortlink for new member activation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -334,6 +334,12 @@ const nextConfig: NextConfig = {
       },
       // SMS shortlinks
       {
+        destination:
+          '/action/email?utm_source=swc&utm_medium=sms&utm_campaign=new-member-activation-1&sessionId=:sessionId*',
+        source: '/TODO/:sessionId*',
+        permanent: true,
+      },
+      {
         source: '/theblocknews',
         destination:
           'https://www.theblock.co/post/331309/stand-with-crypto-advocates-flood-senate-with-107000-emails-opposing-sec-crenshaws-renomination',

--- a/next.config.ts
+++ b/next.config.ts
@@ -334,9 +334,9 @@ const nextConfig: NextConfig = {
       },
       // SMS shortlinks
       {
+        source: '/new-congress/:sessionId*',
         destination:
           '/action/email?utm_source=swc&utm_medium=sms&utm_campaign=new-member-activation-1&sessionId=:sessionId*',
-        source: '/TODO/:sessionId*',
         permanent: true,
       },
       {


### PR DESCRIPTION
## What changed? Why?

Adds vanity URL for [this](https://docs.google.com/document/d/1CLY7WZswo9lsHhNFR_LnJ33s9GjhuqBs8D9WCEgUKds/edit?pli=1&tab=t.0#heading=h.gvqve1o4rr73) SMS communication

## How has it been tested?

- [ ] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
