### PR TITLE
fix: CA and UK banners not showing with custom cookie

### DIFF
--- a/src/app/[countryCode]/internal/user-settings/userConfig.tsx
+++ b/src/app/[countryCode]/internal/user-settings/userConfig.tsx
@@ -117,6 +117,7 @@ export function UserConfig() {
                 secure: true,
               },
             )
+            window.location.reload()
           })}
         >
           <div className="flex items-end gap-4">

--- a/src/components/app/navbarGlobalBanner/index.tsx
+++ b/src/components/app/navbarGlobalBanner/index.tsx
@@ -98,14 +98,14 @@ const DISCLAIMER_BANNER_COUNTRY_CODES_MAP: readonly {
 }[] = [
   {
     language: 'en-GB',
-    countryCode: 'UK',
+    countryCode: 'uk',
     label: 'United Kingdom',
     url: 'https://uk.standwithcrypto.org',
     emoji: '🇬🇧',
   },
   {
     language: 'en-CA',
-    countryCode: 'CA',
+    countryCode: 'ca',
     label: 'Canada',
     url: 'https://ca.standwithcrypto.org',
     emoji: '🇨🇦',


### PR DESCRIPTION
## What changed? Why?

This PR fixes CA and UK global navbar banner not showing because our banner logic is comparing UK with uk and CA with ca, causing a mismatch and the corresponding banner not showing

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
