### PR TITLE
Display invalid phone number instead of throwing

### DIFF
--- a/src/utils/shared/phoneNumber.ts
+++ b/src/utils/shared/phoneNumber.ts
@@ -56,9 +56,15 @@ export function formatPhoneNumber(phoneNumber: string) {
 export function validatePhoneNumber(phoneNumber: string) {
   if (!phoneNumber) return false
 
-  const parsedPhoneNumber = parsePhoneNumber(phoneNumber)
+  try {
+    const parsedPhoneNumber = parsePhoneNumber(phoneNumber)
+    if (!parsedPhoneNumber) return false
 
-  if (!parsedPhoneNumber) return false
-
-  return parsedPhoneNumber.isPossible() && parsedPhoneNumber.isValid()
+    return parsedPhoneNumber.isPossible() && parsedPhoneNumber.isValid()
+  } catch (e) {
+    if (e instanceof ParseError) {
+      return false
+    }
+    throw e
+  }
 }


### PR DESCRIPTION
closes #1762 

fixes [PROD-SWC-WEB-5K0](https://stand-with-crypto.sentry.io/issues/6200525119/)

## What changed? Why?

Before the change, a `TOO_SHORT` parse error will break the form:
https://github.com/user-attachments/assets/69b1571d-140f-4abb-be0f-4bbbe39d7ee2

After the change we display proper user feedback and correct analytics info:
https://github.com/user-attachments/assets/6fce7f27-b17e-4cc0-8486-3efd77024d0d



<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
