### PR TITLE
Fix async window open

### DIFF
--- a/src/actions/actionCreateCoinbaseCommerceCharge.ts
+++ b/src/actions/actionCreateCoinbaseCommerceCharge.ts
@@ -23,3 +23,7 @@ async function _actionCreateCoinbaseCommerceCharge() {
   ).data.hosted_url
   return { hostedUrl }
 }
+
+export type ActionCreateCoinbaseCommerceChargeResponse = Awaited<
+  ReturnType<typeof actionCreateCoinbaseCommerceCharge>
+>

--- a/src/components/app/pageDonate/donateButton.tsx
+++ b/src/components/app/pageDonate/donateButton.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import * as Sentry from '@sentry/nextjs'
 
 import {
   actionCreateCoinbaseCommerceCharge,
@@ -28,6 +29,11 @@ export function DonateButton() {
     )
 
     if (actionCreateCoinbaseCommerceChargeResponse.status !== 'success') {
+      Sentry.captureException('Donate button failed', {
+        level: 'fatal',
+        tags: { domain: 'donate' },
+        extra: { response: actionCreateCoinbaseCommerceChargeResponse.response },
+      })
       return null
     }
 
@@ -37,6 +43,11 @@ export function DonateButton() {
     if (commerceChargeResponse && 'hostedUrl' in commerceChargeResponse) {
       return commerceChargeResponse.hostedUrl
     } else {
+      Sentry.captureException('Donate button returned unexpected response', {
+        level: 'fatal',
+        tags: { domain: 'donate' },
+        extra: { response: actionCreateCoinbaseCommerceChargeResponse.response },
+      })
       return null
     }
   }

--- a/src/components/app/pageDonate/donateButton.tsx
+++ b/src/components/app/pageDonate/donateButton.tsx
@@ -1,19 +1,21 @@
 'use client'
-import React from 'react'
 
-import { actionCreateCoinbaseCommerceCharge } from '@/actions/actionCreateCoinbaseCommerceCharge'
+import { useState } from 'react'
+
+import {
+  actionCreateCoinbaseCommerceCharge,
+  ActionCreateCoinbaseCommerceChargeResponse,
+} from '@/actions/actionCreateCoinbaseCommerceCharge'
 import { Button } from '@/components/ui/button'
-import { openWindow } from '@/utils/shared/openWindow'
 import { ErrorBoundary } from '@/utils/web/errorBoundary'
 import { triggerServerActionForForm } from '@/utils/web/formUtils'
 import { toastGenericError } from '@/utils/web/toastUtils'
 
 export function DonateButton() {
-  const [buttonState, setButtonState] = React.useState<'completed' | 'loading'>('completed')
+  const [buttonState, setButtonState] = useState<'completed' | 'loading'>('completed')
 
   const handleDonateClick = async () => {
-    setButtonState('loading')
-    await triggerServerActionForForm(
+    const actionCreateCoinbaseCommerceChargeResponse = await triggerServerActionForForm(
       {
         formName: 'Donate Button',
         onError: toastGenericError,
@@ -22,22 +24,23 @@ export function DonateButton() {
           level: 'fatal',
         },
       },
-      () =>
-        actionCreateCoinbaseCommerceCharge().then(
-          async actionCreateCoinbaseCommerceChargeResponse => {
-            const commerceChargeResponse = await actionCreateCoinbaseCommerceChargeResponse
-            if (commerceChargeResponse && 'hostedUrl' in commerceChargeResponse) {
-              const windowReference = openWindow(commerceChargeResponse.hostedUrl, '_blank', '')
-              if (!windowReference) {
-                openWindow(commerceChargeResponse.hostedUrl, '_self')
-              }
-            }
-            return commerceChargeResponse
-          },
-        ),
+      () => actionCreateCoinbaseCommerceCharge(),
     )
-    setButtonState('completed')
+
+    if (actionCreateCoinbaseCommerceChargeResponse.status !== 'success') {
+      return null
+    }
+
+    const commerceChargeResponse =
+      actionCreateCoinbaseCommerceChargeResponse.response as ActionCreateCoinbaseCommerceChargeResponse
+
+    if (commerceChargeResponse && 'hostedUrl' in commerceChargeResponse) {
+      return commerceChargeResponse.hostedUrl
+    } else {
+      return null
+    }
   }
+
   return (
     <div className="flex justify-center">
       <ErrorBoundary
@@ -46,7 +49,23 @@ export function DonateButton() {
           domain: 'DonateButton',
         }}
       >
-        <Button disabled={buttonState === 'loading'} onClick={handleDonateClick} size="lg">
+        <Button
+          disabled={buttonState === 'loading'}
+          onClick={() => {
+            setButtonState('loading')
+            const windowRef = window.open()
+            void handleDonateClick()
+              .then(url => {
+                if (url && windowRef) {
+                  windowRef.location.href = url
+                }
+              })
+              .finally(() => {
+                setButtonState('completed')
+              })
+          }}
+          size="lg"
+        >
           Donate
         </Button>
       </ErrorBoundary>


### PR DESCRIPTION
closes #1869

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

Safari blocks `window.open()` calls made without user interaction or in async functions. This PR fixes the problem by calling window.open synchronously on user click and then changes the url of that window.

[Same solution used for the Turbovote fix](https://github.com/Stand-With-Crypto/swc-web/pull/1396)

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
