### PR TITLE
fix: remove cacheSeconds from event queries

### DIFF
--- a/src/utils/server/builder/models/data/events.ts
+++ b/src/utils/server/builder/models/data/events.ts
@@ -23,7 +23,6 @@ export async function getEvent(eventSlug: string, state: string) {
             ...(NEXT_PUBLIC_ENVIRONMENT === 'production' && { published: 'published' }),
           },
           includeUnpublished: NEXT_PUBLIC_ENVIRONMENT !== 'production',
-          cacheSeconds: 60,
         }),
       {
         retries: 3,
@@ -61,7 +60,6 @@ async function getAllEventsWithOffset(offset: number) {
           },
         },
         includeUnpublished: NEXT_PUBLIC_ENVIRONMENT !== 'production',
-        cacheSeconds: 60,
         limit: LIMIT,
         offset,
       }),


### PR DESCRIPTION
## What changed? Why?

This PR removes the internal builder.io caching system to try to fix the current behavior in prod causing new events to now show up on events page.

This change won't have a direct impact as the events page has the same cache time

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
