### PR TITLE
feat: add new SMS shortlink redirect for new congress activation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -334,6 +334,12 @@ const nextConfig: NextConfig = {
       },
       // SMS shortlinks
       {
+        source: '/new-congress-2/:sessionId*',
+        destination:
+          '/action/email?utm_source=swc&utm_medium=sms&utm_campaign=new-member-activation-2&sessionId=:sessionId*',
+        permanent: true,
+      },
+      {
         source: '/email-congress-retry/:sessionId*',
         destination:
           '/action/email?utm_source=swc&utm_medium=sms&utm_campaign=new-member-activation-retry&sessionId=:sessionId*',


### PR DESCRIPTION
## What changed? Why?

Vanity URL for [this](https://docs.google.com/document/d/1CLY7WZswo9lsHhNFR_LnJ33s9GjhuqBs8D9WCEgUKds/edit?tab=t.0#heading=h.ab4kcs4gvyg0) SMS

## How has it been tested?

- [ ] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
