### PR TITLE
fix: remove 3 dashes validation from dtsi slug

### DIFF
--- a/src/validation/fields/zodDTSISlug.ts
+++ b/src/validation/fields/zodDTSISlug.ts
@@ -1,5 +1,3 @@
 import { string } from 'zod'
 
-export const zodDTSISlug = string({ required_error: 'Person required to submit' }).includes('---', {
-  message: 'Must have a valid person selected',
-})
+export const zodDTSISlug = string({ required_error: 'Person required to submit' })


### PR DESCRIPTION
Turns out it's possible that dtsi slugs only have two dashes, I'm removing the 3 dashes validation for that reason

closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
