### PR TITLE
feat: add countryCode parameter to page content

### DIFF
--- a/src/app/(builder)/[countryCode]/about/page.tsx
+++ b/src/app/(builder)/[countryCode]/about/page.tsx
@@ -15,17 +15,19 @@ const PATHNAME = '/about'
 export default async function AboutPage(props: PageProps) {
   const { countryCode } = await props.params
 
-  const content = await getPageContent(PAGE_MODEL, PATHNAME)
+  const content = await getPageContent(PAGE_MODEL, PATHNAME, countryCode)
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }
 
-export async function generateMetadata(): Promise<Metadata> {
-  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME)
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { countryCode } = await props.params
+
+  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME, countryCode)
 
   return generateMetadataDetails({
     title: metadata.title,

--- a/src/app/(builder)/[countryCode]/advocacy-toolkit/page.tsx
+++ b/src/app/(builder)/[countryCode]/advocacy-toolkit/page.tsx
@@ -15,17 +15,19 @@ const PATHNAME = '/advocacy-toolkit'
 export default async function AdvocacyToolkitPage(props: PageProps) {
   const { countryCode } = await props.params
 
-  const content = await getPageContent(PAGE_MODEL, PATHNAME)
+  const content = await getPageContent(PAGE_MODEL, PATHNAME, countryCode)
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }
 
-export async function generateMetadata(): Promise<Metadata> {
-  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME)
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { countryCode } = await props.params
+
+  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME, countryCode)
 
   return generateMetadataDetails({
     title: metadata.title,

--- a/src/app/(builder)/[countryCode]/content/[[...page]]/page.tsx
+++ b/src/app/(builder)/[countryCode]/content/[[...page]]/page.tsx
@@ -21,21 +21,21 @@ export default async function Page(props: DynamicPageProps) {
 
   const pathname = PAGE_PREFIX + page?.join('/')
 
-  const content = await getPageContent(PAGE_MODEL, pathname)
+  const content = await getPageContent(PAGE_MODEL, pathname, countryCode)
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={pathname}>
-      <RenderBuilderContent content={content} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }
 
 export async function generateMetadata(props: DynamicPageProps): Promise<Metadata> {
-  const { page } = await props.params
+  const { page, countryCode } = await props.params
 
   const pathname = PAGE_PREFIX + page?.join('/')
 
-  const metadata = await getPageDetails(PAGE_MODEL, pathname)
+  const metadata = await getPageDetails(PAGE_MODEL, pathname, countryCode)
 
   return generateMetadataDetails({
     title: metadata.title,

--- a/src/app/(builder)/[countryCode]/partners/page.tsx
+++ b/src/app/(builder)/[countryCode]/partners/page.tsx
@@ -17,12 +17,12 @@ const PATHNAME = '/partners'
 export default async function PartnersPage(props: PageProps) {
   const { countryCode } = await props.params
 
-  const content = await getPageContent(PAGE_MODEL, PATHNAME)
+  const content = await getPageContent(PAGE_MODEL, PATHNAME, countryCode)
   const partners = await getPartners()
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
       <div className="standard-spacing-from-navbar container space-y-20">
         <PartnerGrid partners={partners} />
       </div>
@@ -30,8 +30,10 @@ export default async function PartnersPage(props: PageProps) {
   )
 }
 
-export async function generateMetadata(): Promise<Metadata> {
-  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME)
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { countryCode } = await props.params
+
+  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME, countryCode)
 
   return generateMetadataDetails({
     title: metadata.title,

--- a/src/app/(builder)/[countryCode]/press/[...page]/page.tsx
+++ b/src/app/(builder)/[countryCode]/press/[...page]/page.tsx
@@ -23,21 +23,21 @@ export default async function Page(props: PressReleasePageProps) {
 
   const pathname = PAGE_PREFIX + page?.join('/')
 
-  const content = await getPageContent(PAGE_MODEL, pathname)
+  const content = await getPageContent(PAGE_MODEL, pathname, countryCode)
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={pathname}>
-      <RenderBuilderContent content={content} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }
 
 export async function generateMetadata(props: PressReleasePageProps): Promise<Metadata> {
-  const { page } = await props.params
+  const { page, countryCode } = await props.params
 
   const pathname = PAGE_PREFIX + page?.join('/')
 
-  const metadata = await getPageDetails(PAGE_MODEL, pathname)
+  const metadata = await getPageDetails(PAGE_MODEL, pathname, countryCode)
 
   return generateMetadataDetails({
     title: metadata.title,

--- a/src/app/(builder)/[countryCode]/press/page.tsx
+++ b/src/app/(builder)/[countryCode]/press/page.tsx
@@ -18,18 +18,20 @@ export default async function PressPage(props: PageProps) {
   const { countryCode } = await props.params
 
   const news = await getNewsList()
-  const content = await getPageContent(PAGE_MODEL, PATHNAME)
+  const content = await getPageContent(PAGE_MODEL, PATHNAME, countryCode)
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
       <NewsList initialNews={news} />
     </BuilderPageLayout>
   )
 }
 
-export async function generateMetadata(): Promise<Metadata> {
-  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME)
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { countryCode } = await props.params
+
+  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME, countryCode)
 
   return generateMetadataDetails({
     title: metadata.title,

--- a/src/app/(builder)/[countryCode]/privacy/page.tsx
+++ b/src/app/(builder)/[countryCode]/privacy/page.tsx
@@ -15,17 +15,19 @@ const PATHNAME = '/privacy'
 export default async function PrivacyPage(props: PageProps) {
   const { countryCode } = await props.params
 
-  const content = await getPageContent(PAGE_MODEL, PATHNAME)
+  const content = await getPageContent(PAGE_MODEL, PATHNAME, countryCode)
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }
 
-export async function generateMetadata(): Promise<Metadata> {
-  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME)
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { countryCode } = await props.params
+
+  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME, countryCode)
 
   return generateMetadataDetails({
     title: metadata.title,

--- a/src/app/(builder)/[countryCode]/terms-of-service/page.tsx
+++ b/src/app/(builder)/[countryCode]/terms-of-service/page.tsx
@@ -15,17 +15,19 @@ const PATHNAME = '/terms-of-service'
 export default async function TermsOfServicePage(props: PageProps) {
   const { countryCode } = await props.params
 
-  const content = await getPageContent(PAGE_MODEL, PATHNAME)
+  const content = await getPageContent(PAGE_MODEL, PATHNAME, countryCode)
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }
 
-export async function generateMetadata(): Promise<Metadata> {
-  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME)
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { countryCode } = await props.params
+
+  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME, countryCode)
 
   return generateMetadataDetails({
     title: metadata.title,

--- a/src/components/app/builder/builderComponent.tsx
+++ b/src/components/app/builder/builderComponent.tsx
@@ -5,11 +5,21 @@ import { Builder, BuilderComponent } from '@builder.io/react'
 import { notFound } from 'next/navigation'
 
 import { useSession } from '@/hooks/useSession'
+import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/constants'
+import {
+  DEFAULT_SUPPORTED_COUNTRY_CODE,
+  SupportedCountryCodes,
+} from '@/utils/shared/supportedCountries'
 import { BuilderState } from '@/utils/web/builder/types'
 
-type BuilderPageProps = ComponentProps<typeof BuilderComponent>
+type BuilderPageProps = ComponentProps<typeof BuilderComponent> & {
+  countryCode: SupportedCountryCodes
+}
 
-export function RenderBuilderContent(props: BuilderPageProps) {
+export function RenderBuilderContent({
+  countryCode = DEFAULT_SUPPORTED_COUNTRY_CODE,
+  ...props
+}: BuilderPageProps) {
   const session = useSession()
 
   const builderData: BuilderState = {
@@ -18,8 +28,23 @@ export function RenderBuilderContent(props: BuilderPageProps) {
     mockIsAuthenticated: session.isLoggedIn,
   }
 
+  const getModelName = () => {
+    if (
+      props.model === BuilderPageModelIdentifiers.PAGE &&
+      countryCode !== DEFAULT_SUPPORTED_COUNTRY_CODE
+    ) {
+      // TODO: remove this once we add more SupportedCountryCodes
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      return `page-${countryCode}`
+    }
+
+    return props.model
+  }
+
+  const modelName = getModelName()
+
   if (props.content || Builder.isEditing) {
-    return <BuilderComponent {...props} data={builderData} />
+    return <BuilderComponent {...props} data={builderData} model={modelName} />
   }
 
   return notFound()

--- a/src/components/app/builder/builderPageLayout.tsx
+++ b/src/components/app/builder/builderPageLayout.tsx
@@ -15,7 +15,7 @@ export async function BuilderPageLayout({
   pathname: string
   modelName: BuilderPageModelIdentifiers
 }) {
-  const pageMetadata = await getPageDetails(modelName, pathname)
+  const pageMetadata = await getPageDetails(modelName, pathname, countryCode)
 
   return (
     <>

--- a/src/utils/server/builder/models/page/constants.ts
+++ b/src/utils/server/builder/models/page/constants.ts
@@ -1,3 +1,11 @@
+import {
+  DEFAULT_SUPPORTED_COUNTRY_CODE,
+  SupportedCountryCodes,
+} from '@/utils/shared/supportedCountries'
+
+export type InternationalBuilderPageModel =
+  `page-${Exclude<SupportedCountryCodes, typeof DEFAULT_SUPPORTED_COUNTRY_CODE>}`
+
 export enum BuilderPageModelIdentifiers {
   CONTENT = 'content',
   PAGE = 'page',

--- a/src/utils/server/builder/models/page/utils/getPageContent.ts
+++ b/src/utils/server/builder/models/page/utils/getPageContent.ts
@@ -1,11 +1,35 @@
 import { builderSDKClient } from '@/utils/server/builder/builderSDKClient'
-import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/constants'
+import {
+  BuilderPageModelIdentifiers,
+  InternationalBuilderPageModel,
+} from '@/utils/server/builder/models/page/constants'
+import {
+  DEFAULT_SUPPORTED_COUNTRY_CODE,
+  SupportedCountryCodes,
+} from '@/utils/shared/supportedCountries'
 
-export function getPageContent(pageModelName: BuilderPageModelIdentifiers, pathname: string) {
+export function getPageContent(
+  pageModelName: BuilderPageModelIdentifiers,
+  pathname: string,
+  countryCode: SupportedCountryCodes,
+) {
+  let urlPath = pathname
+  let pageModel: BuilderPageModelIdentifiers | InternationalBuilderPageModel = pageModelName
+
+  if (
+    pageModelName === BuilderPageModelIdentifiers.PAGE &&
+    countryCode !== DEFAULT_SUPPORTED_COUNTRY_CODE
+  ) {
+    // TODO: remove this once we add more SupportedCountryCodes
+    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+    urlPath = `/${countryCode}${pathname}`
+    pageModel = ('page-' + countryCode) as InternationalBuilderPageModel
+  }
+
   return builderSDKClient
-    .get(pageModelName, {
+    .get(pageModel, {
       userAttributes: {
-        urlPath: pathname,
+        urlPath,
       },
       // Set prerender to false to return JSON instead of HTML
       prerender: false,


### PR DESCRIPTION
closes [#1887](https://github.com/Stand-With-Crypto/swc-web/issues/1887)

## What changed? Why?

Adds support for country specific page models

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
