### PR TITLE
fix: news fetching using builder.io private key on client

### DIFF
--- a/src/components/app/pagePress/NewsList.tsx
+++ b/src/components/app/pagePress/NewsList.tsx
@@ -8,16 +8,14 @@ import { PageSubTitle } from '@/components/ui/pageSubTitle'
 import { Skeleton } from '@/components/ui/skeleton'
 import { TrackedExternalLink } from '@/components/ui/trackedExternalLink'
 import { TrackedInternalLink } from '@/components/ui/trackedInternalLink'
-import {
-  getNewsList,
-  NEWS_LIST_LIMIT,
-  NormalizedNews,
-} from '@/utils/server/builder/models/data/news'
+import { getNewsList, NormalizedNews } from '@/utils/server/builder/models/data/news'
 import { AnalyticActionType, AnalyticComponentType } from '@/utils/shared/sharedAnalytics'
 
 interface NewsListProps {
   initialNews: NormalizedNews[]
 }
+
+const NEWS_LIST_LIMIT = 10
 
 export function NewsList({ initialNews }: NewsListProps) {
   const [isLoading, setIsLoading] = useState(false)
@@ -34,7 +32,7 @@ export function NewsList({ initialNews }: NewsListProps) {
 
     setIsLoading(true)
     const newOffset = offset + 1
-    const newNews = await getNewsList(newOffset)
+    const newNews = await getNewsList(newOffset, NEWS_LIST_LIMIT)
     setIsLoading(false)
 
     if (!newNews || newNews.length < NEWS_LIST_LIMIT) {

--- a/src/utils/server/builder/builderSDKClient.ts
+++ b/src/utils/server/builder/builderSDKClient.ts
@@ -1,3 +1,5 @@
+import 'server-only'
+
 import { builder } from '@builder.io/sdk'
 
 import { requiredOutsideLocalEnv } from '@/utils/shared/requiredEnv'


### PR DESCRIPTION
fixes [PROD-SWC-WEB-5V4](https://stand-with-crypto.sentry.io/issues/6327979949/events/c92c5f0fa0c54588a8fca5c5fdb140d7/)

## What changed? Why?

* refactor `getNewsList` into a server action to correctly fetch news in the client
* Mark builderSDKClient as `server-only`

## How has it been tested?

- [ ] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
