### PR TITLE
fix: remove tenantId from user action creation functions and mocks

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,7 +43,6 @@ model Address {
   usCongressionalDistrict  String?  @map("us_congressional_district") // ex: 12
   datetimeUpdated          DateTime @updatedAt @map("datetime_updated")
   datetimeCreated          DateTime @default(now()) @map("datetime_created")
-  tenantId                 String   @default("us") @map("tenant_id")
 
   userActionEmails                      UserActionEmail[]
   userActionCalls                       UserActionCall[]
@@ -216,7 +215,6 @@ model UserEmailAddress {
   dataCreationMethod DataCreationMethod     @default(BY_USER) @map("data_creation_method")
   datetimeUpdated    DateTime               @updatedAt @map("datetime_updated")
   datetimeCreated    DateTime               @default(now()) @map("datetime_created")
-  tenantId           String                 @default("us") @map("tenant_id")
 
   userActions                     UserAction[]
   asPrimaryUserEmailAddress       User?              @relation("asPrimaryUserEmailAddress")
@@ -333,7 +331,6 @@ model UserActionOptIn {
   id         String              @id @default(uuid())
   userAction UserAction          @relation(fields: [id], references: [id])
   optInType  UserActionOptInType @map("opt_in_type")
-  tenantId   String              @default("us") @map("tenant_id")
 
   @@map("user_action_opt_in")
 }
@@ -347,7 +344,6 @@ model UserActionEmail {
   address                   Address?                   @relation(fields: [addressId], references: [id])
   addressId                 String?                    @map("address_id")
   userActionEmailRecipients UserActionEmailRecipient[]
-  tenantId                  String                     @default("us") @map("tenant_id")
 
   @@index([addressId])
   @@map("user_action_email")
@@ -373,7 +369,6 @@ model UserActionCall {
   recipientPhoneNumber String?    @map("recipient_phone_number")
   address              Address?   @relation(fields: [addressId], references: [id])
   addressId            String?    @map("address_id")
-  tenantId             String     @default("us") @map("tenant_id")
 
   @@index([addressId])
   @@map("user_action_call")
@@ -391,7 +386,6 @@ model UserActionDonation {
   amountCurrencyCode String               @map("amount_currency_code")
   amountUsd          Decimal              @map("amount_usd")
   recipient          DonationOrganization
-  tenantId           String               @default("us") @map("tenant_id")
 
   coinbaseCommerceDonationId String? @map("coinbase_commerce_donation_id")
 
@@ -428,7 +422,6 @@ model NFTMint {
   costAtMint             Decimal       @map("cost_at_mint")
   costAtMintCurrencyCode NFTCurrency   @map("cost_at_mint_currency_code")
   costAtMintUsd          Decimal       @map("cost_at_mint_usd")
-  tenantId               String        @default("us") @map("tenant_id")
 
   userActions UserAction[]
 
@@ -441,7 +434,6 @@ model UserActionVotingDay {
   userAction UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   votingYear String     @map("voting_year")
   usaState   String?    @map("usa_state")
-  tenantId   String     @default("us") @map("tenant_id")
 
   @@map("user_action_voting_day")
 }
@@ -451,7 +443,6 @@ model UserActionViewKeyRaces {
   userAction              UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   usCongressionalDistrict String?    @map("us_congressional_district")
   usaState                String?    @map("usa_state")
-  tenantId                String     @default("us") @map("tenant_id")
 
   @@map("user_action_view_key_races")
 }
@@ -460,7 +451,6 @@ model UserActionVoterRegistration {
   id         String     @id @default(uuid())
   userAction UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   usaState   String?    @map("usa_state")
-  tenantId   String     @default("us") @map("tenant_id")
 
   @@map("user_action_voter_registration")
 }
@@ -469,7 +459,6 @@ model UserActionVoterAttestation {
   id         String     @id @default(uuid())
   userAction UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   usaState   String?    @map("usa_state")
-  tenantId   String     @default("us") @map("tenant_id")
 
   @@map("user_action_voter_attestation")
 }
@@ -478,7 +467,6 @@ model UserActionTweetAtPerson {
   id                String     @id @default(uuid())
   userAction        UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   recipientDtsiSlug String?    @map("recipient_dtsi_slug")
-  tenantId          String     @default("us") @map("tenant_id")
 
   @@map("user_action_tweet_at_person")
 }
@@ -489,7 +477,6 @@ model UserActionRsvpEvent {
   eventState                 String     @map("event_state")
   shouldReceiveNotifications Boolean    @map("should_receive_notifications")
   userAction                 UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
-  tenantId                   String     @default("us") @map("tenant_id")
 
   @@index([eventSlug, eventState])
   @@map("user_action_rsvp_event")
@@ -501,7 +488,6 @@ model UserActionVotingInformationResearched {
   shouldReceiveNotifications Boolean    @map("should_receive_notifications")
   address                    Address?   @relation(fields: [addressId], references: [id])
   addressId                  String?    @map("address_id")
-  tenantId                   String     @default("us") @map("tenant_id")
 
   @@index([addressId])
   @@map("user_action_voting_information_researched")
@@ -511,7 +497,6 @@ model UserActionRefer {
   id             String     @id @default(uuid())
   userAction     UserAction @relation(fields: [id], references: [id], onDelete: Cascade)
   referralsCount Int        @default(0) @map("referrals_count")
-  tenantId       String     @default("us") @map("tenant_id")
 
   @@map("user_action_refer")
 }
@@ -532,7 +517,6 @@ model UserCommunicationJourney {
   datetimeCreated    DateTime                     @default(now()) @map("datetime_created")
   userCommunications UserCommunication[]
   campaignName       String?                      @map("campaign_name")
-  tenantId           String                       @default("us") @map("tenant_id")
 
   @@index([userId])
   @@map("user_communication_journey")

--- a/src/actions/actionCreateUserActionCallCongressperson/index.ts
+++ b/src/actions/actionCreateUserActionCallCongressperson/index.ts
@@ -256,10 +256,9 @@ async function createActionAndUpdateUser<U extends User>({
           address: {
             connectOrCreate: {
               where: { googlePlaceId: validatedInput.address.googlePlaceId },
-              create: { ...validatedInput.address, tenantId },
+              create: validatedInput.address,
             },
           },
-          tenantId,
         },
       },
     },

--- a/src/actions/actionCreateUserActionEmailCongressperson.ts
+++ b/src/actions/actionCreateUserActionEmailCongressperson.ts
@@ -184,11 +184,11 @@ async function _actionCreateUserActionEmailCongressperson(input: Input) {
           senderEmail: validatedFields.data.emailAddress,
           firstName: validatedFields.data.firstName,
           lastName: validatedFields.data.lastName,
-          tenantId,
+
           address: {
             connectOrCreate: {
               where: { googlePlaceId: validatedFields.data.address.googlePlaceId },
-              create: { ...validatedFields.data.address, tenantId },
+              create: validatedFields.data.address,
             },
           },
           userActionEmailRecipients: {
@@ -297,7 +297,6 @@ async function maybeUpsertUser({
               emailAddress,
               isVerified: false,
               source: UserEmailAddressSource.USER_ENTERED,
-              tenantId,
             },
           },
         }),
@@ -306,7 +305,7 @@ async function maybeUpsertUser({
           address: {
             connectOrCreate: {
               where: { googlePlaceId: address.googlePlaceId },
-              create: { ...address, tenantId },
+              create: address,
             },
           },
         }),
@@ -361,13 +360,12 @@ async function maybeUpsertUser({
           emailAddress,
           isVerified: false,
           source: UserEmailAddressSource.USER_ENTERED,
-          tenantId,
         },
       },
       address: {
         connectOrCreate: {
           where: { googlePlaceId: address.googlePlaceId },
-          create: { ...address, tenantId },
+          create: address,
         },
       },
       tenantId,

--- a/src/actions/actionCreateUserActionEmailDebate.ts
+++ b/src/actions/actionCreateUserActionEmailDebate.ts
@@ -140,7 +140,7 @@ async function _actionCreateUserActionEmailDebate(input: Input) {
           address: {
             connectOrCreate: {
               where: { googlePlaceId: validatedFields.data.address.googlePlaceId },
-              create: { ...validatedFields.data.address, tenantId },
+              create: validatedFields.data.address,
             },
           },
           userActionEmailRecipients: {
@@ -148,7 +148,6 @@ async function _actionCreateUserActionEmailDebate(input: Input) {
               emailAddress: DEBATE_RECEIVER_EMAIL,
             },
           },
-          tenantId,
         },
       },
       tenantId,
@@ -226,7 +225,6 @@ async function maybeUpsertUser({
               emailAddress,
               isVerified: false,
               source: UserEmailAddressSource.USER_ENTERED,
-              tenantId,
             },
           },
         }),
@@ -235,7 +233,7 @@ async function maybeUpsertUser({
           address: {
             connectOrCreate: {
               where: { googlePlaceId: address.googlePlaceId },
-              create: { ...address, tenantId },
+              create: address,
             },
           },
         }),
@@ -289,13 +287,12 @@ async function maybeUpsertUser({
           emailAddress,
           isVerified: false,
           source: UserEmailAddressSource.USER_ENTERED,
-          tenantId,
         },
       },
       address: {
         connectOrCreate: {
           where: { googlePlaceId: address.googlePlaceId },
-          create: { ...address, tenantId },
+          create: address,
         },
       },
     },

--- a/src/actions/actionCreateUserActionNFTMint.ts
+++ b/src/actions/actionCreateUserActionNFTMint.ts
@@ -176,7 +176,6 @@ async function createAction<U extends User>({
           costAtMintCurrencyCode: NFTCurrency.ETH,
           costAtMintUsd: decimalEthTransactionValue.mul(ratio),
           transactionHash: validatedInput.transactionHash,
-          tenantId,
         },
       },
     },

--- a/src/actions/actionCreateUserActionRsvpEvent.ts
+++ b/src/actions/actionCreateUserActionRsvpEvent.ts
@@ -243,7 +243,6 @@ async function createAction<U extends User>({
           eventSlug: validatedInput.eventSlug,
           eventState: validatedInput.eventState,
           shouldReceiveNotifications: validatedInput.shouldReceiveNotifications,
-          tenantId,
         },
       },
     },

--- a/src/actions/actionCreateUserActionTweetAtPerson.ts
+++ b/src/actions/actionCreateUserActionTweetAtPerson.ts
@@ -249,7 +249,6 @@ async function createAction<U extends User>({
       userActionTweetAtPerson: {
         create: {
           recipientDtsiSlug: validatedInput.dtsiSlug,
-          tenantId,
         },
       },
     },

--- a/src/actions/actionUpdateUserProfile.ts
+++ b/src/actions/actionUpdateUserProfile.ts
@@ -24,7 +24,6 @@ import {
   CapitolCanaryCampaignName,
   getCapitolCanaryCampaignID,
 } from '@/utils/server/capitolCanary/campaigns'
-import { getTenantId } from '@/utils/server/getTenantId'
 import { prismaClient } from '@/utils/server/prismaClient'
 import { throwIfRateLimited } from '@/utils/server/ratelimit/throwIfRateLimited'
 import { getServerPeopleAnalytics } from '@/utils/server/serverAnalytics'
@@ -49,7 +48,7 @@ const logger = getLogger(`actionUpdateUserProfile`)
 
 async function _actionUpdateUserProfile(data: z.infer<typeof zodUpdateUserProfileFormAction>) {
   const authUser = await appRouterGetAuthUser()
-  const tenantId = await getTenantId()
+
   if (!authUser) {
     throw new Error('Unauthenticated')
   }
@@ -105,10 +104,7 @@ async function _actionUpdateUserProfile(data: z.infer<typeof zodUpdateUserProfil
         where: {
           googlePlaceId: validatedFields.data.address.googlePlaceId,
         },
-        create: {
-          ...validatedFields.data.address,
-          tenantId,
-        },
+        create: validatedFields.data.address,
         update: {},
       })
     : null
@@ -122,7 +118,6 @@ async function _actionUpdateUserProfile(data: z.infer<typeof zodUpdateUserProfil
             emailAddress,
             source: UserEmailAddressSource.USER_ENTERED,
             isVerified: false,
-            tenantId,
             user: {
               connect: {
                 id: user.id,

--- a/src/bin/localDevelopment/simulateLiveActivityOnSite.ts
+++ b/src/bin/localDevelopment/simulateLiveActivityOnSite.ts
@@ -16,7 +16,6 @@ import { mockUserActionTweetAtPerson } from '@/mocks/models/mockUserActionTweetA
 import { mockCreateUserActionVoterRegistrationInput } from '@/mocks/models/mockUserActionVoterRegistration'
 import { mockCreateUserCryptoAddressInput } from '@/mocks/models/mockUserCryptoAddress'
 import { mockCreateUserEmailAddressInput } from '@/mocks/models/mockUserEmailAddress'
-import { getTenantId } from '@/utils/server/getTenantId'
 import { prismaClient } from '@/utils/server/prismaClient'
 import { getLogger } from '@/utils/shared/logger'
 import { sleep } from '@/utils/shared/sleep'
@@ -112,7 +111,6 @@ async function createUser() {
 }
 
 async function createAction(user: Awaited<ReturnType<typeof createUser>>) {
-  const tenantId = await getTenantId()
   const actionType = user.primaryUserEmailAddressId
     ? UserActionType.EMAIL
     : faker.helpers.arrayElement(Object.values(UserActionType))
@@ -217,7 +215,6 @@ async function createAction(user: Awaited<ReturnType<typeof createUser>>) {
           userActionTweetAtPerson: {
             create: {
               recipientDtsiSlug: mockUserActionTweetAtPerson().recipientDtsiSlug,
-              tenantId,
             },
           },
         },

--- a/src/bin/seed/seedLocalDb.ts
+++ b/src/bin/seed/seedLocalDb.ts
@@ -242,7 +242,6 @@ async function seed() {
       emailAddress: emailAddress,
       isVerified: true,
       source: UserEmailAddressSource.USER_ENTERED,
-      tenantId: otherUserToMerge.tenantId,
     })),
   })
   await prismaClient.userMergeAlert.create({

--- a/src/bin/smokeTests/nft/airdropNFT.ts
+++ b/src/bin/smokeTests/nft/airdropNFT.ts
@@ -34,7 +34,6 @@ async function smokeTestAirdropNFTWithInngest() {
           contractAddress: NFT_SLUG_BACKEND_METADATA[NFTSlug.SWC_SHIELD].contractAddress,
           costAtMintCurrencyCode: NFTCurrency.ETH,
           costAtMintUsd: new Decimal(0),
-          tenantId: user.tenantId,
         },
       },
       tenantId: user.tenantId,
@@ -43,7 +42,6 @@ async function smokeTestAirdropNFTWithInngest() {
       userActionOptIn: {
         create: {
           optInType: UserActionOptInType.SWC_SIGN_UP_AS_SUBSCRIBER,
-          tenantId: user.tenantId,
         },
       },
     },

--- a/src/bin/smokeTests/onNewLogin/2testCaseUserPreviouslySignedUpOnCoinbaseAndThenLoggedInWithEmbeddedWalletWithSameEmail.ts
+++ b/src/bin/smokeTests/onNewLogin/2testCaseUserPreviouslySignedUpOnCoinbaseAndThenLoggedInWithEmbeddedWalletWithSameEmail.ts
@@ -21,7 +21,6 @@ export const testCaseUserPreviouslySignedUpOnCoinbaseAndThenLoggedInWithEmbedded
               ...mockCreateUserEmailAddressInput(),
               isVerified: true,
               source: UserEmailAddressSource.VERIFIED_THIRD_PARTY,
-              tenantId: DEFAULT_SUPPORTED_COUNTRY_CODE,
             },
           },
           userActions: {
@@ -32,7 +31,6 @@ export const testCaseUserPreviouslySignedUpOnCoinbaseAndThenLoggedInWithEmbedded
               userActionOptIn: {
                 create: {
                   optInType: UserActionOptInType.SWC_SIGN_UP_AS_SUBSCRIBER,
-                  tenantId: DEFAULT_SUPPORTED_COUNTRY_CODE,
                 },
               },
             },

--- a/src/inngest/functions/backfillNFTCronJob/index.ts
+++ b/src/inngest/functions/backfillNFTCronJob/index.ts
@@ -140,14 +140,9 @@ export const backfillNFTInngestCronJob = inngest.createFunction(
       await step.run(`script.claim-nfts-${batchNum}`, async () => {
         await Promise.all(
           userActionBatch.map(userAction =>
-            claimNFT(
-              userAction,
-              userAction.user.primaryUserCryptoAddress!,
-              {
-                skipTransactionFeeCheck: true,
-              },
-              userAction.user.tenantId,
-            ),
+            claimNFT(userAction, userAction.user.primaryUserCryptoAddress!, {
+              skipTransactionFeeCheck: true,
+            }),
           ),
         )
       })

--- a/src/inngest/functions/initialSignupUserCommunicationJourney/initialSignupUserCommunicationJourney.tsx
+++ b/src/inngest/functions/initialSignupUserCommunicationJourney/initialSignupUserCommunicationJourney.tsx
@@ -173,15 +173,6 @@ async function createCommunicationJourney(userId: string) {
     throw new NonRetriableError('UserCommunicationJourney already exists')
   }
 
-  await prismaClient.user.findFirstOrThrow({
-    where: {
-      id: userId,
-    },
-    select: {
-      tenantId: true,
-    },
-  })
-
   return prismaClient.userCommunicationJourney.create({
     data: {
       userId,

--- a/src/inngest/functions/initialSignupUserCommunicationJourney/initialSignupUserCommunicationJourney.tsx
+++ b/src/inngest/functions/initialSignupUserCommunicationJourney/initialSignupUserCommunicationJourney.tsx
@@ -173,7 +173,7 @@ async function createCommunicationJourney(userId: string) {
     throw new NonRetriableError('UserCommunicationJourney already exists')
   }
 
-  const { tenantId } = await prismaClient.user.findFirstOrThrow({
+  await prismaClient.user.findFirstOrThrow({
     where: {
       id: userId,
     },
@@ -186,7 +186,6 @@ async function createCommunicationJourney(userId: string) {
     data: {
       userId,
       journeyType: UserCommunicationJourneyType.INITIAL_SIGNUP,
-      tenantId,
     },
   })
 }

--- a/src/mocks/models/mockAddress.ts
+++ b/src/mocks/models/mockAddress.ts
@@ -3,11 +3,8 @@ import { Address, Prisma } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
 import { mockCommonDatetimes } from '@/mocks/mockCommonDatetimes'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateAddressInput() {
-  const countryCode = faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES))
-
   const partial = {
     googlePlaceId: null,
     streetNumber: faker.location.buildingNumber(),
@@ -18,9 +15,8 @@ export function mockCreateAddressInput() {
     administrativeAreaLevel2: '',
     postalCode: faker.location.zipCode(),
     postalCodeSuffix: '',
-    countryCode: countryCode.toUpperCase(),
+    countryCode: 'US',
     usCongressionalDistrict: '12',
-    tenantId: countryCode,
   } satisfies Partial<Prisma.AddressCreateInput>
   return {
     ...partial,

--- a/src/mocks/models/mockNFTMint.ts
+++ b/src/mocks/models/mockNFTMint.ts
@@ -7,7 +7,6 @@ import { mockCommonDatetimes } from '@/mocks/mockCommonDatetimes'
 import { NFT_SLUG_BACKEND_METADATA } from '@/utils/server/nft/constants'
 import { MOCK_CURRENT_ETH_USD_EXCHANGE_RATE } from '@/utils/shared/exchangeRate'
 import { NFTSlug } from '@/utils/shared/nft'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateNFTMintInput() {
   const status = faker.helpers.arrayElement(Object.values(NFTMintStatus))
@@ -32,7 +31,6 @@ export function mockCreateNFTMintInput() {
     costAtMintCurrencyCode: NFTCurrency.ETH,
     contractAddress: NFT_SLUG_BACKEND_METADATA[nftSlug].contractAddress,
     costAtMintUsd: costAtMint.times(MOCK_CURRENT_ETH_USD_EXCHANGE_RATE),
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.NFTMintCreateInput
 }
 export function mockNFTMint(): NFTMint {

--- a/src/mocks/models/mockUserActionCall.ts
+++ b/src/mocks/models/mockUserActionCall.ts
@@ -1,14 +1,11 @@
-import { faker } from '@faker-js/faker'
 import { Prisma, UserActionCall } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionCallInput() {
   return {
     recipientPhoneNumber: fakerFields.phoneNumber(),
     recipientDtsiSlug: fakerFields.dtsiSlug(),
-    tenantId: faker.helpers.arrayElement(ORDERED_SUPPORTED_COUNTRIES),
   } satisfies Omit<Prisma.UserActionCallCreateInput, 'addressId' | 'address'>
 }
 
@@ -18,6 +15,5 @@ export function mockUserActionCall(): UserActionCall {
     recipientPhoneNumber: fakerFields.phoneNumber(),
     recipientDtsiSlug: fakerFields.dtsiSlug(),
     addressId: fakerFields.id(),
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   }
 }

--- a/src/mocks/models/mockUserActionDonation.ts
+++ b/src/mocks/models/mockUserActionDonation.ts
@@ -4,7 +4,6 @@ import { Decimal } from '@prisma/client/runtime/library'
 
 import { fakerFields } from '@/mocks/fakerUtils'
 import { SupportedFiatCurrencyCodes } from '@/utils/shared/currency'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionDonationInput() {
   const amount = new Decimal(faker.number.float({ min: 0, max: 1000, multipleOf: 0.01 }))
@@ -15,7 +14,6 @@ export function mockCreateUserActionDonationInput() {
     amountUsd: amount,
     recipient: faker.helpers.arrayElement(Object.values(DonationOrganization)),
     coinbaseCommerceDonationId: fakerFields.id(),
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionDonationCreateInput
 }
 

--- a/src/mocks/models/mockUserActionEmail.ts
+++ b/src/mocks/models/mockUserActionEmail.ts
@@ -2,14 +2,12 @@ import { faker } from '@faker-js/faker'
 import { Prisma, UserActionEmail } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionEmailInput() {
   return {
     senderEmail: faker.internet.email(),
     firstName: faker.person.firstName(),
     lastName: faker.person.lastName(),
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Omit<Prisma.UserActionEmailCreateInput, 'address' | 'addressId'>
 }
 

--- a/src/mocks/models/mockUserActionOptIn.ts
+++ b/src/mocks/models/mockUserActionOptIn.ts
@@ -2,12 +2,10 @@ import { faker } from '@faker-js/faker'
 import { Prisma, UserActionOptIn, UserActionOptInType } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionOptInInput() {
   return {
     optInType: faker.helpers.arrayElement(Object.values(UserActionOptInType)),
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionOptInCreateInput
 }
 

--- a/src/mocks/models/mockUserActionRefer.ts
+++ b/src/mocks/models/mockUserActionRefer.ts
@@ -2,12 +2,10 @@ import { faker } from '@faker-js/faker'
 import { Prisma, UserActionRefer } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionReferInput() {
   return {
     referralsCount: faker.number.int({ min: 0, max: 100 }),
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionReferCreateInput
 }
 

--- a/src/mocks/models/mockUserActionRsvpEvent.ts
+++ b/src/mocks/models/mockUserActionRsvpEvent.ts
@@ -2,14 +2,12 @@ import { faker } from '@faker-js/faker'
 import { Prisma, UserActionRsvpEvent } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionRsvpEventInput() {
   return {
     eventSlug: faker.string.uuid(),
     eventState: fakerFields.stateCode(),
     shouldReceiveNotifications: false,
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionRsvpEventCreateInput
 }
 export function mockUserActionRsvpEvent(): UserActionRsvpEvent {

--- a/src/mocks/models/mockUserActionTweetAtPerson.ts
+++ b/src/mocks/models/mockUserActionTweetAtPerson.ts
@@ -1,13 +1,10 @@
-import { faker } from '@faker-js/faker'
 import { Prisma, UserActionTweetAtPerson } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockUserActionTweetAtPersonInput() {
   return {
     recipientDtsiSlug: fakerFields.dtsiSlug(),
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionTweetAtPersonCreateInput
 }
 

--- a/src/mocks/models/mockUserActionViewKeyRaces.ts
+++ b/src/mocks/models/mockUserActionViewKeyRaces.ts
@@ -1,14 +1,11 @@
-import { faker } from '@faker-js/faker'
 import { Prisma, UserActionViewKeyRaces } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionViewKeyRacesInput() {
   return {
     usaState: fakerFields.stateCode({ abbreviated: true }),
     usCongressionalDistrict: fakerFields.usCongressionalDistrict(),
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionViewKeyRacesCreateInput
 }
 

--- a/src/mocks/models/mockUserActionVoterAttestation.ts
+++ b/src/mocks/models/mockUserActionVoterAttestation.ts
@@ -1,13 +1,10 @@
-import { faker } from '@faker-js/faker'
 import { Prisma, UserActionVoterAttestation } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionVoterAttestationInput() {
   return {
     usaState: fakerFields.stateCode(),
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionVoterAttestationCreateInput
 }
 

--- a/src/mocks/models/mockUserActionVoterRegistration.ts
+++ b/src/mocks/models/mockUserActionVoterRegistration.ts
@@ -1,13 +1,10 @@
-import { faker } from '@faker-js/faker'
 import { Prisma, UserActionVoterRegistration } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionVoterRegistrationInput() {
   return {
     usaState: fakerFields.stateCode(),
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionVoterRegistrationCreateInput
 }
 

--- a/src/mocks/models/mockUserActionVotingDay.ts
+++ b/src/mocks/models/mockUserActionVotingDay.ts
@@ -1,14 +1,11 @@
-import { faker } from '@faker-js/faker'
 import { Prisma, UserActionVotingDay } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionVotingDayInput() {
   return {
     usaState: fakerFields.stateCode({ abbreviated: true }),
     votingYear: new Date().getFullYear().toString(),
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionVotingDayCreateInput
 }
 

--- a/src/mocks/models/mockUserActionVotingInformationResearched.ts
+++ b/src/mocks/models/mockUserActionVotingInformationResearched.ts
@@ -1,13 +1,10 @@
-import { faker } from '@faker-js/faker'
 import { Prisma, UserActionVotingInformationResearched } from '@prisma/client'
 
 import { fakerFields } from '@/mocks/fakerUtils'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserActionVotingInformationResearchedInput() {
   return {
     shouldReceiveNotifications: false,
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserActionVotingInformationResearchedCreateInput
 }
 

--- a/src/mocks/models/mockUserEmailAddress.ts
+++ b/src/mocks/models/mockUserEmailAddress.ts
@@ -8,7 +8,6 @@ import {
 
 import { fakerFields } from '@/mocks/fakerUtils'
 import { mockCommonDatetimes } from '@/mocks/mockCommonDatetimes'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export function mockCreateUserEmailAddressInput() {
   const source = faker.helpers.arrayElement(Object.values(UserEmailAddressSource))
@@ -16,7 +15,6 @@ export function mockCreateUserEmailAddressInput() {
     source,
     emailAddress: faker.internet.email(),
     isVerified: source === UserEmailAddressSource.VERIFIED_THIRD_PARTY,
-    tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Omit<Prisma.UserEmailAddressCreateInput, 'userId' | 'user'>
 }
 

--- a/src/utils/server/coinbaseCommerce/storePaymentRequest.ts
+++ b/src/utils/server/coinbaseCommerce/storePaymentRequest.ts
@@ -215,8 +215,6 @@ async function createNewUser(payment: CoinbaseCommercePayment) {
             isVerified: false,
             emailAddress: payment.event.data.metadata.email,
             source: 'USER_ENTERED',
-            // Same as above
-            tenantId: DEFAULT_SUPPORTED_COUNTRY_CODE,
           },
         },
       }),
@@ -320,7 +318,6 @@ async function createUserActionDonation(
           amountUsd: pricingValues.amountUsd,
           recipient: DonationOrganization.STAND_WITH_CRYPTO,
           coinbaseCommerceDonationId: payment.id,
-          tenantId: user.tenantId,
         },
       },
     },

--- a/src/utils/server/externalOptIn/handleExternalUserActionOptIn.ts
+++ b/src/utils/server/externalOptIn/handleExternalUserActionOptIn.ts
@@ -232,7 +232,6 @@ export async function handleExternalUserActionOptIn(
       userActionOptIn: {
         create: {
           optInType,
-          tenantId: user.tenantId,
         },
       },
       tenantId: user.tenantId,
@@ -359,7 +358,6 @@ async function maybeUpsertUser({
               emailAddress,
               isVerified: isVerifiedEmailAddress,
               source: emailSource,
-              tenantId,
             },
           },
         }),
@@ -379,11 +377,11 @@ async function maybeUpsertUser({
             ? {
                 connectOrCreate: {
                   where: { googlePlaceId: dbAddress.googlePlaceId },
-                  create: { ...dbAddress, tenantId },
+                  create: dbAddress,
                 },
               }
             : {
-                create: { ...dbAddress, tenantId },
+                create: dbAddress,
               }),
         },
       }),
@@ -466,7 +464,6 @@ async function maybeUpsertUser({
           emailAddress,
           isVerified: isVerifiedEmailAddress,
           source: emailSource,
-          tenantId,
         },
       },
       ...(cryptoAddress && {
@@ -484,11 +481,11 @@ async function maybeUpsertUser({
             ? {
                 connectOrCreate: {
                   where: { googlePlaceId: dbAddress.googlePlaceId },
-                  create: { ...dbAddress, tenantId },
+                  create: dbAddress,
                 },
               }
             : {
-                create: { ...dbAddress, tenantId },
+                create: dbAddress,
               }),
         },
       }),

--- a/src/utils/server/nft/claimNFT.tsx
+++ b/src/utils/server/nft/claimNFT.tsx
@@ -18,7 +18,6 @@ import {
   EmailEnabledActionNFTs,
 } from '@/utils/server/email/templates/common/constants'
 import NFTOnTheWayEmail from '@/utils/server/email/templates/nftOnTheWay'
-import { getTenantId } from '@/utils/server/getTenantId'
 import { NFT_SLUG_BACKEND_METADATA } from '@/utils/server/nft/constants'
 import { prismaClient } from '@/utils/server/prismaClient'
 import { fetchAirdropTransactionFee } from '@/utils/server/thirdweb/fetchCurrentClaimTransactionFee'
@@ -116,7 +115,6 @@ export async function claimNFT(
   userAction: UserActionToClaim,
   userCryptoAddress: Pick<UserCryptoAddress, 'cryptoAddress'>,
   config: Config = {},
-  tenantId?: string,
 ) {
   const hydratedConfig = {
     skipTransactionFeeCheck: false,
@@ -153,8 +151,6 @@ export async function claimNFT(
     throw Error(`Action ${userAction.id} for campaign ${campaignName} already has an NFT mint.`)
   }
 
-  const tenant = tenantId ?? (await getTenantId())
-
   const action = await prismaClient.userAction.update({
     where: { id: userAction.id },
     data: {
@@ -167,7 +163,6 @@ export async function claimNFT(
           contractAddress: NFT_SLUG_BACKEND_METADATA[nftSlug].contractAddress,
           costAtMintCurrencyCode: NFTCurrency.ETH,
           costAtMintUsd: new Decimal(0),
-          tenantId: tenant,
         },
       },
     },

--- a/src/utils/server/sms/communicationJourney.ts
+++ b/src/utils/server/sms/communicationJourney.ts
@@ -36,7 +36,6 @@ export async function bulkCreateCommunicationJourney({
     select: {
       id: true,
       phoneNumber: true,
-      tenantId: true,
     },
   })
 
@@ -55,7 +54,6 @@ export async function bulkCreateCommunicationJourney({
       },
       select: {
         userId: true,
-        tenantId: true,
       },
     })
   ).map(({ userId }) => userId)
@@ -63,11 +61,10 @@ export async function bulkCreateCommunicationJourney({
   await prismaClient.userCommunicationJourney.createMany({
     data: users
       .filter(({ id }) => !usersWithExistingCommunicationJourney.includes(id))
-      .map(({ id, tenantId }) => ({
+      .map(({ id }) => ({
         journeyType,
         campaignName,
         userId: id,
-        tenantId,
       })),
   })
 

--- a/src/utils/server/thirdweb/onLogin.ts
+++ b/src/utils/server/thirdweb/onLogin.ts
@@ -414,7 +414,6 @@ export async function onNewLogin(props: NewLoginParams) {
           user,
           cryptoAddressAssociatedWithEmail: userCryptoAddress,
           embeddedWalletUserDetails,
-          tenantId,
         })
       : null
 
@@ -713,12 +712,10 @@ async function maybeUpsertEmbeddedWalletEmailAddress({
   user,
   cryptoAddressAssociatedWithEmail,
   embeddedWalletUserDetails,
-  tenantId,
 }: {
   user: UpsertedUser
   cryptoAddressAssociatedWithEmail: UserCryptoAddress
   embeddedWalletUserDetails: ThirdwebEmbeddedWalletMetadata
-  tenantId: string
 }) {
   const log = getLog(cryptoAddressAssociatedWithEmail.cryptoAddress)
   let email = user.userEmailAddresses.find(
@@ -738,7 +735,6 @@ async function maybeUpsertEmbeddedWalletEmailAddress({
         emailAddress: embeddedWalletUserDetails.email!.toLowerCase(),
         userId: user.id,
         asPrimaryUserEmailAddress: { connect: { id: user.id } },
-        tenantId,
       },
     })
     log(`maybeUpsertEmbeddedWalletEmailAddress: user email address created from embedded wallet`)
@@ -877,7 +873,6 @@ async function triggerPostLoginUserActionSteps({
         userActionOptIn: {
           create: {
             optInType: UserActionOptInType.SWC_SIGN_UP_AS_SUBSCRIBER,
-            tenantId,
           },
         },
       },

--- a/src/validation/fields/zodAddress.ts
+++ b/src/validation/fields/zodAddress.ts
@@ -1,7 +1,5 @@
 import { object, string } from 'zod'
 
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
-
 export const zodAddress = object({
   googlePlaceId: string().optional(),
   formattedDescription: string(),
@@ -15,9 +13,4 @@ export const zodAddress = object({
   postalCodeSuffix: string(),
   countryCode: string().length(2),
   usCongressionalDistrict: string().optional(),
-  tenantId: string()
-    .refine(value => ORDERED_SUPPORTED_COUNTRIES.includes(value), {
-      message: 'Invalid country code',
-    })
-    .optional(),
 })


### PR DESCRIPTION
## What changed? Why?

This PR drops all unnecessary tenantId columns across our database.

## PlanetScale deploy request

This is the first deploy request: https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/103
We will need to create another deploy request afterwards because planetscale limits deploy request to update at max 10 tables to prevent impact in production performance.

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
