### PR TITLE
chore: add builder.io to Sentry ignore patterns

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,7 +20,7 @@ const contentSecurityPolicy = {
     "'self'",
     !isProd
       ? // NextJS requires 'unsafe-eval' in dev (faster source maps)
-        "'unsafe-eval' 'unsafe-inline' blob:"
+        "'unsafe-inline' blob:"
       : /*
         Streaming react server components within next.js relies on adding inline scripts to the page as content
         is progressively streamed in. https://github.com/vercel/next.js/discussions/42170#discussioncomment-8137079

--- a/next.config.ts
+++ b/next.config.ts
@@ -20,7 +20,7 @@ const contentSecurityPolicy = {
     "'self'",
     !isProd
       ? // NextJS requires 'unsafe-eval' in dev (faster source maps)
-        "'unsafe-inline' blob:"
+        "'unsafe-eval' 'unsafe-inline' blob:"
       : /*
         Streaming react server components within next.js relies on adding inline scripts to the page as content
         is progressively streamed in. https://github.com/vercel/next.js/discussions/42170#discussioncomment-8137079

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -92,6 +92,7 @@ Sentry.init({
     /extensions\//i,
     /^chrome:\/\//i,
     /inject/i,
+    /builder\.io/i,
   ],
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 1.0,

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -43,6 +43,11 @@ const COMMON_ERROR_MESSAGES_TO_GROUP = [
 
 const COMMON_TRANSACTION_NAMES_TO_GROUP = ['node_modules/@thirdweb-dev', 'maps/api/js']
 
+// List of parent page URLs where errors should be ignored
+// If the app is embedded in an iframe on any of these domains,
+// Sentry will discard errors to avoid unnecessary reporting.
+const IGNORED_IFRAME_PARENT_URLS = ['https://builder.io']
+
 const isSupportedBrowser = getIsSupportedBrowser(maybeDetectBrowser())
 
 // Single source of truth for log prefixes and messages
@@ -92,7 +97,6 @@ Sentry.init({
     /extensions\//i,
     /^chrome:\/\//i,
     /inject/i,
-    /https:\/\/builder\.io\/.*/i,
   ],
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 1.0,
@@ -124,6 +128,16 @@ Sentry.init({
     // skip logging if the console log matches known prefixes
     if (errorMessage && LOG_PREFIXES.some(prefix => errorMessage.startsWith(prefix))) {
       return null
+    }
+
+    // Check if the current window is within an iframe
+    if (window.self !== window.top) {
+      // Retrieve the URL of the parent frame
+      const parentUrl = document.referrer
+
+      if (IGNORED_IFRAME_PARENT_URLS.some(url => url.startsWith(parentUrl))) {
+        return null
+      }
     }
 
     // force group common transaction names

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -130,14 +130,10 @@ Sentry.init({
       return null
     }
 
-    console.log(window.self, window.top)
-
     // Check if the current window is within an iframe
     if (window.self !== window.top) {
       // Retrieve the URL of the parent frame
       const parentUrl = document.referrer
-
-      console.log('Parent URL:', parentUrl)
 
       if (IGNORED_IFRAME_PARENT_URLS.some(url => url.startsWith(parentUrl))) {
         return null

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -46,7 +46,7 @@ const COMMON_TRANSACTION_NAMES_TO_GROUP = ['node_modules/@thirdweb-dev', 'maps/a
 // List of parent page URLs where errors should be ignored
 // If the app is embedded in an iframe on any of these domains,
 // Sentry will discard errors to avoid unnecessary reporting.
-const IGNORED_IFRAME_PARENT_URLS = ['https://builder.io']
+const IGNORED_IFRAME_PARENT_URLS = ['https://builder.io/']
 
 const isSupportedBrowser = getIsSupportedBrowser(maybeDetectBrowser())
 
@@ -130,10 +130,14 @@ Sentry.init({
       return null
     }
 
+    console.log(window.self, window.top)
+
     // Check if the current window is within an iframe
     if (window.self !== window.top) {
       // Retrieve the URL of the parent frame
       const parentUrl = document.referrer
+
+      console.log('Parent URL:', parentUrl)
 
       if (IGNORED_IFRAME_PARENT_URLS.some(url => url.startsWith(parentUrl))) {
         return null

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -92,7 +92,7 @@ Sentry.init({
     /extensions\//i,
     /^chrome:\/\//i,
     /inject/i,
-    /builder\.io/i,
+    /https:\/\/builder\.io\/.*/i,
   ],
   replaysSessionSampleRate: 0,
   replaysOnErrorSampleRate: 1.0,


### PR DESCRIPTION
fixes [PROD-SWC-WEB-5PZ](https://stand-with-crypto.sentry.io/issues/6243931808/events/51af5add355f4e1588f708d42c0c8478/)

## What changed? Why?

Implemented a check to determine if the current window is within an iframe and discard errors if the parent URL matches any in the `IGNORED_IFRAME_PARENT_URLS` list. 

## How has it been tested?

- [x] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
