### PR TITLE
Backfill script for user action REFER

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -10,6 +10,7 @@ import {
   backfillReactivationWithInngest,
 } from '@/inngest/functions/backfillReactivation'
 import { backfillSessionIdCronJob } from '@/inngest/functions/backfillSessionId'
+import { backfillUserActionRefer } from '@/inngest/functions/backfillUserActionRefer'
 import { backfillUserCommunicationMessageStatus } from '@/inngest/functions/backfillUserCommunicationMessageStatus'
 import {
   backfillSMSOptInReplyWithInngest,
@@ -79,5 +80,6 @@ export const { GET, POST, PUT } = serve({
     updateMetricsCacheInngestCronJob,
     backfillOptedOutUsers,
     cleanupDatadogSyntheticTestsWithInngest,
+    backfillUserActionRefer,
   ],
 })

--- a/src/inngest/functions/backfillUserActionRefer/index.ts
+++ b/src/inngest/functions/backfillUserActionRefer/index.ts
@@ -1,0 +1,131 @@
+import { UserActionType } from '@prisma/client'
+import { groupBy } from 'lodash-es'
+
+import { inngest } from '@/inngest/inngest'
+import { onScriptFailure } from '@/inngest/onScriptFailure'
+import { prismaClient } from '@/utils/server/prismaClient'
+import { batchAsyncAndLog } from '@/utils/shared/batchAsyncAndLog'
+import { USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP } from '@/utils/shared/userActionCampaigns'
+
+const BACKFILL_USER_ACTION_REFER_INNGEST_EVENT_NAME = 'script/backfill-user-action-refer'
+const BACKFILL_USER_ACTION_REFER_INNGEST_FUNCTION_ID = 'script.backfill-user-action-refer'
+
+export interface BackfillUserActionReferInngestSchema {
+  name: typeof BACKFILL_USER_ACTION_REFER_INNGEST_EVENT_NAME
+  data: {
+    persist: boolean
+  }
+}
+
+export const backfillUserActionRefer = inngest.createFunction(
+  {
+    id: BACKFILL_USER_ACTION_REFER_INNGEST_FUNCTION_ID,
+    retries: 0,
+    onFailure: onScriptFailure,
+  },
+  { event: BACKFILL_USER_ACTION_REFER_INNGEST_EVENT_NAME },
+  async ({ event, step, logger }) => {
+    const { persist = false } = event.data
+
+    logger.info(`Started with persist=${String(persist)}`)
+
+    // Find all users who were referred (have utm_source=swc and utm_medium=referral)
+    const referredUsers = await step.run('find-referred-users', async () => {
+      const users = await prismaClient.user.findMany({
+        where: {
+          acquisitionSource: 'swc',
+          acquisitionMedium: 'referral',
+          // Make sure they have a referral ID in the campaign
+          NOT: {
+            acquisitionCampaign: '',
+          },
+        },
+        select: {
+          id: true,
+          acquisitionCampaign: true, // This contains the referrer's referral ID
+        },
+      })
+      logger.info(`Found ${users.length} referred users`)
+      return users
+    })
+
+    // Group referred users by their referrer's ID
+    const referredUsersGroupedByReferrerId = groupBy(referredUsers, 'acquisitionCampaign')
+
+    // Find all referrers by their referral IDs
+    const referrerIds = Object.keys(referredUsersGroupedByReferrerId)
+    const referrers = await step.run('find-referrers', async () => {
+      const users = await prismaClient.user.findMany({
+        where: {
+          referralId: {
+            in: referrerIds,
+          },
+        },
+        include: {
+          userActions: true,
+        },
+      })
+      logger.info(`Found ${users.length} referrers`)
+      return users
+    })
+
+    // Create or update REFER actions
+    const updates = referrers.map(referrer => ({
+      referrer,
+      referredCount: referredUsersGroupedByReferrerId[referrer.referralId].length,
+      existingReferAction: referrer.userActions.find(
+        action => action.actionType === UserActionType.REFER,
+      ),
+    }))
+
+    if (!persist) {
+      logger.info(`[DRY RUN] Would process ${updates.length} referrer actions`)
+      return { message: 'Dry run complete', count: updates.length }
+    }
+
+    const results = await step.run('process-updates', async () => {
+      const processed = await batchAsyncAndLog(updates, async batch =>
+        Promise.all(
+          batch.map(({ referrer, referredCount, existingReferAction }) => {
+            if (existingReferAction) {
+              logger.info(
+                `Updating existing REFER action for user ${referrer.id} with ${referredCount} referrals`,
+              )
+              return prismaClient.userAction.update({
+                where: { id: existingReferAction.id },
+                data: {
+                  userActionRefer: {
+                    update: {
+                      referralsCount: referredCount,
+                    },
+                  },
+                },
+              })
+            } else {
+              logger.info(
+                `Creating new REFER action for user ${referrer.id} with ${referredCount} referrals`,
+              )
+              return prismaClient.userAction.create({
+                data: {
+                  userId: referrer.id,
+                  actionType: UserActionType.REFER,
+                  campaignName: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP[UserActionType.REFER],
+                  userActionRefer: {
+                    create: {
+                      referralsCount: referredCount,
+                    },
+                  },
+                },
+              })
+            }
+          }),
+        ),
+      )
+      const totalProcessed = processed.reduce((acc, batch) => acc + batch.length, 0)
+      logger.info(`Successfully processed ${totalProcessed} referral actions`)
+      return totalProcessed
+    })
+
+    return { processedCount: results, updatesFound: updates.length }
+  },
+)

--- a/src/inngest/types.ts
+++ b/src/inngest/types.ts
@@ -7,6 +7,7 @@ import type { BackfillNftInngestSchema } from '@/inngest/functions/backfillNFT'
 import type { BackfillNftInngestCronJobSchema } from '@/inngest/functions/backfillNFTCronJob'
 import type { BackfillReactivationInngestSchema } from '@/inngest/functions/backfillReactivation'
 import type { BackfillSessionIdInngestSchema } from '@/inngest/functions/backfillSessionId'
+import type { BackfillUserActionReferInngestSchema } from '@/inngest/functions/backfillUserActionRefer'
 import { BackfillUserCommunicationMessageStatusSchema } from '@/inngest/functions/backfillUserCommunicationMessageStatus'
 import type {
   CapitolCanaryBackfillSmsOptInReplySchema,
@@ -60,5 +61,6 @@ type EventTypes =
   | BackfillUserCommunicationMessageStatusSchema
   | UpdateMetricsCounterCacheCronJobSchema
   | BackfillOptedOutUsersSchema
+  | BackfillUserActionReferInngestSchema
 
 export const INNGEST_SCHEMAS = new EventSchemas().fromUnion<EventTypes>()


### PR DESCRIPTION
closes #1836 

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

Creates an Inngest function to backfill the `UserActionRefer` records based on user acquisition data. The script:

- Dry run mode for validation before persisting changes
- Identifies users who were referred through referral links (utm_source=swc, utm_medium=referral)
- Groups referred users by their referrer's ID
- Creates or updates REFER actions for referrers with accurate referral counts

![image](https://github.com/user-attachments/assets/0f9da2a3-d873-441a-8eef-afceed4f4faf)
![image](https://github.com/user-attachments/assets/1a85b675-fba2-4787-b253-2abb2bf580f9)


## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
