### PR TITLE
fix: increase ANALYTICS_FLUSH_TIMEOUT_MS to 10000

### DIFF
--- a/src/app/api/public/sms/events/status/route.ts
+++ b/src/app/api/public/sms/events/status/route.ts
@@ -44,8 +44,6 @@ const EVENT_MESSAGE_STATUS_TO_COMMUNICATION_STATUS: Partial<
 
 const logger = getLogger('smsStatus')
 
-export const maxDuration = 10
-
 export const POST = withRouteMiddleware(async (request: NextRequest) => {
   const [isVerified, body] = await verifySignature<SMSStatusEvent>(request)
 

--- a/src/app/api/public/sms/events/status/route.ts
+++ b/src/app/api/public/sms/events/status/route.ts
@@ -44,6 +44,8 @@ const EVENT_MESSAGE_STATUS_TO_COMMUNICATION_STATUS: Partial<
 
 const logger = getLogger('smsStatus')
 
+export const maxDuration = 10
+
 export const POST = withRouteMiddleware(async (request: NextRequest) => {
   const [isVerified, body] = await verifySignature<SMSStatusEvent>(request)
 

--- a/src/utils/server/serverAnalytics/shared.ts
+++ b/src/utils/server/serverAnalytics/shared.ts
@@ -9,4 +9,4 @@ const NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN = requiredEnv(
 
 export const mixpanel = mixpanelLib.init(NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN)
 
-export const ANALYTICS_FLUSH_TIMEOUT_MS = 2500
+export const ANALYTICS_FLUSH_TIMEOUT_MS = 10000


### PR DESCRIPTION
fixes [PROD-SWC-WEB-4WW](https://stand-with-crypto.sentry.io/issues/5895385971/)

## What changed? Why?

Increase SMS status webhook duration to fix timeout

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
