### PR TITLE
fix: improve SMS webhook Sentry logging

### DIFF
--- a/src/app/api/public/sms/events/status/route.ts
+++ b/src/app/api/public/sms/events/status/route.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import { CommunicationMessageStatus, UserCommunicationJourneyType } from '@prisma/client'
+import * as Sentry from '@sentry/nextjs'
 import { waitUntil } from '@vercel/functions'
 import { NextRequest, NextResponse } from 'next/server'
 
@@ -75,6 +76,11 @@ export const POST = withRouteMiddleware(async (request: NextRequest) => {
   const user = await getUserByPhoneNumber(phoneNumber)
 
   if (!user) {
+    Sentry.captureMessage(`User not found for phone number ${phoneNumber}`, {
+      tags: {
+        domain: 'smsStatusRoute',
+      },
+    })
     return new NextResponse('success', {
       status: 200,
     })

--- a/src/inngest/functions/sms/tests/enqueueMessages.test.ts
+++ b/src/inngest/functions/sms/tests/enqueueMessages.test.ts
@@ -12,8 +12,8 @@ import { flagInvalidPhoneNumbers } from '@/inngest/functions/sms/utils/flagInval
 import { fakerFields } from '@/mocks/fakerUtils'
 import { sendSMS, SendSMSError } from '@/utils/server/sms'
 import { optOutUser } from '@/utils/server/sms/actions'
-import type { SendSMSPayload } from '@/utils/server/sms/sendSMS'
 import * as smsErrorCodes from '@/utils/server/sms/errorCodes'
+import type { SendSMSPayload } from '@/utils/server/sms/sendSMS'
 import { UserSMSVariables } from '@/utils/server/sms/utils/variables'
 import { apiUrls, fullUrl } from '@/utils/shared/urls'
 

--- a/src/inngest/functions/sms/tests/enqueueMessages.test.ts
+++ b/src/inngest/functions/sms/tests/enqueueMessages.test.ts
@@ -13,11 +13,7 @@ import { fakerFields } from '@/mocks/fakerUtils'
 import { sendSMS, SendSMSError } from '@/utils/server/sms'
 import { optOutUser } from '@/utils/server/sms/actions'
 import type { SendSMSPayload } from '@/utils/server/sms/sendSMS'
-import {
-  INVALID_PHONE_NUMBER_CODE,
-  IS_UNSUBSCRIBED_USER_CODE,
-  TOO_MANY_REQUESTS_CODE,
-} from '@/utils/server/sms/SendSMSError'
+import * as smsErrorCodes from '@/utils/server/sms/errorCodes'
 import { UserSMSVariables } from '@/utils/server/sms/utils/variables'
 import { apiUrls, fullUrl } from '@/utils/shared/urls'
 
@@ -120,9 +116,9 @@ describe('enqueueMessages', () => {
     const failedPhoneNumber = mockedPayload[2].phoneNumber
 
     const phoneNumbersThatShouldThrowErrors = {
-      [invalidPhoneNumber]: INVALID_PHONE_NUMBER_CODE,
-      [unsubscribedPhoneNumber]: IS_UNSUBSCRIBED_USER_CODE,
-      [failedPhoneNumber]: TOO_MANY_REQUESTS_CODE,
+      [invalidPhoneNumber]: smsErrorCodes.INVALID_PHONE_NUMBER_CODE,
+      [unsubscribedPhoneNumber]: smsErrorCodes.IS_UNSUBSCRIBED_USER_CODE,
+      [failedPhoneNumber]: smsErrorCodes.TOO_MANY_REQUESTS_CODE,
     }
 
     ;(sendSMS as jest.Mock).mockImplementation(({ to, body }: SendSMSPayload) => {

--- a/src/utils/server/sms/SendSMSError.ts
+++ b/src/utils/server/sms/SendSMSError.ts
@@ -1,15 +1,11 @@
 import axios from 'axios'
 import RestException from 'twilio/lib/base/RestException'
 
-export const INVALID_PHONE_NUMBER_CODE = 21211
-export const NOT_A_VALID_PHONE_NUMBER_CODE = 21614
-export const TOO_MANY_REQUESTS_CODE = 20429
-export const IS_UNSUBSCRIBED_USER_CODE = 21610
-export const MESSAGE_BLOCKED_CODE = 30004
+import * as smsErrorCodes from './errorCodes'
 
 export class SendSMSError {
   phoneNumber: string
-  code: number | string = 'Unknown'
+  code = 'Unknown'
   message = 'Unknown SendSMS Error'
   moreInfo?: string
   details?: object | unknown
@@ -23,21 +19,21 @@ export class SendSMSError {
 
     if (error instanceof RestException) {
       if (error.code) {
-        this.code = error.code
+        this.code = String(error.code)
       }
       this.message = error.message
       this.moreInfo = error.moreInfo
       this.details = error.details
     } else if (axios.isAxiosError(error)) {
       if (error.code) {
-        this.code = error.code
+        this.code = String(error.code)
       }
       this.message = error.message
       this.moreInfo = error.stack
       this.details = error.cause
     } else {
       if ('code' in (error as any)) {
-        this.code = (error as any).code
+        this.code = String((error as any).code)
       }
       if ('message' in (error as any)) {
         this.message = (error as any).message
@@ -45,10 +41,12 @@ export class SendSMSError {
     }
 
     this.isInvalidPhoneNumber =
-      this.code === INVALID_PHONE_NUMBER_CODE || this.code === NOT_A_VALID_PHONE_NUMBER_CODE
-    this.isUnsubscribedUser = this.code === IS_UNSUBSCRIBED_USER_CODE
+      this.code === smsErrorCodes.INVALID_PHONE_NUMBER_CODE ||
+      this.code === smsErrorCodes.NOT_A_VALID_PHONE_NUMBER_CODE ||
+      this.code === smsErrorCodes.INFORMATION_SERVICE_NUMBER_CODE
+    this.isUnsubscribedUser = this.code === smsErrorCodes.IS_UNSUBSCRIBED_USER_CODE
     this.isTooManyRequests =
-      this.code === TOO_MANY_REQUESTS_CODE ||
+      this.code === smsErrorCodes.TOO_MANY_REQUESTS_CODE ||
       this.code === 'ECONNABORTED' ||
       this.code === 'ETIMEDOUT'
   }

--- a/src/utils/server/sms/errorCodes.ts
+++ b/src/utils/server/sms/errorCodes.ts
@@ -1,0 +1,21 @@
+// See https://www.twilio.com/docs/api/errors/{code} for more information on the error codes
+
+// We should retry to send messages to these phone numbers
+export const TOO_MANY_REQUESTS_CODE = '20429'
+
+// We're flagging these phone numbers as invalid
+export const INVALID_PHONE_NUMBER_CODE = '21211'
+export const INFORMATION_SERVICE_NUMBER_CODE = '21268'
+export const NOT_A_VALID_PHONE_NUMBER_CODE = '21614'
+
+// We should opt out these phone numbers
+export const IS_UNSUBSCRIBED_USER_CODE = '21610'
+export const MESSAGE_BLOCKED_CODE = '30004'
+
+// These errors are related to the user's mobile carrier not being available when we send messages
+export const UNREACHABLE_DESTINATION_HANDSET_CODE = '30003'
+export const UNKNOWN_DESTINATION_HANDSET_CODE = '30005'
+export const LANDLINE_OR_UNREACHABLE_CARRIER_CODE = '30006'
+
+// We received a machine generated response
+export const FILTERED_TO_PREVENT_MESSAGE_LOOPS_CODE = '30039'


### PR DESCRIPTION
closes [#312](https://github.com/Stand-With-Crypto/swc-internal/issues/312)

## What changed? Why?

- Added more errors to be filtered from Sentry in the SMS fails webhook
- Added a log to Sentry when the SMS status webhook cannot find the user

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
