### PR TITLE
feat: add autoComplete off attribute to message textarea component

### DIFF
--- a/src/actions/actionCreateUserActionEmailCongressperson.ts
+++ b/src/actions/actionCreateUserActionEmailCongressperson.ts
@@ -227,7 +227,7 @@ async function _actionCreateUserActionEmailCongressperson(input: Input) {
         isEmailOptin: true,
       },
       emailSubject: validatedFields.data.subject,
-      emailMessage: validatedFields.data.message,
+      emailMessage: validatedFields.data.contactMessage,
     },
   })
 

--- a/src/components/app/userActionFormEmailCongressperson/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/index.tsx
@@ -329,6 +329,7 @@ export function UserActionFormEmailCongressperson({
                       )}
                       <FormControl>
                         <Textarea
+                          autoComplete="off"
                           placeholder=""
                           rows={16}
                           {...field}

--- a/src/components/app/userActionFormEmailCongressperson/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/index.tsx
@@ -330,8 +330,10 @@ export function UserActionFormEmailCongressperson({
                       <FormControl>
                         <Textarea
                           autoComplete="off"
+                          autoCorrect="off"
                           placeholder=""
                           rows={16}
+                          spellCheck={false}
                           {...field}
                           onChange={e => {
                             hasModifiedMessage.current = true

--- a/src/components/app/userActionFormEmailCongressperson/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/index.tsx
@@ -71,7 +71,7 @@ const getDefaultValues = ({
       firstName: user.firstName,
       lastName: user.lastName,
       emailAddress: user.primaryUserEmailAddress?.emailAddress || '',
-      message: getEmailBodyText({
+      contactMessage: getEmailBodyText({
         firstName: user.firstName,
         lastName: user.lastName,
         address: user?.address?.formattedDescription,
@@ -91,7 +91,7 @@ const getDefaultValues = ({
     firstName: '',
     lastName: '',
     emailAddress: '',
-    message: getEmailBodyText(),
+    contactMessage: getEmailBodyText(),
     subject: 'Crypto Matters To Me',
     address: undefined,
     dtsiSlugs,
@@ -175,7 +175,7 @@ export function UserActionFormEmailCongressperson({
     if (hasModifiedMessage.current) return
 
     form.setValue(
-      'message',
+      'contactMessage',
       getEmailBodyText({
         firstName,
         lastName,
@@ -316,7 +316,7 @@ export function UserActionFormEmailCongressperson({
               />
               <FormField
                 control={form.control}
-                name="message"
+                name="contactMessage"
                 render={({ field }) => (
                   <FormItem>
                     <div className="relative">

--- a/src/components/app/userActionFormEmailCongressperson/skeleton.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/skeleton.tsx
@@ -70,9 +70,11 @@ export function UserActionFormEmailCongresspersonSkeleton({
               <FormItemSkeleton>
                 <Textarea
                   autoComplete="off"
+                  autoCorrect="off"
                   defaultValue={getEmailBodyText()}
                   placeholder="Your message..."
                   rows={16}
+                  spellCheck={false}
                 />
               </FormItemSkeleton>
             </div>

--- a/src/components/app/userActionFormEmailCongressperson/skeleton.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/skeleton.tsx
@@ -69,6 +69,7 @@ export function UserActionFormEmailCongresspersonSkeleton({
               </div>
               <FormItemSkeleton>
                 <Textarea
+                  autoComplete="off"
                   defaultValue={getEmailBodyText()}
                   placeholder="Your message..."
                   rows={16}

--- a/src/validation/forms/zodUserActionFormEmailCongressperson.ts
+++ b/src/validation/forms/zodUserActionFormEmailCongressperson.ts
@@ -9,7 +9,7 @@ import { zodYourPoliticianCategory } from '@/validation/fields/zodYourPolitician
 
 const base = object({
   emailAddress: string().trim().email('Please enter a valid email address').toLowerCase(),
-  message: string()
+  contactMessage: string()
     .min(1, 'Please enter a message')
     .max(2000, 'Your message should not exceed 2000 characters'),
   subject: string().trim(),


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged --> https://github.com/Stand-With-Crypto/swc-web/issues/1740

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
