### PR TITLE
fix: make unavailableContent optional in GeoGate component

### DIFF
--- a/src/components/app/geoGate.tsx
+++ b/src/components/app/geoGate.tsx
@@ -10,7 +10,7 @@ import { isValidCountryCode } from '@/utils/shared/isValidCountryCode'
 interface GeoGateProps {
   children: React.ReactNode
   countryCode: string
-  unavailableContent: React.ReactNode
+  unavailableContent?: React.ReactNode
   bypassCountryCheck?: boolean
 }
 
@@ -24,6 +24,8 @@ export const GeoGate = (props: GeoGateProps) => {
   const userCountryCode = Cookies.get(USER_COUNTRY_CODE_COOKIE_NAME)
 
   if (!isValidCountryCode({ countryCode, userCountryCode, bypassCountryCheck })) {
+    if (!unavailableContent) return null
+
     return React.cloneElement(unavailableContent as React.ReactElement<{ countryCode: string }>, {
       countryCode,
     })

--- a/src/components/app/pageDonate/heading.tsx
+++ b/src/components/app/pageDonate/heading.tsx
@@ -12,7 +12,7 @@ export function Heading({ locale, title, description, sumDonations }: PageDonate
       <SumDonationsCounter initialData={sumDonations} locale={locale} />
       <PageTitle>{title}</PageTitle>
       <PageSubTitle>{description}</PageSubTitle>
-      <GeoGate countryCode={DEFAULT_SUPPORTED_COUNTRY_CODE} unavailableContent={null}>
+      <GeoGate countryCode={DEFAULT_SUPPORTED_COUNTRY_CODE}>
         <DonateButton />
       </GeoGate>
       <PageSubTitle className="text-xs lg:text-sm">

--- a/src/components/app/pageEvents/index.tsx
+++ b/src/components/app/pageEvents/index.tsx
@@ -31,7 +31,7 @@ export function EventsPage({ events, isDeepLink }: EventsPageProps) {
 
       <PromotedEvents events={events} />
 
-      <GeoGate countryCode={DEFAULT_SUPPORTED_COUNTRY_CODE} unavailableContent={null}>
+      <GeoGate countryCode={DEFAULT_SUPPORTED_COUNTRY_CODE}>
         <EventsNearYou events={filteredFutureEvents} />
       </GeoGate>
 


### PR DESCRIPTION
fixes [PROD-SWC-WEB-5Q5](https://stand-with-crypto.sentry.io/issues/6256951763/events/716c384999894130b2cc6cc6f4931e4c/)

## What changed? Why?

Make unavailableContent optional as React.cloneElement is complaining about it being null

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
