### PR TITLE
feat: save country code information in mixpanel and sentry

### DIFF
--- a/src/app/[countryCode]/topLevelClientLogic.tsx
+++ b/src/app/[countryCode]/topLevelClientLogic.tsx
@@ -17,6 +17,7 @@ import { getUserIdOnClient } from '@/utils/shared/userId'
 import { maybeInitClientAnalytics, trackClientAnalytic } from '@/utils/web/clientAnalytics'
 import { bootstrapLocalUser } from '@/utils/web/clientLocalUser'
 import { getUserSessionIdOnClient } from '@/utils/web/clientUserSessionId'
+import { getCountryCodeOnClient } from '@/utils/web/getCountryCodeOnClient'
 import { identifyUserOnClient } from '@/utils/web/identifyUser'
 
 const InitialOrchestration = () => {
@@ -24,6 +25,7 @@ const InitialOrchestration = () => {
   const searchParams = useSearchParams()
   const router = useRouter()
   const authUser = useThirdwebAuthUser()
+  const countryCode = getCountryCodeOnClient()
 
   useReloadDueToInactivity({ timeInMinutes: 25 })
 
@@ -40,6 +42,9 @@ const InitialOrchestration = () => {
       Sentry.setUser({ id: sessionId, idType: 'session' })
     }
   }, [])
+  useEffect(() => {
+    Sentry.setTag('countryCode', countryCode)
+  }, [countryCode])
   useEffect(() => {
     const clientUserId = getUserIdOnClient()
     if (authUser.user?.userId || clientUserId) {

--- a/src/bin/smokeTests/onNewLogin/9testCaseWithLongAcquisitionReferrer.ts
+++ b/src/bin/smokeTests/onNewLogin/9testCaseWithLongAcquisitionReferrer.ts
@@ -19,6 +19,7 @@ export const testCaseWithLongAcquisitionReferer: TestCase = {
           },
           initialReferer: faker.string.alphanumeric({ length: 200 }),
           datetimeFirstSeen: new Date().toISOString(),
+          countryCode: 'us',
         },
         currentSession: {
           datetimeOnLoad: new Date().toISOString(),

--- a/src/utils/server/serverLocalUser.ts
+++ b/src/utils/server/serverLocalUser.ts
@@ -22,11 +22,13 @@ const zodServerLocalUser = object({
     initialReferer: string().optional(),
     datetimeFirstSeen: string(),
     experiments: any(),
+    countryCode: string(),
   }),
   currentSession: object({
     datetimeOnLoad: string(),
     refererOnLoad: string().optional(),
     searchParamsOnLoad: record(string(), string()),
+    countryCode: string(),
   }),
 })
 
@@ -41,11 +43,13 @@ export function getLocalUserFromUser(user: User): ServerLocalUser {
       },
       initialReferer: '',
       datetimeFirstSeen: user.datetimeCreated.toISOString(),
+      countryCode: user.tenantId,
     },
     currentSession: {
       datetimeOnLoad: user.datetimeCreated.toISOString(),
       refererOnLoad: '',
       searchParamsOnLoad: {},
+      countryCode: user.tenantId,
     },
   }
 }
@@ -54,7 +58,11 @@ export function mapLocalUserToUserDatabaseFields(
   localUser: ServerLocalUser | null,
 ): Pick<
   User,
-  'acquisitionReferer' | 'acquisitionSource' | 'acquisitionMedium' | 'acquisitionCampaign'
+  | 'acquisitionReferer'
+  | 'acquisitionSource'
+  | 'acquisitionMedium'
+  | 'acquisitionCampaign'
+  | 'tenantId'
 > {
   return {
     // We are trimming the char input in case it is greater than the DB limit (191 characters)
@@ -71,6 +79,7 @@ export function mapLocalUserToUserDatabaseFields(
       localUser?.persisted?.initialSearchParams.utm_campaign?.slice(0, 191) ||
       localUser?.currentSession.searchParamsOnLoad.utm_campaign?.slice(0, 191) ||
       '',
+    tenantId: localUser?.persisted?.countryCode || localUser?.currentSession.countryCode || '',
   }
 }
 

--- a/src/utils/server/thirdweb/onLogin.ts
+++ b/src/utils/server/thirdweb/onLogin.ts
@@ -362,7 +362,6 @@ export async function onNewLogin(props: NewLoginParams) {
       localUser,
       hasSignedInWithEmail,
       sessionId: await props.getUserSessionId(),
-      tenantId,
     }).catch(error => {
       log(
         `createUser: error creating user\n ${JSON.stringify(
@@ -598,12 +597,10 @@ async function createUser({
   localUser,
   hasSignedInWithEmail,
   sessionId,
-  tenantId,
 }: {
   localUser: ServerLocalUser | null
   hasSignedInWithEmail: boolean
   sessionId: string | null
-  tenantId: string
 }) {
   return prismaClient.user.create({
     include: {
@@ -621,7 +618,6 @@ async function createUser({
       userSessions: {
         create: { id: sessionId ?? undefined },
       },
-      tenantId,
       ...mapLocalUserToUserDatabaseFields(localUser),
     },
   })

--- a/src/utils/shared/localUser.ts
+++ b/src/utils/shared/localUser.ts
@@ -8,12 +8,14 @@ export interface PersistedLocalUser {
   datetimeFirstSeen: string
   recentlyUsedAddress?: Pick<ClientAddress, 'googlePlaceId' | 'formattedDescription'>
   experiments?: IExperimentContext
+  countryCode: string
 }
 
 export interface CurrentSessionLocalUser {
   datetimeOnLoad: string
   refererOnLoad?: string
   searchParamsOnLoad: Record<string, string>
+  countryCode?: string
 }
 
 export interface LocalUser {

--- a/src/utils/web/clientAnalytics.ts
+++ b/src/utils/web/clientAnalytics.ts
@@ -7,6 +7,7 @@ import { requiredEnv } from '@/utils/shared/requiredEnv'
 import { AnalyticProperties } from '@/utils/shared/sharedAnalytics'
 import { getClientCookieConsent } from '@/utils/web/clientCookieConsent'
 import { getLocalUser } from '@/utils/web/clientLocalUser'
+import { getCountryCodeOnClient } from '@/utils/web/getCountryCodeOnClient'
 
 const NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN = requiredEnv(
   process.env.NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN,
@@ -51,7 +52,8 @@ export function trackClientAnalytic(
   _eventProperties?: AnalyticProperties,
   optionsOrCallback?: RequestOptions | Callback,
 ) {
-  const eventProperties = { ...getExperimentProperties(), ..._eventProperties }
+  const countryCode = getCountryCodeOnClient()
+  const eventProperties = { ...getExperimentProperties(), ..._eventProperties, countryCode }
   customLogger(
     {
       category: 'analytics',

--- a/src/utils/web/clientLocalUser.ts
+++ b/src/utils/web/clientLocalUser.ts
@@ -79,7 +79,7 @@ export const getLocalUser = (): LocalUser => {
     return localUser
   }
 
-  const currentSession: CurrentSessionLocalUser = getDefaultCurrentSessionLocalUser(countryCode)
+  const currentSession = getDefaultCurrentSessionLocalUser(countryCode)
 
   if (!canUsePersistedData) {
     localUser = { currentSession, persisted: undefined }

--- a/src/utils/web/clientLocalUser.ts
+++ b/src/utils/web/clientLocalUser.ts
@@ -11,6 +11,7 @@ import {
 import { getLogger } from '@/utils/shared/logger'
 import { getClientCookieConsent } from '@/utils/web/clientCookieConsent'
 import { getAllExperiments } from '@/utils/web/clientExperiments'
+import { getCountryCodeOnClient } from '@/utils/web/getCountryCodeOnClient'
 
 const getPersistedLocalUser = () => {
   const val = Cookies.get(LOCAL_USER_PERSISTED_KEY)
@@ -25,17 +26,19 @@ const removeLocalUser = () => {
   Cookies.remove(LOCAL_USER_CURRENT_SESSION_KEY)
 }
 
-const getDefaultCurrentSessionLocalUser = (): CurrentSessionLocalUser => ({
+const getDefaultCurrentSessionLocalUser = (countryCode: string): CurrentSessionLocalUser => ({
   datetimeOnLoad: new Date().toISOString(),
   refererOnLoad: window.document.referrer || undefined,
   searchParamsOnLoad: Object.fromEntries(new URLSearchParams(window.location.search)),
+  countryCode,
 })
 
-const getDefaultPersistedLocalUser = (): PersistedLocalUser => ({
+const getDefaultPersistedLocalUser = (countryCode: string): PersistedLocalUser => ({
   initialReferer: window.document.referrer || undefined,
   datetimeFirstSeen: new Date().toISOString(),
   initialSearchParams: Object.fromEntries(new URLSearchParams(window.location.search)),
   experiments: getAllExperiments(null).experiments,
+  countryCode,
 })
 
 let localUser: LocalUser | null = null
@@ -54,12 +57,16 @@ export const getLocalUser = (): LocalUser => {
         refererOnLoad: undefined,
         datetimeOnLoad: new Date().toISOString(),
         searchParamsOnLoad: {},
+        countryCode: undefined,
       },
       persisted: undefined,
     }
   }
   const canUsePersistedData =
     getClientCookieConsent().targeting && getClientCookieConsent().functional
+
+  const countryCode = getCountryCodeOnClient()
+
   if (localUser) {
     if (!canUsePersistedData) {
       if (localUser.persisted) {
@@ -71,7 +78,9 @@ export const getLocalUser = (): LocalUser => {
     }
     return localUser
   }
-  const currentSession: CurrentSessionLocalUser = getDefaultCurrentSessionLocalUser()
+
+  const currentSession: CurrentSessionLocalUser = getDefaultCurrentSessionLocalUser(countryCode)
+
   if (!canUsePersistedData) {
     localUser = { currentSession, persisted: undefined }
     return localUser
@@ -86,7 +95,11 @@ export const getLocalUser = (): LocalUser => {
       return { currentSession, persisted }
     }
     logger.info('new experiments, updating existed persisted data')
-    const newPersisted = { ...persisted, experiments: experimentResults.experiments }
+    const newPersisted = {
+      ...persisted,
+      experiments: experimentResults.experiments,
+      countryCode: persisted?.countryCode ?? countryCode,
+    }
     Cookies.set(LOCAL_USER_PERSISTED_KEY, JSON.stringify(newPersisted), {
       expires: 365,
     })
@@ -94,7 +107,7 @@ export const getLocalUser = (): LocalUser => {
     return localUser
   }
   logger.info('no data, setting new persisted data')
-  const newPersisted = getDefaultPersistedLocalUser()
+  const newPersisted = getDefaultPersistedLocalUser(countryCode)
   Cookies.set(LOCAL_USER_PERSISTED_KEY, JSON.stringify(newPersisted), {
     expires: 365,
   })

--- a/src/utils/web/getCountryCodeOnClient.ts
+++ b/src/utils/web/getCountryCodeOnClient.ts
@@ -1,12 +1,15 @@
 import * as Sentry from '@sentry/nextjs'
 import Cookies from 'js-cookie'
 
+import { isBrowser } from '@/utils/shared/executionEnvironment'
 import {
   COUNTRY_CODE_REGEX_PATTERN,
   SWC_CURRENT_PAGE_COUNTRY_CODE_COOKIE_NAME,
 } from '@/utils/shared/supportedCountries'
 
 export function getCountryCodeOnClient() {
+  if (!isBrowser) return ''
+
   const countryCode = Cookies.get(SWC_CURRENT_PAGE_COUNTRY_CODE_COOKIE_NAME)
 
   if (!countryCode) {

--- a/src/utils/web/getCountryCodeOnClient.ts
+++ b/src/utils/web/getCountryCodeOnClient.ts
@@ -13,9 +13,7 @@ export function getCountryCodeOnClient() {
   const countryCode = Cookies.get(SWC_CURRENT_PAGE_COUNTRY_CODE_COOKIE_NAME)
 
   if (!countryCode) {
-    const error = new Error('Country code cookie not found on client')
-    Sentry.captureException(error, { tags: { countryCode } })
-    throw error
+    return 'not-set'
   }
 
   if (!COUNTRY_CODE_REGEX_PATTERN.test(countryCode)) {

--- a/src/utils/web/getCountryCodeOnClient.ts
+++ b/src/utils/web/getCountryCodeOnClient.ts
@@ -1,0 +1,25 @@
+import * as Sentry from '@sentry/nextjs'
+import Cookies from 'js-cookie'
+
+import {
+  COUNTRY_CODE_REGEX_PATTERN,
+  SWC_CURRENT_PAGE_COUNTRY_CODE_COOKIE_NAME,
+} from '@/utils/shared/supportedCountries'
+
+export function getCountryCodeOnClient() {
+  const countryCode = Cookies.get(SWC_CURRENT_PAGE_COUNTRY_CODE_COOKIE_NAME)
+
+  if (!countryCode) {
+    const error = new Error('Country code cookie not found on client')
+    Sentry.captureException(error, { tags: { countryCode } })
+    throw error
+  }
+
+  if (!COUNTRY_CODE_REGEX_PATTERN.test(countryCode)) {
+    const error = new Error('Found invalid country code cookie on client.')
+    Sentry.captureException(error, { tags: { countryCode } })
+    throw error
+  }
+
+  return countryCode
+}


### PR DESCRIPTION
closes #1784 

## What changed? Why?

This PR saves the country code cookie on Mixpanel events and sentry to help track and filter events and errors by country code. 

Note that I'm already using countryCode naming instead of tenantId because we've decided to pivot from the multi-tenant architecture. All other necessary changes to rename tenantId to countryCode will be done afterwards.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
