### PR TITLE
fix: pass tenantId to claimNFT function for improved context handling

### DIFF
--- a/src/inngest/functions/backfillNFTCronJob/index.ts
+++ b/src/inngest/functions/backfillNFTCronJob/index.ts
@@ -140,9 +140,14 @@ export const backfillNFTInngestCronJob = inngest.createFunction(
       await step.run(`script.claim-nfts-${batchNum}`, async () => {
         await Promise.all(
           userActionBatch.map(userAction =>
-            claimNFT(userAction, userAction.user.primaryUserCryptoAddress!, {
-              skipTransactionFeeCheck: true,
-            }),
+            claimNFT(
+              userAction,
+              userAction.user.primaryUserCryptoAddress!,
+              {
+                skipTransactionFeeCheck: true,
+              },
+              userAction.user.tenantId,
+            ),
           ),
         )
       })

--- a/src/utils/server/nft/claimNFT.tsx
+++ b/src/utils/server/nft/claimNFT.tsx
@@ -116,6 +116,7 @@ export async function claimNFT(
   userAction: UserActionToClaim,
   userCryptoAddress: Pick<UserCryptoAddress, 'cryptoAddress'>,
   config: Config = {},
+  tenantId?: string,
 ) {
   const hydratedConfig = {
     skipTransactionFeeCheck: false,
@@ -152,7 +153,7 @@ export async function claimNFT(
     throw Error(`Action ${userAction.id} for campaign ${campaignName} already has an NFT mint.`)
   }
 
-  const tenantId = await getTenantId()
+  const tenant = tenantId ?? (await getTenantId())
 
   const action = await prismaClient.userAction.update({
     where: { id: userAction.id },
@@ -166,7 +167,7 @@ export async function claimNFT(
           contractAddress: NFT_SLUG_BACKEND_METADATA[nftSlug].contractAddress,
           costAtMintCurrencyCode: NFTCurrency.ETH,
           costAtMintUsd: new Decimal(0),
-          tenantId,
+          tenantId: tenant,
         },
       },
     },


### PR DESCRIPTION
## What changed? Why?

This PR fixes the NFT backfill inngest function calling a server function that requests cookies to get the tenantId.


## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
