### PR TITLE
fix: remove default value for tenantId in multiple models

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,7 +43,7 @@ model Address {
   usCongressionalDistrict  String?  @map("us_congressional_district") // ex: 12
   datetimeUpdated          DateTime @updatedAt @map("datetime_updated")
   datetimeCreated          DateTime @default(now()) @map("datetime_created")
-  tenantId                 String   @default("us") @map("tenant_id")
+  tenantId                 String   @map("tenant_id")
 
   userActionEmails                      UserActionEmail[]
   userActionCalls                       UserActionCall[]
@@ -146,7 +146,7 @@ model User {
   capitolCanaryInstance    CapitolCanaryInstance?     @map("capitol_canary_instance")
   UserCommunicationJourney UserCommunicationJourney[]
   smsStatus                SMSStatus                  @default(NOT_OPTED_IN) @map("sms_status")
-  tenantId                 String                     @default("us") @map("tenant_id")
+  tenantId                 String                     @map("tenant_id")
 
   @@index([addressId])
   @@index([internalStatus])
@@ -216,7 +216,7 @@ model UserEmailAddress {
   dataCreationMethod DataCreationMethod     @default(BY_USER) @map("data_creation_method")
   datetimeUpdated    DateTime               @updatedAt @map("datetime_updated")
   datetimeCreated    DateTime               @default(now()) @map("datetime_created")
-  tenantId           String                 @default("us") @map("tenant_id")
+  tenantId           String                 @map("tenant_id")
 
   userActions                     UserAction[]
   asPrimaryUserEmailAddress       User?              @relation("asPrimaryUserEmailAddress")
@@ -298,7 +298,7 @@ model UserAction {
   nftMintId           String?            @unique @map("nft_mint_id")
   nftMint             NFTMint?           @relation(fields: [nftMintId], references: [id])
   actionType          UserActionType     @map("action_type")
-  tenantId            String             @default("us") @map("tenant_id")
+  tenantId            String             @map("tenant_id")
 
   // We'll need in-memory logic to validate and verify only one action type is every associated with a UserAction
   userActionEmail                       UserActionEmail?
@@ -333,7 +333,7 @@ model UserActionOptIn {
   id         String              @id @default(uuid())
   userAction UserAction          @relation(fields: [id], references: [id])
   optInType  UserActionOptInType @map("opt_in_type")
-  tenantId   String              @default("us") @map("tenant_id")
+  tenantId   String              @map("tenant_id")
 
   @@map("user_action_opt_in")
 }
@@ -347,7 +347,7 @@ model UserActionEmail {
   address                   Address?                   @relation(fields: [addressId], references: [id])
   addressId                 String?                    @map("address_id")
   userActionEmailRecipients UserActionEmailRecipient[]
-  tenantId                  String                     @default("us") @map("tenant_id")
+  tenantId                  String                     @map("tenant_id")
 
   @@index([addressId])
   @@map("user_action_email")
@@ -373,7 +373,7 @@ model UserActionCall {
   recipientPhoneNumber String?    @map("recipient_phone_number")
   address              Address?   @relation(fields: [addressId], references: [id])
   addressId            String?    @map("address_id")
-  tenantId             String     @default("us") @map("tenant_id")
+  tenantId             String     @map("tenant_id")
 
   @@index([addressId])
   @@map("user_action_call")
@@ -391,7 +391,7 @@ model UserActionDonation {
   amountCurrencyCode String               @map("amount_currency_code")
   amountUsd          Decimal              @map("amount_usd")
   recipient          DonationOrganization
-  tenantId           String               @default("us") @map("tenant_id")
+  tenantId           String               @map("tenant_id")
 
   coinbaseCommerceDonationId String? @map("coinbase_commerce_donation_id")
 
@@ -428,7 +428,7 @@ model NFTMint {
   costAtMint             Decimal       @map("cost_at_mint")
   costAtMintCurrencyCode NFTCurrency   @map("cost_at_mint_currency_code")
   costAtMintUsd          Decimal       @map("cost_at_mint_usd")
-  tenantId               String        @default("us") @map("tenant_id")
+  tenantId               String        @map("tenant_id")
 
   userActions UserAction[]
 
@@ -441,7 +441,7 @@ model UserActionVotingDay {
   userAction UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   votingYear String     @map("voting_year")
   usaState   String?    @map("usa_state")
-  tenantId   String     @default("us") @map("tenant_id")
+  tenantId   String     @map("tenant_id")
 
   @@map("user_action_voting_day")
 }
@@ -451,7 +451,7 @@ model UserActionViewKeyRaces {
   userAction              UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   usCongressionalDistrict String?    @map("us_congressional_district")
   usaState                String?    @map("usa_state")
-  tenantId                String     @default("us") @map("tenant_id")
+  tenantId                String     @map("tenant_id")
 
   @@map("user_action_view_key_races")
 }
@@ -460,7 +460,7 @@ model UserActionVoterRegistration {
   id         String     @id @default(uuid())
   userAction UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   usaState   String?    @map("usa_state")
-  tenantId   String     @default("us") @map("tenant_id")
+  tenantId   String     @map("tenant_id")
 
   @@map("user_action_voter_registration")
 }
@@ -469,7 +469,7 @@ model UserActionVoterAttestation {
   id         String     @id @default(uuid())
   userAction UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   usaState   String?    @map("usa_state")
-  tenantId   String     @default("us") @map("tenant_id")
+  tenantId   String     @map("tenant_id")
 
   @@map("user_action_voter_attestation")
 }
@@ -478,7 +478,7 @@ model UserActionTweetAtPerson {
   id                String     @id @default(uuid())
   userAction        UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   recipientDtsiSlug String?    @map("recipient_dtsi_slug")
-  tenantId          String     @default("us") @map("tenant_id")
+  tenantId          String     @map("tenant_id")
 
   @@map("user_action_tweet_at_person")
 }
@@ -489,7 +489,7 @@ model UserActionRsvpEvent {
   eventState                 String     @map("event_state")
   shouldReceiveNotifications Boolean    @map("should_receive_notifications")
   userAction                 UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
-  tenantId                   String     @default("us") @map("tenant_id")
+  tenantId                   String     @map("tenant_id")
 
   @@index([eventSlug, eventState])
   @@map("user_action_rsvp_event")
@@ -501,7 +501,7 @@ model UserActionVotingInformationResearched {
   shouldReceiveNotifications Boolean    @map("should_receive_notifications")
   address                    Address?   @relation(fields: [addressId], references: [id])
   addressId                  String?    @map("address_id")
-  tenantId                   String     @default("us") @map("tenant_id")
+  tenantId                   String     @map("tenant_id")
 
   @@index([addressId])
   @@map("user_action_voting_information_researched")
@@ -511,7 +511,7 @@ model UserActionRefer {
   id             String     @id @default(uuid())
   userAction     UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   referralsCount Int        @default(0) @map("referrals_count")
-  tenantId       String     @default("us") @map("tenant_id")
+  tenantId       String     @map("tenant_id")
 
   @@map("user_action_refer")
 }
@@ -532,7 +532,7 @@ model UserCommunicationJourney {
   datetimeCreated    DateTime                     @default(now()) @map("datetime_created")
   userCommunications UserCommunication[]
   campaignName       String?                      @map("campaign_name")
-  tenantId           String                       @default("us") @map("tenant_id")
+  tenantId           String                       @map("tenant_id")
 
   @@index([userId])
   @@map("user_communication_journey")


### PR DESCRIPTION
closes #1884 

## What changed? Why?

This PR removes the default tenantId value on multiple models in the DB schema.

## PlanetScale deploy request

Deploy request: https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/102

## Notes to reviewers

As we can't update more than 10 models at the same time in PlanetScale and to prevent production bugs, we will need to merge this PR first and deploy it to prod. After the PR is merged, I'll execute the database migration steps.

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
