### PR TITLE
fix: stops home from revalidating when receiving an unexpected countryCode

### DIFF
--- a/src/app/[countryCode]/page.tsx
+++ b/src/app/[countryCode]/page.tsx
@@ -9,6 +9,7 @@ import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export const revalidate = 60 // 1 minute
 export const dynamic = 'error'
+export const dynamicParams = false
 
 export default async function Home(props: PageProps) {
   const params = await props.params


### PR DESCRIPTION
## What changed? Why?

We noticed we were rebuilding the home page when a path with a `.` character was received, this was caused because having a dot makes the request skip the `middleware.ts` (see the image below) that transforms a `/foo` request into `/en/foo`, that made so the `/[countryCode]/page.tsx` was being called with an unexpected `countryCode`. Since all countryCodes should be explicitly defined we should be using `export const dynamicParams = false` in the page, this adds that configuration.

![image](https://github.com/user-attachments/assets/d13a8834-e725-412c-b3da-b591ae0b014c)
 

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
