### PR TITLE
fix: update getPhoneNumberList validation to not include PROCESSING messages

### DIFF
--- a/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
+++ b/src/inngest/functions/sms/bulkSMSCommunicationJourney.ts
@@ -378,9 +378,7 @@ async function getPhoneNumberList(options: GetPhoneNumberOptions) {
                     campaignName: options.campaignName,
                     userCommunications: {
                       every: {
-                        status: {
-                          not: CommunicationMessageStatus.DELIVERED,
-                        },
+                        status: CommunicationMessageStatus.FAILED,
                       },
                     },
                   },


### PR DESCRIPTION
## What changed? Why?

Updates the message delivery status validation when fetching the bulk SMS phone number list to exclude 'PROCESSING' messages, preventing duplicate message sends.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
