### PR TITLE
feat: save locale information on middleware

### DIFF
--- a/src/utils/server/localeRouter/index.ts
+++ b/src/utils/server/localeRouter/index.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { LOCALE_COOKIE } from '@/utils/shared/supportedLocales'
 
 const DEFAULT_LOCALE = 'en-US' as const
+const LOCALE_MATCHER = /^[a-z]{2}-[A-Z]{2}$/
 
 /**
  * Custom router that hides the default locale (en-US) from URLs
@@ -15,22 +16,28 @@ export function localeRouter(request: NextRequest): NextResponse {
   const firstSegment = segments[0]
 
   const requestLocale =
-    !!firstSegment && firstSegment.match(/^[a-z]{2}-[A-Z]{2}$/) ? firstSegment : DEFAULT_LOCALE
+    !!firstSegment && firstSegment.match(LOCALE_MATCHER) ? firstSegment : DEFAULT_LOCALE
 
   // If path starts with default locale, redirect to path without it
   if (firstSegment === DEFAULT_LOCALE) {
     const newPath = pathname.replace(`/${DEFAULT_LOCALE}`, '') || '/'
     const searchParams = request.nextUrl.search
 
-    return setLocaleCookie(NextResponse.redirect(new URL(`${newPath}${searchParams}`, request.url)), requestLocale)
+    return setLocaleCookie(
+      NextResponse.redirect(new URL(`${newPath}${searchParams}`, request.url)),
+      requestLocale,
+    )
   }
 
   // If path doesn't start with any locale, rewrite to include default locale
-  if (!firstSegment || !firstSegment.match(/^[a-z]{2}-[A-Z]{2}$/)) {
+  if (!firstSegment || !firstSegment.match(LOCALE_MATCHER)) {
     const newPath = `/${DEFAULT_LOCALE}${pathname}`
     const searchParams = request.nextUrl.search
 
-    return setLocaleCookie(NextResponse.rewrite(new URL(`${newPath}${searchParams}`, request.url)), requestLocale)
+    return setLocaleCookie(
+      NextResponse.rewrite(new URL(`${newPath}${searchParams}`, request.url)),
+      requestLocale,
+    )
   }
 
   // For all other locales, keep them visible in the URL

--- a/src/utils/server/localeRouter/index.ts
+++ b/src/utils/server/localeRouter/index.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { LOCALE_COOKIE } from '@/utils/shared/supportedLocales'
+
 const DEFAULT_LOCALE = 'en-US' as const
 
 /**
@@ -12,12 +14,17 @@ export function localeRouter(request: NextRequest): NextResponse {
   const segments = pathname.split('/').filter(Boolean)
   const firstSegment = segments[0]
 
+  const requestLocale =
+    !!firstSegment && firstSegment.match(/^[a-z]{2}-[A-Z]{2}$/) ? firstSegment : DEFAULT_LOCALE
+
   // If path starts with default locale, redirect to path without it
   if (firstSegment === DEFAULT_LOCALE) {
     const newPath = pathname.replace(`/${DEFAULT_LOCALE}`, '') || '/'
     const searchParams = request.nextUrl.search
 
-    return NextResponse.redirect(new URL(`${newPath}${searchParams}`, request.url))
+    const response = NextResponse.redirect(new URL(`${newPath}${searchParams}`, request.url))
+    setLocaleCookie(response, requestLocale)
+    return response
   }
 
   // If path doesn't start with any locale, rewrite to include default locale
@@ -25,9 +32,23 @@ export function localeRouter(request: NextRequest): NextResponse {
     const newPath = `/${DEFAULT_LOCALE}${pathname}`
     const searchParams = request.nextUrl.search
 
-    return NextResponse.rewrite(new URL(`${newPath}${searchParams}`, request.url))
+    const response = NextResponse.rewrite(new URL(`${newPath}${searchParams}`, request.url))
+    setLocaleCookie(response, requestLocale)
+    return response
   }
 
   // For all other locales, keep them visible in the URL
-  return NextResponse.next()
+  const response = NextResponse.next()
+  setLocaleCookie(response, requestLocale)
+  return response
+}
+
+function setLocaleCookie(response: NextResponse, locale: string) {
+  const localeCookie = response.cookies.get(LOCALE_COOKIE)
+
+  if (localeCookie?.value !== locale) {
+    response.cookies.set(LOCALE_COOKIE, locale)
+  }
+
+  return response
 }

--- a/src/utils/server/localeRouter/index.ts
+++ b/src/utils/server/localeRouter/index.ts
@@ -22,9 +22,7 @@ export function localeRouter(request: NextRequest): NextResponse {
     const newPath = pathname.replace(`/${DEFAULT_LOCALE}`, '') || '/'
     const searchParams = request.nextUrl.search
 
-    const response = NextResponse.redirect(new URL(`${newPath}${searchParams}`, request.url))
-    setLocaleCookie(response, requestLocale)
-    return response
+    return setLocaleCookie(NextResponse.redirect(new URL(`${newPath}${searchParams}`, request.url)), requestLocale)
   }
 
   // If path doesn't start with any locale, rewrite to include default locale
@@ -32,15 +30,11 @@ export function localeRouter(request: NextRequest): NextResponse {
     const newPath = `/${DEFAULT_LOCALE}${pathname}`
     const searchParams = request.nextUrl.search
 
-    const response = NextResponse.rewrite(new URL(`${newPath}${searchParams}`, request.url))
-    setLocaleCookie(response, requestLocale)
-    return response
+    return setLocaleCookie(NextResponse.rewrite(new URL(`${newPath}${searchParams}`, request.url)), requestLocale)
   }
 
   // For all other locales, keep them visible in the URL
-  const response = NextResponse.next()
-  setLocaleCookie(response, requestLocale)
-  return response
+  return setLocaleCookie(NextResponse.next(), requestLocale)
 }
 
 function setLocaleCookie(response: NextResponse, locale: string) {

--- a/src/utils/shared/supportedLocales.ts
+++ b/src/utils/shared/supportedLocales.ts
@@ -3,3 +3,5 @@ export enum SupportedLocale {
 }
 export const DEFAULT_LOCALE = SupportedLocale.EN_US
 export const ORDERED_SUPPORTED_LOCALES: readonly SupportedLocale[] = [SupportedLocale.EN_US]
+
+export const LOCALE_COOKIE = 'SWC_LOCALE'


### PR DESCRIPTION
closes #1781 

## What changed? Why?

This PR adds new logic to save the locale information on our middleware to be used in actions, Mixpanel and Sentry

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
