### PR TITLE
Referrals ranking cron job

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,7 +51,6 @@ model Address {
   userActionVotingInformationResearched UserActionVotingInformationResearched[]
 
   @@index([administrativeAreaLevel1, countryCode])
-  @@index([countryCode, usCongressionalDistrict, administrativeAreaLevel1])
   @@map("address")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ model Address {
   userActionVotingInformationResearched UserActionVotingInformationResearched[]
 
   @@index([administrativeAreaLevel1, countryCode])
+  @@index([countryCode, usCongressionalDistrict, administrativeAreaLevel1])
   @@map("address")
 }
 

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -22,6 +22,7 @@ import { upsertAdvocateInCapitolCanaryWithInngest } from '@/inngest/functions/ca
 import { cleanupNFTMintsWithInngest } from '@/inngest/functions/cleanupNFTMints'
 import { cleanupPostalCodesWithInngest } from '@/inngest/functions/cleanupPostalCodes'
 import { cleanupDatadogSyntheticTestsWithInngest } from '@/inngest/functions/datadog/cleanup'
+import { updateDistrictsRankings } from '@/inngest/functions/districtsRankings/updateRankings'
 import { sendEventNotificationWithInngest } from '@/inngest/functions/eventNotification'
 import { initialSignUpUserCommunicationJourney } from '@/inngest/functions/initialSignupUserCommunicationJourney/initialSignupUserCommunicationJourney'
 import { monitorBaseETHBalances } from '@/inngest/functions/monitorBaseETHBalances'
@@ -81,5 +82,6 @@ export const { GET, POST, PUT } = serve({
     backfillOptedOutUsers,
     cleanupDatadogSyntheticTestsWithInngest,
     backfillUserActionRefer,
+    updateDistrictsRankings,
   ],
 })

--- a/src/inngest/functions/districtsRankings/updateRankings.ts
+++ b/src/inngest/functions/districtsRankings/updateRankings.ts
@@ -1,0 +1,94 @@
+import { inngest } from '@/inngest/inngest'
+import { onScriptFailure } from '@/inngest/onScriptFailure'
+import { REDIS_KEYS } from '@/utils/server/districtRankings/constants'
+import {
+  getAdvocatesCountByDistrict,
+  getReferralsCountByDistrict,
+} from '@/utils/server/districtRankings/getRankingData'
+import { createDistrictRankingUpserter } from '@/utils/server/districtRankings/upsertRankings'
+import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
+
+const UPDATE_DISTRICT_RANKINGS_CRON_JOB_FUNCTION_ID = 'script.update-districts-rankings'
+const UPDATE_DISTRICT_RANKINGS_CRON_JOB_SCHEDULE = '0 */1 * * *' // every 1 hour
+const UPDATE_DISTRICT_RANKINGS_INNGEST_EVENT_NAME = 'script/update-districts-rankings'
+
+export interface UpdateDistrictsRankingsCronJobSchema {
+  name: typeof UPDATE_DISTRICT_RANKINGS_INNGEST_EVENT_NAME
+}
+
+export const updateDistrictsRankings = inngest.createFunction(
+  {
+    id: UPDATE_DISTRICT_RANKINGS_CRON_JOB_FUNCTION_ID,
+    onFailure: onScriptFailure,
+  },
+  {
+    ...(NEXT_PUBLIC_ENVIRONMENT === 'production'
+      ? { cron: UPDATE_DISTRICT_RANKINGS_CRON_JOB_SCHEDULE }
+      : { event: UPDATE_DISTRICT_RANKINGS_INNGEST_EVENT_NAME }),
+  },
+  async ({ step, logger }) => {
+    const [districtAdvocatesCounts, districtsReferralsCount] = await Promise.all([
+      step.run('Get Advocates Count by District', async () => {
+        logger.info('Getting Advocates Count by District')
+        return await getAdvocatesCountByDistrict()
+      }),
+      step.run('Get Referrals Count by District', async () => {
+        logger.info('Getting Referrals Count by District')
+        return await getReferralsCountByDistrict()
+      }),
+    ])
+
+    const upsertDistrictAdvocatesRanking = createDistrictRankingUpserter(
+      REDIS_KEYS.DISTRICT_ADVOCATES_RANKING,
+    )
+    const upsertDistrictReferralsRanking = createDistrictRankingUpserter(
+      REDIS_KEYS.DISTRICT_REFERRALS_RANKING,
+    )
+
+    const [districtAdvocatesRankingResults, districtReferralsRankingResults] = await Promise.all([
+      step.run('Update Districts Advocates Rankings', async () => {
+        const results = await Promise.all(
+          districtAdvocatesCounts.map(entry => {
+            logger.info(`Updating District Advocates Count for ${entry.state}-${entry.district}`)
+            return upsertDistrictAdvocatesRanking(entry)
+          }),
+        )
+
+        const successfulResults = results.filter(result => result.success)
+        const failedResults = results.filter(result => !result.success)
+
+        return {
+          totalResults: results.length,
+          successfulResults: successfulResults.length,
+          failedResults: failedResults.length,
+          failedEntries: failedResults.map(result => result.entry),
+        }
+      }),
+      step.run('Update Districts Referrals Ranking', async () => {
+        const results = await Promise.all(
+          districtsReferralsCount.map(entry => {
+            logger.info(`Updating District Referrals Count for ${entry.state}-${entry.district}`)
+            return upsertDistrictReferralsRanking(entry)
+          }),
+        )
+
+        const successfulResults = results.filter(result => result.success)
+        const failedResults = results.filter(result => !result.success)
+
+        return {
+          totalResults: results.length,
+          successfulResults: successfulResults.length,
+          failedResults: failedResults.length,
+          failedEntries: failedResults.map(result => result.entry),
+        }
+      }),
+    ])
+
+    return {
+      districtAdvocatesCountEntries: districtAdvocatesCounts.length,
+      districtAdvocatesRankingResults,
+      districtReferralsCountEntries: districtsReferralsCount.length,
+      districtReferralsRankingResults,
+    }
+  },
+)

--- a/src/inngest/functions/districtsRankings/updateRankings.ts
+++ b/src/inngest/functions/districtsRankings/updateRankings.ts
@@ -38,13 +38,11 @@ export const updateDistrictsRankings = inngest.createFunction(
       }),
     ])
 
-    const [upsertDistrictAdvocatesRanking, upsertDistrictReferralsRanking] = await Promise.all([
-      createDistrictRankingUpserter(REDIS_KEYS.DISTRICT_ADVOCATES_RANKING),
-      createDistrictRankingUpserter(REDIS_KEYS.DISTRICT_REFERRALS_RANKING),
-    ])
-
     const [districtAdvocatesRankingResults, districtReferralsRankingResults] = await Promise.all([
       step.run('Update Districts Advocates Rankings', async () => {
+        const upsertDistrictAdvocatesRanking = await createDistrictRankingUpserter(
+          REDIS_KEYS.DISTRICT_ADVOCATES_RANKING,
+        )
         const results = await Promise.all(
           districtAdvocatesCounts.map(entry => upsertDistrictAdvocatesRanking(entry)),
         )
@@ -61,6 +59,9 @@ export const updateDistrictsRankings = inngest.createFunction(
       }),
 
       step.run('Update Districts Referrals Ranking', async () => {
+        const upsertDistrictReferralsRanking = await createDistrictRankingUpserter(
+          REDIS_KEYS.DISTRICT_REFERRALS_RANKING,
+        )
         const results = await Promise.all(
           districtsReferralsCount.map(entry => upsertDistrictReferralsRanking(entry)),
         )

--- a/src/inngest/types.ts
+++ b/src/inngest/types.ts
@@ -18,6 +18,7 @@ import type { CapitolCanaryEmailInngestEventSchema } from '@/inngest/functions/c
 import type { CapitolCanaryUpsertAdvocateInngestSchema } from '@/inngest/functions/capitolCanary/upsertAdvocateInCapitolCanary'
 import type { CleanupNftMintsEventSchema } from '@/inngest/functions/cleanupNFTMints'
 import type { CleanupPostalCodesInngestEventSchema } from '@/inngest/functions/cleanupPostalCodes'
+import { UpdateDistrictsRankingsCronJobSchema } from '@/inngest/functions/districtsRankings/updateRankings'
 import type { InitialSignupUserCommunicationSchema } from '@/inngest/functions/initialSignupUserCommunicationJourney/initialSignupUserCommunicationJourney'
 import type { MonitorBaseEthBalancesInngestEventSchema } from '@/inngest/functions/monitorBaseETHBalances'
 import type { SetCryptoAddressOfUserInngestEventSchema } from '@/inngest/functions/setPrimaryCryptoAddressOfUser'
@@ -62,5 +63,6 @@ type EventTypes =
   | UpdateMetricsCounterCacheCronJobSchema
   | BackfillOptedOutUsersSchema
   | BackfillUserActionReferInngestSchema
+  | UpdateDistrictsRankingsCronJobSchema
 
 export const INNGEST_SCHEMAS = new EventSchemas().fromUnion<EventTypes>()

--- a/src/mocks/models/mockAddress.ts
+++ b/src/mocks/models/mockAddress.ts
@@ -25,11 +25,32 @@ const getDistrict = (stateCode: USStateCode) => {
 export function mockCreateAddressInput() {
   const countryCode = faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES))
 
-  // Faker location.state does not generates DC
+  const partial = {
+    googlePlaceId: null,
+    streetNumber: faker.location.buildingNumber(),
+    route: faker.location.street(),
+    subpremise: faker.location.secondaryAddress(),
+    locality: faker.location.city(),
+    administrativeAreaLevel1: faker.location.state({ abbreviated: true }),
+    administrativeAreaLevel2: '',
+    postalCode: faker.location.zipCode(),
+    postalCodeSuffix: '',
+    countryCode: countryCode.toUpperCase(),
+    usCongressionalDistrict: '12',
+    tenantId: countryCode,
+  } satisfies Partial<Prisma.AddressCreateInput>
+  return {
+    ...partial,
+    formattedDescription: `${partial.streetNumber} ${partial.route}, ${partial.subpremise}, ${partial.locality} ${partial.administrativeAreaLevel1}, ${partial.postalCode} ${partial.countryCode}`,
+  } satisfies Prisma.AddressCreateInput
+}
+
+export function mockCreateAddressInputWithDC() {
+  const countryCode = faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES))
+
   const stateCode =
     faker.helpers.maybe(() => 'DC', { probability: 0.05 }) ||
     faker.location.state({ abbreviated: true })
-
   const district = getDistrict(stateCode as USStateCode)
 
   const partial = {
@@ -38,7 +59,7 @@ export function mockCreateAddressInput() {
     route: faker.location.street(),
     subpremise: faker.location.secondaryAddress(),
     locality: faker.location.city(),
-    administrativeAreaLevel1: stateCode,
+    administrativeAreaLevel1: faker.location.state({ abbreviated: true }),
     administrativeAreaLevel2: '',
     postalCode: faker.location.zipCode(),
     postalCodeSuffix: '',
@@ -51,9 +72,14 @@ export function mockCreateAddressInput() {
     formattedDescription: `${partial.streetNumber} ${partial.route}, ${partial.subpremise}, ${partial.locality} ${partial.administrativeAreaLevel1}, ${partial.postalCode} ${partial.countryCode}`,
   } satisfies Prisma.AddressCreateInput
 }
-export function mockAddress(): Address {
+
+export function mockAddress(includeDC = false): Address {
   return {
-    ...mockCreateAddressInput(),
+    /**
+     * Need to ensure our tests are not affected by the DC change.
+     * ANY address related changes made to the mockCreateAddressInput affects the seed output.
+     */
+    ...(includeDC ? mockCreateAddressInputWithDC() : mockCreateAddressInput()),
     ...mockCommonDatetimes(),
     id: fakerFields.id(),
   }

--- a/src/mocks/models/mockAddress.ts
+++ b/src/mocks/models/mockAddress.ts
@@ -4,9 +4,15 @@ import { Address, Prisma } from '@prisma/client'
 import { fakerFields } from '@/mocks/fakerUtils'
 import { mockCommonDatetimes } from '@/mocks/mockCommonDatetimes'
 import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
+import { US_STATE_CODE_TO_DISTRICT_COUNT_MAP } from '@/utils/shared/usStateDistrictUtils'
+import { USStateCode } from '@/utils/shared/usStateUtils'
 
 export function mockCreateAddressInput() {
   const countryCode = faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES))
+
+  const stateCode = faker.location.state({ abbreviated: true })
+  const stateDistrictCount = US_STATE_CODE_TO_DISTRICT_COUNT_MAP[stateCode as USStateCode]
+  const district = faker.number.int({ min: 1, max: stateDistrictCount })
 
   const partial = {
     googlePlaceId: null,
@@ -14,12 +20,12 @@ export function mockCreateAddressInput() {
     route: faker.location.street(),
     subpremise: faker.location.secondaryAddress(),
     locality: faker.location.city(),
-    administrativeAreaLevel1: faker.location.state({ abbreviated: true }),
+    administrativeAreaLevel1: stateCode,
     administrativeAreaLevel2: '',
     postalCode: faker.location.zipCode(),
     postalCodeSuffix: '',
     countryCode: countryCode.toUpperCase(),
-    usCongressionalDistrict: '12',
+    usCongressionalDistrict: district.toString(),
     tenantId: countryCode,
   } satisfies Partial<Prisma.AddressCreateInput>
   return {

--- a/src/mocks/models/mockAddress.ts
+++ b/src/mocks/models/mockAddress.ts
@@ -25,7 +25,11 @@ const getDistrict = (stateCode: USStateCode) => {
 export function mockCreateAddressInput() {
   const countryCode = faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES))
 
-  const stateCode = faker.location.state({ abbreviated: true })
+  // Faker location.state does not generates DC
+  const stateCode =
+    faker.helpers.maybe(() => 'DC', { probability: 0.05 }) ||
+    faker.location.state({ abbreviated: true })
+
   const district = getDistrict(stateCode as USStateCode)
 
   const partial = {

--- a/src/mocks/models/mockAddress.ts
+++ b/src/mocks/models/mockAddress.ts
@@ -7,12 +7,26 @@ import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 import { US_STATE_CODE_TO_DISTRICT_COUNT_MAP } from '@/utils/shared/usStateDistrictUtils'
 import { USStateCode } from '@/utils/shared/usStateUtils'
 
+const getDistrict = (stateCode: USStateCode) => {
+  const stateDistrictCount = US_STATE_CODE_TO_DISTRICT_COUNT_MAP[stateCode]
+
+  if (stateDistrictCount === 0) {
+    return null
+  }
+
+  // Faker number.int throws when there are no integers between min and max
+  if (stateDistrictCount === 1) {
+    return '1'
+  }
+
+  return faker.number.int({ min: 1, max: stateDistrictCount }).toString()
+}
+
 export function mockCreateAddressInput() {
   const countryCode = faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES))
 
   const stateCode = faker.location.state({ abbreviated: true })
-  const stateDistrictCount = US_STATE_CODE_TO_DISTRICT_COUNT_MAP[stateCode as USStateCode]
-  const district = faker.number.int({ min: 1, max: stateDistrictCount })
+  const district = getDistrict(stateCode as USStateCode)
 
   const partial = {
     googlePlaceId: null,
@@ -25,7 +39,7 @@ export function mockCreateAddressInput() {
     postalCode: faker.location.zipCode(),
     postalCodeSuffix: '',
     countryCode: countryCode.toUpperCase(),
-    usCongressionalDistrict: district.toString(),
+    usCongressionalDistrict: district,
     tenantId: countryCode,
   } satisfies Partial<Prisma.AddressCreateInput>
   return {

--- a/src/mocks/models/mockUserActionRefer.ts
+++ b/src/mocks/models/mockUserActionRefer.ts
@@ -6,7 +6,7 @@ import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionReferInput() {
   return {
-    referralsCount: faker.number.int({ min: 0, max: 100 }),
+    referralsCount: faker.number.int({ min: 1, max: 100 }),
     tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionReferCreateInput
 }

--- a/src/utils/server/districtRankings/constants.ts
+++ b/src/utils/server/districtRankings/constants.ts
@@ -2,3 +2,5 @@ export const REDIS_KEYS = {
   DISTRICT_ADVOCATES_RANKING: 'district:ranking:advocates',
   DISTRICT_REFERRALS_RANKING: 'district:ranking:referrals',
 } as const
+
+export const CURRENT_DISTRICT_RANKING = REDIS_KEYS.DISTRICT_ADVOCATES_RANKING

--- a/src/utils/server/districtRankings/constants.ts
+++ b/src/utils/server/districtRankings/constants.ts
@@ -1,0 +1,4 @@
+export const REDIS_KEYS = {
+  DISTRICT_ADVOCATES_RANKING: 'district:ranking:advocates',
+  DISTRICT_REFERRALS_RANKING: 'district:ranking:referrals',
+} as const

--- a/src/utils/server/districtRankings/getRankingData.ts
+++ b/src/utils/server/districtRankings/getRankingData.ts
@@ -19,7 +19,7 @@ function isValidDistrict(state: string, district: string): boolean {
   }
 
   const districtNum = parseInt(district, 10)
-  if (isNaN(districtNum) || districtNum <= 0) {
+  if (isNaN(districtNum) || districtNum <= 0 || districtNum > stateDistrictCount) {
     logger.warn('[District Rankings] Invalid district number:', { state, district })
     return false
   }

--- a/src/utils/server/districtRankings/getRankingData.ts
+++ b/src/utils/server/districtRankings/getRankingData.ts
@@ -1,0 +1,112 @@
+import { UserActionType } from '@prisma/client'
+
+import { prismaClient } from '@/utils/server/prismaClient'
+import { logger } from '@/utils/shared/logger'
+import { US_STATE_CODE_TO_DISTRICT_COUNT_MAP } from '@/utils/shared/usStateDistrictUtils'
+import { USStateCode } from '@/utils/shared/usStateUtils'
+
+type RawQueryResult = {
+  state: string
+  district: string
+  count: number
+}
+
+function isValidDistrict(state: string, district: string): boolean {
+  const stateDistrictCount = US_STATE_CODE_TO_DISTRICT_COUNT_MAP[state as USStateCode]
+  if (!stateDistrictCount) {
+    logger.warn('[District Rankings] State not found in district map:', { state })
+    return false
+  }
+
+  const districtNum = parseInt(district, 10)
+  if (isNaN(districtNum) || districtNum <= 0) {
+    logger.warn('[District Rankings] Invalid district number:', { state, district })
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Count seems wrong. Need to double check, update mockCreateUserActionReferInput
+ */
+export async function getAdvocatesCountByDistrict(): Promise<RawQueryResult[]> {
+  const results = await prismaClient.$queryRaw<RawQueryResult[]>`
+    SELECT
+      a.administrative_area_level_1 as state,
+      a.us_congressional_district as district,
+      COUNT(DISTINCT u.id) as count
+    FROM address a
+    INNER JOIN user u ON u.address_id = a.id
+    WHERE a.country_code = 'US'
+      AND a.administrative_area_level_1 IS NOT NULL
+      AND a.administrative_area_level_1 != ''
+      AND a.us_congressional_district IS NOT NULL
+      AND a.us_congressional_district != ''
+      AND a.us_congressional_district REGEXP '^[0-9]+$'
+    GROUP BY a.administrative_area_level_1, a.us_congressional_district
+    HAVING count > 0
+  `
+
+  // logger.info('Raw results:', {
+  //   totalResults: results.length,
+  //   sampleResults: results.slice(0, 5),
+  // })
+
+  const validResults = results
+    .filter(result => isValidDistrict(result.state, result.district))
+    .map(({ state, district, count }) => ({
+      state,
+      district,
+      count: Number(count),
+    }))
+
+  // logger.info('Valid results:', {
+  //   totalValidResults: validResults.length,
+  //   sampleValidResults: validResults.slice(0, 5),
+  // })
+
+  return validResults
+}
+
+export async function getReferralsCountByDistrict(): Promise<RawQueryResult[]> {
+  const results = await prismaClient.$queryRaw<RawQueryResult[]>`
+    SELECT
+      a.administrative_area_level_1 as state,
+      a.us_congressional_district as district,
+      COUNT(DISTINCT u.id) * MAX(uar.referrals_count) as count
+    FROM address a
+    INNER JOIN user u ON u.address_id = a.id
+    INNER JOIN user_action ua ON ua.user_id = u.id
+    INNER JOIN user_action_refer uar ON uar.id = ua.id
+    WHERE a.country_code = 'US'
+      AND a.administrative_area_level_1 IS NOT NULL
+      AND a.administrative_area_level_1 != ''
+      AND a.us_congressional_district IS NOT NULL
+      AND a.us_congressional_district != ''
+      AND a.us_congressional_district REGEXP '^[0-9]+$'
+      AND ua.action_type = ${UserActionType.REFER}
+    GROUP BY a.administrative_area_level_1, a.us_congressional_district
+    HAVING count > 0
+  `
+
+  // logger.info('Raw results:', {
+  //   totalResults: results.length,
+  //   sampleResults: results.slice(0, 5),
+  // })
+
+  const validResults = results
+    .filter(result => isValidDistrict(result.state, result.district))
+    .map(result => ({
+      state: result.state,
+      district: result.district,
+      count: Number(result.count),
+    }))
+
+  // logger.info('Valid results:', {
+  //   totalValidResults: validResults.length,
+  //   sampleValidResults: validResults.slice(0, 5),
+  // })
+
+  return validResults
+}

--- a/src/utils/server/districtRankings/getRankingData.ts
+++ b/src/utils/server/districtRankings/getRankingData.ts
@@ -1,4 +1,5 @@
 import { UserActionType } from '@prisma/client'
+import * as Sentry from '@sentry/nextjs'
 
 import { prismaClient } from '@/utils/server/prismaClient'
 import { logger } from '@/utils/shared/logger'
@@ -11,11 +12,24 @@ type RawQueryResult = {
   count: number
 }
 
+type ReferralsCountByDistrictResult = {
+  state: string
+  district: string
+  users_count: number
+  refer_actions_count: number
+  referrals: number
+}
+
 function isValidDistrict(state: string, district: string): boolean {
   const stateDistrictCount = US_STATE_CODE_TO_DISTRICT_COUNT_MAP[state as USStateCode]
-  if (!stateDistrictCount) {
+  if (stateDistrictCount === undefined) {
     logger.warn('[District Rankings] State not found in district map:', { state })
     return false
+  }
+
+  // Special case for DC
+  if (stateDistrictCount === 0) {
+    return district === 'N/A'
   }
 
   const districtNum = parseInt(district, 10)
@@ -27,9 +41,6 @@ function isValidDistrict(state: string, district: string): boolean {
   return true
 }
 
-/**
- * Count seems wrong. Need to double check, update mockCreateUserActionReferInput
- */
 export async function getAdvocatesCountByDistrict(): Promise<RawQueryResult[]> {
   const results = await prismaClient.$queryRaw<RawQueryResult[]>`
     SELECT
@@ -38,75 +49,104 @@ export async function getAdvocatesCountByDistrict(): Promise<RawQueryResult[]> {
       COUNT(DISTINCT u.id) as count
     FROM address a
     INNER JOIN user u ON u.address_id = a.id
+    INNER JOIN user_action ua ON ua.user_id = u.id
     WHERE a.country_code = 'US'
-      AND a.administrative_area_level_1 IS NOT NULL
-      AND a.administrative_area_level_1 != ''
       AND a.us_congressional_district IS NOT NULL
       AND a.us_congressional_district != ''
       AND a.us_congressional_district REGEXP '^[0-9]+$'
-    GROUP BY a.administrative_area_level_1, a.us_congressional_district
+      AND a.administrative_area_level_1 IS NOT NULL
+      AND a.administrative_area_level_1 != ''
+      AND a.administrative_area_level_1 != 'DC'
+      AND ua.action_type = ${UserActionType.OPT_IN}
+    GROUP BY
+      a.administrative_area_level_1,
+      a.us_congressional_district
+    HAVING count > 0
+
+    UNION ALL
+
+    SELECT
+      'DC' as state,
+      'N/A' as district,
+      COUNT(DISTINCT u.id) as count
+    FROM address a
+    INNER JOIN user u ON u.address_id = a.id
+    INNER JOIN user_action ua ON ua.user_id = u.id
+    WHERE a.country_code = 'US'
+      AND a.administrative_area_level_1 = 'DC'
+      AND ua.action_type = ${UserActionType.OPT_IN}
     HAVING count > 0
   `
 
-  // logger.info('Raw results:', {
-  //   totalResults: results.length,
-  //   sampleResults: results.slice(0, 5),
-  // })
-
-  const validResults = results
+  return results
     .filter(result => isValidDistrict(result.state, result.district))
     .map(({ state, district, count }) => ({
       state,
       district,
       count: Number(count),
     }))
-
-  // logger.info('Valid results:', {
-  //   totalValidResults: validResults.length,
-  //   sampleValidResults: validResults.slice(0, 5),
-  // })
-
-  return validResults
 }
 
 export async function getReferralsCountByDistrict(): Promise<RawQueryResult[]> {
-  const results = await prismaClient.$queryRaw<RawQueryResult[]>`
+  const results = await prismaClient.$queryRaw<ReferralsCountByDistrictResult[]>`
     SELECT
       a.administrative_area_level_1 as state,
       a.us_congressional_district as district,
-      COUNT(DISTINCT u.id) * MAX(uar.referrals_count) as count
-    FROM address a
-    INNER JOIN user u ON u.address_id = a.id
-    INNER JOIN user_action ua ON ua.user_id = u.id
-    INNER JOIN user_action_refer uar ON uar.id = ua.id
+      COUNT(DISTINCT u.id) as users_count,
+      COUNT(DISTINCT ua.id) as refer_actions_count,
+      SUM(uar.referrals_count) as referrals
+    FROM user_action_refer uar
+    INNER JOIN user_action ua ON ua.id = uar.id
+    INNER JOIN user u ON u.id = ua.user_id
+    INNER JOIN address a ON a.id = u.address_id
     WHERE a.country_code = 'US'
       AND a.administrative_area_level_1 IS NOT NULL
       AND a.administrative_area_level_1 != ''
+      AND a.administrative_area_level_1 != 'DC'
       AND a.us_congressional_district IS NOT NULL
       AND a.us_congressional_district != ''
       AND a.us_congressional_district REGEXP '^[0-9]+$'
       AND ua.action_type = ${UserActionType.REFER}
-    GROUP BY a.administrative_area_level_1, a.us_congressional_district
-    HAVING count > 0
+      AND uar.referrals_count > 0
+    GROUP BY
+      a.administrative_area_level_1,
+      a.us_congressional_district
+    HAVING referrals > 0
+
+    UNION ALL
+
+    SELECT
+      'DC' as state,
+      'N/A' as district,
+      COUNT(DISTINCT u.id) as users_count,
+      COUNT(DISTINCT ua.id) as refer_actions_count,
+      SUM(uar.referrals_count) as referrals
+    FROM user_action_refer uar
+    INNER JOIN user_action ua ON ua.id = uar.id
+    INNER JOIN user u ON u.id = ua.user_id
+    INNER JOIN address a ON a.id = u.address_id
+    WHERE a.country_code = 'US'
+      AND a.administrative_area_level_1 = 'DC'
+      AND ua.action_type = ${UserActionType.REFER}
+      AND uar.referrals_count > 0
+    HAVING referrals > 0
   `
 
-  // logger.info('Raw results:', {
-  //   totalResults: results.length,
-  //   sampleResults: results.slice(0, 5),
-  // })
+  const filteredResults = results.filter(r => r.refer_actions_count !== r.users_count)
+  if (filteredResults.length > 0) {
+    logger.warn('Found districts where users have multiple REFER actions:', filteredResults)
+    Sentry.captureMessage('Found districts where users have multiple REFER actions:', {
+      extra: { results: filteredResults },
+      tags: { domain: 'referrals' },
+      level: 'error',
+    })
+  }
 
-  const validResults = results
+  return filteredResults
     .filter(result => isValidDistrict(result.state, result.district))
     .map(result => ({
       state: result.state,
       district: result.district,
-      count: Number(result.count),
+      count: Number(result.referrals),
     }))
-
-  // logger.info('Valid results:', {
-  //   totalValidResults: validResults.length,
-  //   sampleValidResults: validResults.slice(0, 5),
-  // })
-
-  return validResults
 }

--- a/src/utils/server/districtRankings/upsertRankings.ts
+++ b/src/utils/server/districtRankings/upsertRankings.ts
@@ -1,0 +1,116 @@
+import { redis, redisWithCache } from '@/utils/server/redis'
+import { logger } from '@/utils/shared/logger'
+import { US_STATE_CODE_TO_DISTRICT_COUNT_MAP } from '@/utils/shared/usStateDistrictUtils'
+import { USStateCode } from '@/utils/shared/usStateUtils'
+
+import { REDIS_KEYS } from './constants'
+
+export type DistrictRankingEntry = {
+  state: string
+  district: string
+  count: number
+}
+
+function isValidDistrictEntry(entry: DistrictRankingEntry): boolean {
+  return (
+    typeof entry.state === 'string' &&
+    entry.state.length > 0 &&
+    typeof entry.district === 'string' &&
+    entry.district.length > 0 &&
+    typeof entry.count === 'number' &&
+    !isNaN(entry.count)
+  )
+}
+
+function getAllPossibleDistricts(): DistrictRankingEntry[] {
+  const districts: DistrictRankingEntry[] = []
+
+  Object.entries(US_STATE_CODE_TO_DISTRICT_COUNT_MAP).forEach(([state, districtCount]) => {
+    // Skip states with no districts (e.g., DC) // TODO: Figure a way to show DC in the rankings
+    if (districtCount === 0) return
+
+    for (let i = 1; i <= districtCount; i++) {
+      districts.push({
+        state: state as USStateCode,
+        district: i.toString(),
+        count: 0,
+      })
+    }
+  })
+
+  return districts
+}
+
+async function maybeInitializeCacheKey(redisKey: string) {
+  const existingCount = await redisWithCache.zcard(redisKey)
+
+  if (existingCount > 0) {
+    return
+  }
+
+  const pipeline = redisWithCache.pipeline()
+  const districts = getAllPossibleDistricts()
+
+  districts.forEach(({ district, state }) => {
+    pipeline.zadd(redisKey, {
+      score: 0,
+      member: JSON.stringify({ district, state }),
+    })
+  })
+
+  await pipeline.exec()
+}
+
+export function createDistrictRankingUpserter(
+  redisKey: (typeof REDIS_KEYS)[keyof typeof REDIS_KEYS],
+) {
+  return async (entry: DistrictRankingEntry) => {
+    if (!isValidDistrictEntry(entry)) {
+      logger.warn(`[${redisKey}] Invalid district entry:`, { entry })
+      return {
+        success: false,
+        entry,
+        rank: null,
+      }
+    }
+
+    await maybeInitializeCacheKey(redisKey)
+
+    const member = JSON.stringify({ district: entry.district, state: entry.state })
+    logger.info(`[${redisKey}] Upserting district entry:`, member)
+
+    const result = await redis.zadd(redisKey, {
+      score: entry.count,
+      member,
+    })
+
+    if (result === null) {
+      logger.warn(`[${redisKey}] Failed to upsert district entry:`, { entry })
+    } else {
+      logger.info(`[${redisKey}] Upserted district entry:`, { entry })
+    }
+
+    return {
+      success: result !== null,
+      entry,
+      rank: result,
+    }
+  }
+}
+
+type RedisZRangeResult = [string, number][]
+
+export async function getDistrictRanking(
+  redisKey: (typeof REDIS_KEYS)[keyof typeof REDIS_KEYS],
+  limit = 10,
+): Promise<DistrictRankingEntry[]> {
+  const results = await redisWithCache.zrange<RedisZRangeResult>(redisKey, 0, limit - 1, {
+    rev: true,
+    withScores: true,
+  })
+
+  return results.map(([member, score]) => ({
+    ...(JSON.parse(member) as Omit<DistrictRankingEntry, 'count'>),
+    count: score,
+  }))
+}

--- a/src/utils/shared/urls/index.ts
+++ b/src/utils/shared/urls/index.ts
@@ -72,6 +72,7 @@ export const getIntlUrls = (
     creatorDefenseFund: () => `${countryPrefix}/creator-defense-fund`,
     press: () => `${countryPrefix}/press`,
     emailDeeplink: () => `${countryPrefix}/action/email`,
+    referrals: () => `${countryPrefix}/referrals`,
   }
 }
 

--- a/src/validation/fields/zodAddress.ts
+++ b/src/validation/fields/zodAddress.ts
@@ -1,4 +1,7 @@
-import { object, string } from 'zod'
+import { object, string, ZodIssueCode } from 'zod'
+
+import { US_STATE_CODE_TO_DISTRICT_COUNT_MAP } from '@/utils/shared/usStateDistrictUtils'
+import { USStateCode } from '@/utils/shared/usStateUtils'
 
 export const zodAddress = object({
   googlePlaceId: string().optional(),
@@ -13,4 +16,42 @@ export const zodAddress = object({
   postalCodeSuffix: string(),
   countryCode: string().length(2),
   usCongressionalDistrict: string().optional(),
+})
+
+export const zodStateDistrict = object({
+  state: string().refine(
+    (val): val is USStateCode => val in US_STATE_CODE_TO_DISTRICT_COUNT_MAP,
+    'Invalid state code',
+  ),
+  district: string(),
+}).superRefine((data, ctx) => {
+  if (!(data.state in US_STATE_CODE_TO_DISTRICT_COUNT_MAP)) {
+    ctx.addIssue({
+      code: ZodIssueCode.custom,
+      message: 'Invalid state code',
+      path: ['state'],
+    })
+    return
+  }
+
+  const districtCount = US_STATE_CODE_TO_DISTRICT_COUNT_MAP[data.state as USStateCode]
+  if (districtCount === 0) {
+    if (data.district !== 'N/A') {
+      ctx.addIssue({
+        code: ZodIssueCode.custom,
+        message: 'District must be N/A for this state',
+        path: ['district'],
+      })
+    }
+    return
+  }
+
+  const districtNum = parseInt(data.district, 10)
+  if (isNaN(districtNum) || districtNum <= 0 || districtNum > districtCount) {
+    ctx.addIssue({
+      code: ZodIssueCode.custom,
+      message: `District must be a number between 1 and ${districtCount}`,
+      path: ['district'],
+    })
+  }
 })


### PR DESCRIPTION
closes #1837 

## What changed? Why?

- Added Inngest cron job to query the district data and upsert it in Redis;
- Compression is not needed, as the final size is about 45KB; 
- Added an index for address queries;

![image](https://github.com/user-attachments/assets/5031ebf7-3809-458c-a5ea-bf0b0510651c)

![image](https://github.com/user-attachments/assets/92ba87d0-82ff-48dd-bd33-d3728f14db08)


<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/98

## Notes to reviewers

🗒️ Referrals count looks way higher in testing due to the mocking script generating a lot more REFER actions than users;

- Added DC state to our mock data with a probability of 5%, this is because faker does not consider DC as an State 😞 

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
