### PR TITLE
feat: add tenantId to models for multi-country support

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model Address {
   usCongressionalDistrict  String?  @map("us_congressional_district") // ex: 12
   datetimeUpdated          DateTime @updatedAt @map("datetime_updated")
   datetimeCreated          DateTime @default(now()) @map("datetime_created")
+  tenantId                 String   @default("US") @map("tenant_id")
 
   userActionEmails                      UserActionEmail[]
   userActionCalls                       UserActionCall[]
@@ -215,6 +216,7 @@ model UserEmailAddress {
   dataCreationMethod DataCreationMethod     @default(BY_USER) @map("data_creation_method")
   datetimeUpdated    DateTime               @updatedAt @map("datetime_updated")
   datetimeCreated    DateTime               @default(now()) @map("datetime_created")
+  tenantId           String                 @default("US") @map("tenant_id")
 
   userActions                     UserAction[]
   asPrimaryUserEmailAddress       User?              @relation("asPrimaryUserEmailAddress")
@@ -465,6 +467,7 @@ model UserActionVoterAttestation {
   id         String     @id @default(uuid())
   userAction UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   usaState   String?    @map("usa_state")
+  tenantId   String     @default("US") @map("tenant_id")
 
   @@map("user_action_voter_attestation")
 }
@@ -473,6 +476,7 @@ model UserActionTweetAtPerson {
   id                String     @id @default(uuid())
   userAction        UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   recipientDtsiSlug String?    @map("recipient_dtsi_slug")
+  tenantId          String     @default("US") @map("tenant_id")
 
   @@map("user_action_tweet_at_person")
 }
@@ -483,6 +487,7 @@ model UserActionRsvpEvent {
   eventState                 String     @map("event_state")
   shouldReceiveNotifications Boolean    @map("should_receive_notifications")
   userAction                 UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
+  tenantId                   String     @default("US") @map("tenant_id")
 
   @@index([eventSlug, eventState])
   @@map("user_action_rsvp_event")
@@ -494,6 +499,7 @@ model UserActionVotingInformationResearched {
   shouldReceiveNotifications Boolean    @map("should_receive_notifications")
   address                    Address?   @relation(fields: [addressId], references: [id])
   addressId                  String?    @map("address_id")
+  tenantId                   String     @default("US") @map("tenant_id")
 
   @@index([addressId])
   @@map("user_action_voting_information_researched")
@@ -515,6 +521,7 @@ model UserCommunicationJourney {
   datetimeCreated    DateTime                     @default(now()) @map("datetime_created")
   userCommunications UserCommunication[]
   campaignName       String?                      @map("campaign_name")
+  tenantId           String                       @default("US") @map("tenant_id")
 
   @@index([userId])
   @@map("user_communication_journey")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -145,6 +145,7 @@ model User {
   capitolCanaryInstance    CapitolCanaryInstance?     @map("capitol_canary_instance")
   UserCommunicationJourney UserCommunicationJourney[]
   smsStatus                SMSStatus                  @default(NOT_OPTED_IN) @map("sms_status")
+  tenantId                 String                     @default("US") @map("tenant_id")
 
   @@index([addressId])
   @@index([internalStatus])
@@ -294,6 +295,7 @@ model UserAction {
   nftMintId           String?            @unique @map("nft_mint_id")
   nftMint             NFTMint?           @relation(fields: [nftMintId], references: [id])
   actionType          UserActionType     @map("action_type")
+  tenantId            String             @default("US") @map("tenant_id")
 
   // We'll need in-memory logic to validate and verify only one action type is every associated with a UserAction
   userActionEmail                       UserActionEmail?
@@ -327,6 +329,7 @@ model UserActionOptIn {
   id         String              @id @default(uuid())
   userAction UserAction          @relation(fields: [id], references: [id])
   optInType  UserActionOptInType @map("opt_in_type")
+  tenantId   String              @default("US") @map("tenant_id")
 
   @@map("user_action_opt_in")
 }
@@ -340,6 +343,7 @@ model UserActionEmail {
   address                   Address?                   @relation(fields: [addressId], references: [id])
   addressId                 String?                    @map("address_id")
   userActionEmailRecipients UserActionEmailRecipient[]
+  tenantId                  String                     @default("US") @map("tenant_id")
 
   @@index([addressId])
   @@map("user_action_email")
@@ -365,6 +369,7 @@ model UserActionCall {
   recipientPhoneNumber String?    @map("recipient_phone_number")
   address              Address?   @relation(fields: [addressId], references: [id])
   addressId            String?    @map("address_id")
+  tenantId             String     @default("US") @map("tenant_id")
 
   @@index([addressId])
   @@map("user_action_call")
@@ -382,6 +387,7 @@ model UserActionDonation {
   amountCurrencyCode String               @map("amount_currency_code")
   amountUsd          Decimal              @map("amount_usd")
   recipient          DonationOrganization
+  tenantId           String               @default("US") @map("tenant_id")
 
   coinbaseCommerceDonationId String? @map("coinbase_commerce_donation_id")
 
@@ -418,6 +424,7 @@ model NFTMint {
   costAtMint             Decimal       @map("cost_at_mint")
   costAtMintCurrencyCode NFTCurrency   @map("cost_at_mint_currency_code")
   costAtMintUsd          Decimal       @map("cost_at_mint_usd")
+  tenantId               String        @default("US") @map("tenant_id")
 
   userActions UserAction[]
 
@@ -430,6 +437,7 @@ model UserActionVotingDay {
   userAction UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   votingYear String     @map("voting_year")
   usaState   String?    @map("usa_state")
+  tenantId   String     @default("US") @map("tenant_id")
 
   @@map("user_action_voting_day")
 }
@@ -439,6 +447,7 @@ model UserActionViewKeyRaces {
   userAction              UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   usCongressionalDistrict String?    @map("us_congressional_district")
   usaState                String?    @map("usa_state")
+  tenantId                String     @default("US") @map("tenant_id")
 
   @@map("user_action_view_key_races")
 }
@@ -447,6 +456,7 @@ model UserActionVoterRegistration {
   id         String     @id @default(uuid())
   userAction UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   usaState   String?    @map("usa_state")
+  tenantId   String     @default("US") @map("tenant_id")
 
   @@map("user_action_voter_registration")
 }

--- a/src/components/app/navbarGlobalBanner/index.tsx
+++ b/src/components/app/navbarGlobalBanner/index.tsx
@@ -10,7 +10,7 @@ import {
   parseUserCountryCodeCookie,
   USER_COUNTRY_CODE_COOKIE_NAME,
 } from '@/utils/server/getCountryCode'
-import { SUPPORTED_COUNTRY_CODES } from '@/utils/shared/supportedCountries'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 const languages = getNavigatorLanguages()
 
@@ -61,7 +61,7 @@ export function NavBarGlobalBanner() {
     )
   }
 
-  if (parsedExistingCountryCode?.countryCode !== SUPPORTED_COUNTRY_CODES.US) {
+  if (parsedExistingCountryCode?.countryCode !== SupportedCountryCodes.US) {
     return (
       <div className="flex h-12 w-full items-center justify-center bg-primary-cta">
         <WrapperContainer className="flex h-12 w-full items-center bg-primary-cta text-center">

--- a/src/mocks/models/mockAddress.ts
+++ b/src/mocks/models/mockAddress.ts
@@ -3,8 +3,11 @@ import { Address, Prisma } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
 import { mockCommonDatetimes } from '@/mocks/mockCommonDatetimes'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateAddressInput() {
+  const countryCode = faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES))
+
   const partial = {
     googlePlaceId: null,
     streetNumber: faker.location.buildingNumber(),
@@ -15,8 +18,9 @@ export function mockCreateAddressInput() {
     administrativeAreaLevel2: '',
     postalCode: faker.location.zipCode(),
     postalCodeSuffix: '',
-    countryCode: 'US',
+    countryCode: countryCode,
     usCongressionalDistrict: '12',
+    tenantId: countryCode,
   } satisfies Partial<Prisma.AddressCreateInput>
   return {
     ...partial,

--- a/src/mocks/models/mockNFTMint.ts
+++ b/src/mocks/models/mockNFTMint.ts
@@ -7,6 +7,7 @@ import { mockCommonDatetimes } from '@/mocks/mockCommonDatetimes'
 import { NFT_SLUG_BACKEND_METADATA } from '@/utils/server/nft/constants'
 import { MOCK_CURRENT_ETH_USD_EXCHANGE_RATE } from '@/utils/shared/exchangeRate'
 import { NFTSlug } from '@/utils/shared/nft'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateNFTMintInput() {
   const status = faker.helpers.arrayElement(Object.values(NFTMintStatus))
@@ -31,6 +32,7 @@ export function mockCreateNFTMintInput() {
     costAtMintCurrencyCode: NFTCurrency.ETH,
     contractAddress: NFT_SLUG_BACKEND_METADATA[nftSlug].contractAddress,
     costAtMintUsd: costAtMint.times(MOCK_CURRENT_ETH_USD_EXCHANGE_RATE),
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.NFTMintCreateInput
 }
 export function mockNFTMint(): NFTMint {

--- a/src/mocks/models/mockUser.ts
+++ b/src/mocks/models/mockUser.ts
@@ -11,6 +11,7 @@ import { Decimal } from '@prisma/client/runtime/library'
 
 import { fakerFields } from '@/mocks/fakerUtils'
 import { mockCommonDatetimes } from '@/mocks/mockCommonDatetimes'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserInput({
   withData = faker.helpers.maybe(() => true, { probability: 0.5 }),
@@ -42,6 +43,7 @@ export function mockCreateUserInput({
     internalStatus: UserInternalStatus.VISIBLE,
     capitolCanaryAdvocateId: null,
     capitolCanaryInstance: null,
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserCreateInput
 }
 

--- a/src/mocks/models/mockUserAction.ts
+++ b/src/mocks/models/mockUserAction.ts
@@ -3,6 +3,7 @@ import { DataCreationMethod, Prisma, UserAction } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
 import { mockCommonDatetimes } from '@/mocks/mockCommonDatetimes'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 import {
   ACTIVE_CLIENT_USER_ACTION_WITH_CAMPAIGN,
   USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP,
@@ -13,6 +14,7 @@ export function mockCreateUserActionInput() {
   return {
     actionType,
     campaignName: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP[actionType],
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Omit<
     Prisma.UserActionCreateInput,
     'userId' | 'nftMintId' | 'userCryptoAddressId' | 'userSessionId' | 'userEmailAddressId' | 'user'

--- a/src/mocks/models/mockUserActionCall.ts
+++ b/src/mocks/models/mockUserActionCall.ts
@@ -1,6 +1,8 @@
+import { faker } from '@faker-js/faker'
 import { Prisma, UserActionCall } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionCallInput() {
   return {
@@ -15,5 +17,6 @@ export function mockUserActionCall(): UserActionCall {
     recipientPhoneNumber: fakerFields.phoneNumber(),
     recipientDtsiSlug: fakerFields.dtsiSlug(),
     addressId: fakerFields.id(),
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   }
 }

--- a/src/mocks/models/mockUserActionDonation.ts
+++ b/src/mocks/models/mockUserActionDonation.ts
@@ -4,6 +4,7 @@ import { Decimal } from '@prisma/client/runtime/library'
 
 import { fakerFields } from '@/mocks/fakerUtils'
 import { SupportedFiatCurrencyCodes } from '@/utils/shared/currency'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionDonationInput() {
   const amount = new Decimal(faker.number.float({ min: 0, max: 1000, multipleOf: 0.01 }))
@@ -14,6 +15,7 @@ export function mockCreateUserActionDonationInput() {
     amountUsd: amount,
     recipient: faker.helpers.arrayElement(Object.values(DonationOrganization)),
     coinbaseCommerceDonationId: fakerFields.id(),
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionDonationCreateInput
 }
 

--- a/src/mocks/models/mockUserActionEmail.ts
+++ b/src/mocks/models/mockUserActionEmail.ts
@@ -2,12 +2,14 @@ import { faker } from '@faker-js/faker'
 import { Prisma, UserActionEmail } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionEmailInput() {
   return {
     senderEmail: faker.internet.email(),
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Omit<Prisma.UserActionEmailCreateInput, 'address' | 'addressId'>
 }
 

--- a/src/mocks/models/mockUserActionOptIn.ts
+++ b/src/mocks/models/mockUserActionOptIn.ts
@@ -2,10 +2,12 @@ import { faker } from '@faker-js/faker'
 import { Prisma, UserActionOptIn, UserActionOptInType } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionOptInInput() {
   return {
     optInType: faker.helpers.arrayElement(Object.values(UserActionOptInType)),
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionOptInCreateInput
 }
 

--- a/src/mocks/models/mockUserActionRsvpEvent.ts
+++ b/src/mocks/models/mockUserActionRsvpEvent.ts
@@ -2,12 +2,14 @@ import { faker } from '@faker-js/faker'
 import { Prisma, UserActionRsvpEvent } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionRsvpEventInput() {
   return {
     eventSlug: faker.string.uuid(),
     eventState: fakerFields.stateCode(),
     shouldReceiveNotifications: false,
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionRsvpEventCreateInput
 }
 export function mockUserActionRsvpEvent(): UserActionRsvpEvent {

--- a/src/mocks/models/mockUserActionTweetAtPerson.ts
+++ b/src/mocks/models/mockUserActionTweetAtPerson.ts
@@ -1,10 +1,13 @@
+import { faker } from '@faker-js/faker'
 import { Prisma, UserActionTweetAtPerson } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockUserActionTweetAtPersonInput() {
   return {
     recipientDtsiSlug: fakerFields.dtsiSlug(),
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionTweetAtPersonCreateInput
 }
 

--- a/src/mocks/models/mockUserActionViewKeyRaces.ts
+++ b/src/mocks/models/mockUserActionViewKeyRaces.ts
@@ -1,11 +1,14 @@
+import { faker } from '@faker-js/faker'
 import { Prisma, UserActionViewKeyRaces } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionViewKeyRacesInput() {
   return {
     usaState: fakerFields.stateCode({ abbreviated: true }),
     usCongressionalDistrict: fakerFields.usCongressionalDistrict(),
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionViewKeyRacesCreateInput
 }
 

--- a/src/mocks/models/mockUserActionVoterAttestation.ts
+++ b/src/mocks/models/mockUserActionVoterAttestation.ts
@@ -1,10 +1,13 @@
+import { faker } from '@faker-js/faker'
 import { Prisma, UserActionVoterAttestation } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionVoterAttestationInput() {
   return {
     usaState: fakerFields.stateCode(),
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionVoterAttestationCreateInput
 }
 

--- a/src/mocks/models/mockUserActionVoterRegistration.ts
+++ b/src/mocks/models/mockUserActionVoterRegistration.ts
@@ -1,10 +1,13 @@
+import { faker } from '@faker-js/faker'
 import { Prisma, UserActionVoterRegistration } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionVoterRegistrationInput() {
   return {
     usaState: fakerFields.stateCode(),
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionVoterRegistrationCreateInput
 }
 

--- a/src/mocks/models/mockUserActionVotingDay.ts
+++ b/src/mocks/models/mockUserActionVotingDay.ts
@@ -1,11 +1,14 @@
+import { faker } from '@faker-js/faker'
 import { Prisma, UserActionVotingDay } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionVotingDayInput() {
   return {
     usaState: fakerFields.stateCode({ abbreviated: true }),
     votingYear: new Date().getFullYear().toString(),
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionVotingDayCreateInput
 }
 

--- a/src/mocks/models/mockUserActionVotingInformationResearched.ts
+++ b/src/mocks/models/mockUserActionVotingInformationResearched.ts
@@ -1,10 +1,13 @@
+import { faker } from '@faker-js/faker'
 import { Prisma, UserActionVotingInformationResearched } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionVotingInformationResearchedInput() {
   return {
     shouldReceiveNotifications: false,
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionVotingInformationResearchedCreateInput
 }
 

--- a/src/mocks/models/mockUserEmailAddress.ts
+++ b/src/mocks/models/mockUserEmailAddress.ts
@@ -8,6 +8,7 @@ import {
 
 import { fakerFields } from '@/mocks/fakerUtils'
 import { mockCommonDatetimes } from '@/mocks/mockCommonDatetimes'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserEmailAddressInput() {
   const source = faker.helpers.arrayElement(Object.values(UserEmailAddressSource))
@@ -15,6 +16,7 @@ export function mockCreateUserEmailAddressInput() {
     source,
     emailAddress: faker.internet.email(),
     isVerified: source === UserEmailAddressSource.VERIFIED_THIRD_PARTY,
+    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Omit<Prisma.UserEmailAddressCreateInput, 'userId' | 'user'>
 }
 

--- a/src/utils/shared/isValidCountryCode.ts
+++ b/src/utils/shared/isValidCountryCode.ts
@@ -1,5 +1,5 @@
 import { parseUserCountryCodeCookie } from '@/utils/server/getCountryCode'
-import { SUPPORTED_COUNTRY_CODES } from '@/utils/shared/supportedCountries'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 type IsValidCountryCodeArgs = {
   countryCode: string
@@ -20,7 +20,7 @@ export function isValidCountryCode({
   if (parsedExistingCountryCode.countryCode === countryCode) return true
   // there are cases where users in the US are getting blocked if they are close to the US border so we want to be more permissive with Canada/Mexico
   if (
-    countryCode === SUPPORTED_COUNTRY_CODES.US &&
+    countryCode === SupportedCountryCodes.US &&
     ['MX', 'CA'].includes(parsedExistingCountryCode.countryCode)
   ) {
     return true

--- a/src/utils/shared/supportedCountries.ts
+++ b/src/utils/shared/supportedCountries.ts
@@ -1,5 +1,14 @@
-export enum SUPPORTED_COUNTRY_CODES {
+import { SupportedLocale } from '@/utils/shared/supportedLocales'
+
+export enum SupportedCountryCodes {
   US = 'US',
 }
 
-export const DEFAULT_SUPPORTED_COUNTRY_CODE = SUPPORTED_COUNTRY_CODES.US
+export const DEFAULT_SUPPORTED_COUNTRY_CODE = SupportedCountryCodes.US
+export const ORDERED_SUPPORTED_COUNTRIES: readonly SupportedCountryCodes[] = [
+  SupportedCountryCodes.US,
+]
+
+export const COUNTRY_CODE_TO_LOCALE: Record<SupportedCountryCodes, SupportedLocale> = {
+  [SupportedCountryCodes.US]: SupportedLocale.EN_US,
+}


### PR DESCRIPTION
closes #1778 

## What changed? Why?

This PR updates the Prisma schema by adding a new `tenantId` column to all models required for our internationalization process.

## PlanetScale deploy request

PlanetScale limits deploy requests to a maximum of 10 tables being updated. Because of this, I'll merge the first 10 tables and then create a second deploy request with the rest to complete the migration.

First deploy request: https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/79
Second deploy request:


P.S.: We are temporarily setting the default value to "US" just for the migration. Afterwards, I'll create another deploy request to remove the default value.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
