### PR TITLE
chore: remove revalidate and update events route revalidation paths

### DIFF
--- a/src/app/[countryCode]/events/[state]/[eventSlug]/page.tsx
+++ b/src/app/[countryCode]/events/[state]/[eventSlug]/page.tsx
@@ -14,7 +14,6 @@ type Props = PageProps<{
   eventSlug: string
 }>
 
-export const revalidate = 60 // 1 minute
 export const dynamic = 'error'
 
 const title = 'Event'

--- a/src/app/[countryCode]/events/[state]/page.tsx
+++ b/src/app/[countryCode]/events/[state]/page.tsx
@@ -9,7 +9,6 @@ import { US_STATE_CODE_TO_DISPLAY_NAME_MAP } from '@/utils/shared/usStateUtils'
 
 type Props = PageProps<{ state: keyof typeof US_STATE_CODE_TO_DISPLAY_NAME_MAP }>
 
-export const revalidate = 60 // 1 minute
 export const dynamic = 'error'
 
 const description =

--- a/src/app/[countryCode]/events/page.tsx
+++ b/src/app/[countryCode]/events/page.tsx
@@ -5,7 +5,6 @@ import { EventsPage } from '@/components/app/pageEvents'
 import { getEvents } from '@/utils/server/builder/models/data/events'
 import { generateMetadataDetails } from '@/utils/server/metadataUtils'
 
-export const revalidate = 60 // 1 minute
 export const dynamic = 'error'
 
 const title = 'Events'

--- a/src/app/api/public/builder/events/data/route.ts
+++ b/src/app/api/public/builder/events/data/route.ts
@@ -15,6 +15,8 @@ const BUILDER_IO_WEBHOOK_AUTH_TOKEN = requiredOutsideLocalEnv(
 )!
 
 const EVENTS_PATH = '/events'
+const EVENTS_STATE_PATH = '/events/[state]'
+const EVENTS_STATE_EVENT_SLUG_PATH = '/events/[state]/[eventSlug]'
 
 export const POST = async (request: NextRequest) => {
   const authHeader = request.headers.get('Authorization')
@@ -36,11 +38,21 @@ export const POST = async (request: NextRequest) => {
   }
 
   revalidatePath(EVENTS_PATH)
+  revalidatePath(EVENTS_STATE_PATH)
+  revalidatePath(EVENTS_STATE_EVENT_SLUG_PATH)
   ORDERED_SUPPORTED_COUNTRIES.forEach(countryCode =>
     revalidatePath(`/${countryCode}${EVENTS_PATH}`),
   )
+  ORDERED_SUPPORTED_COUNTRIES.forEach(countryCode =>
+    revalidatePath(`/${countryCode}${EVENTS_STATE_PATH}`),
+  )
+  ORDERED_SUPPORTED_COUNTRIES.forEach(countryCode =>
+    revalidatePath(`/${countryCode}${EVENTS_STATE_EVENT_SLUG_PATH}`),
+  )
 
-  logger.info(`Revalidation completed for path: ${EVENTS_PATH}`)
+  logger.info(
+    `Revalidation completed for path: ${EVENTS_PATH}, ${EVENTS_STATE_PATH} and ${EVENTS_STATE_EVENT_SLUG_PATH}`,
+  )
 
   return new NextResponse('Success', {
     status: 200,


### PR DESCRIPTION
closes #1809 

## What changed? Why?

This PR removes time-based revalidation on events page.


## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
