### PR TITLE
feat: add report generation for users grouped by completed actions

### DIFF
--- a/src/bin/reports/usersGroupedByCompletedActionsNumber.ts
+++ b/src/bin/reports/usersGroupedByCompletedActionsNumber.ts
@@ -1,0 +1,66 @@
+import { User, UserActionType } from '@prisma/client'
+import xlsx from 'xlsx'
+
+import { runBin } from '@/bin/runBin'
+import { prismaClient } from '@/utils/server/prismaClient'
+
+const BATCH_SIZE = 50000
+
+async function usersGroupedByCompletedActionsNumber() {
+  const usersPerActionCount: { [key: number]: number } = {}
+  let cursor: string | undefined = undefined
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const usersBatch: any = await prismaClient.user.findMany({
+      take: BATCH_SIZE,
+      skip: cursor ? 1 : 0,
+      cursor: cursor ? { id: cursor } : undefined,
+      select: {
+        id: true,
+        _count: {
+          select: {
+            userActions: {
+              where: {
+                actionType: {
+                  not: UserActionType.OPT_IN, // Ignore OPT_IN actions
+                },
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        id: 'asc',
+      },
+    })
+
+    if (usersBatch.length === 0) break
+
+    cursor = usersBatch[usersBatch.length - 1].id
+
+    usersBatch.forEach((user: User & { _count: { userActions: number } }) => {
+      const actionCount = user._count.userActions
+      usersPerActionCount[actionCount] = (usersPerActionCount[actionCount] || 0) + 1
+    })
+
+    console.log(`Processed batch of ${usersBatch.length} users`)
+  }
+
+  const rows = Object.entries(usersPerActionCount).map(([actions, userCount]) => ({
+    numberOfActions: parseInt(actions),
+    numberOfUsers: userCount,
+  }))
+
+  rows.sort((a, b) => a.numberOfActions - b.numberOfActions)
+
+  const workbook = xlsx.utils.book_new()
+  const worksheet = xlsx.utils.json_to_sheet(rows)
+  xlsx.utils.book_append_sheet(workbook, worksheet, 'Users By Action Count')
+
+  await xlsx.writeFile(workbook, './src/bin/reports/usersGroupedByCompletedActions.xlsx')
+
+  console.table(rows)
+}
+
+void runBin(usersGroupedByCompletedActionsNumber)

--- a/src/bin/reports/usersGroupedByCompletedActionsNumber.ts
+++ b/src/bin/reports/usersGroupedByCompletedActionsNumber.ts
@@ -1,62 +1,36 @@
-import { User, UserActionType } from '@prisma/client'
 import xlsx from 'xlsx'
 
 import { runBin } from '@/bin/runBin'
 import { prismaClient } from '@/utils/server/prismaClient'
 
-const BATCH_SIZE = 50000
-
 async function usersGroupedByCompletedActionsNumber() {
-  const usersPerActionCount: { [key: number]: number } = {}
-  let cursor: string | undefined = undefined
+  const result: { actions_completed: number; users: number }[] = await prismaClient.$queryRaw`
+    SELECT
+    CAST(action_count AS SIGNED) as actions_completed, CAST(COUNT(user_id) AS SIGNED) as users
+    FROM (
+      SELECT user_id, COUNT(action_type) AS action_count
+        FROM user_action
+        WHERE action_type != 'OPT_IN'
+        GROUP BY user_id
+    )
+    AS user_actions
+    GROUP BY action_count
+    ORDER BY action_count asc;
+    `
 
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const usersBatch: any = await prismaClient.user.findMany({
-      take: BATCH_SIZE,
-      skip: cursor ? 1 : 0,
-      cursor: cursor ? { id: cursor } : undefined,
-      select: {
-        id: true,
-        _count: {
-          select: {
-            userActions: {
-              where: {
-                actionType: {
-                  not: UserActionType.OPT_IN, // Ignore OPT_IN actions
-                },
-              },
-            },
-          },
-        },
-      },
-      orderBy: {
-        id: 'asc',
-      },
-    })
-
-    if (usersBatch.length === 0) break
-
-    cursor = usersBatch[usersBatch.length - 1].id
-
-    usersBatch.forEach((user: User & { _count: { userActions: number } }) => {
-      const actionCount = user._count.userActions
-      usersPerActionCount[actionCount] = (usersPerActionCount[actionCount] || 0) + 1
-    })
-
-    console.log(`Processed batch of ${usersBatch.length} users`)
-  }
-
-  const rows = Object.entries(usersPerActionCount).map(([actions, userCount]) => ({
-    numberOfActions: parseInt(actions),
-    numberOfUsers: userCount,
+  const formattedResult = result.map((row: any) => ({
+    actions_completed: Number(row.actions_completed),
+    users: Number(row.users),
   }))
 
-  rows.sort((a, b) => a.numberOfActions - b.numberOfActions)
+  const rows = formattedResult.map(row => ({
+    numberOfActions: row.actions_completed,
+    numberOfUsers: row.users,
+  }))
 
   const workbook = xlsx.utils.book_new()
   const worksheet = xlsx.utils.json_to_sheet(rows)
-  xlsx.utils.book_append_sheet(workbook, worksheet, 'Users By Action Count')
+  xlsx.utils.book_append_sheet(workbook, worksheet, 'Users By Action (No Opt-Ins)')
 
   await xlsx.writeFile(workbook, './src/bin/reports/usersGroupedByCompletedActions.xlsx')
 


### PR DESCRIPTION
closes #1824 

## What changed? Why?

This PR creates a new bin script to generate metrics of user quantities grouped by the number of completed actions, excluding the OPT_IN action.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
