### PR TITLE
feat: creates new country code column on User and UserAction tables

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -146,6 +146,7 @@ model User {
   UserCommunicationJourney UserCommunicationJourney[]
   smsStatus                SMSStatus                  @default(NOT_OPTED_IN) @map("sms_status")
   tenantId                 String                     @default("us") @map("tenant_id")
+  countryCode              String?                    @default("us") @map("country_code")
 
   @@index([addressId])
   @@index([internalStatus])
@@ -297,6 +298,7 @@ model UserAction {
   nftMint             NFTMint?           @relation(fields: [nftMintId], references: [id])
   actionType          UserActionType     @map("action_type")
   tenantId            String             @default("us") @map("tenant_id")
+  countryCode         String?            @default("us") @map("country_code")
 
   // We'll need in-memory logic to validate and verify only one action type is every associated with a UserAction
   userActionEmail                       UserActionEmail?

--- a/src/mocks/models/mockUser.ts
+++ b/src/mocks/models/mockUser.ts
@@ -44,6 +44,7 @@ export function mockCreateUserInput({
     capitolCanaryAdvocateId: null,
     capitolCanaryInstance: null,
     tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
+    countryCode: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Prisma.UserCreateInput
 }
 

--- a/src/mocks/models/mockUserAction.ts
+++ b/src/mocks/models/mockUserAction.ts
@@ -15,6 +15,7 @@ export function mockCreateUserActionInput() {
     actionType,
     campaignName: USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP[actionType],
     tenantId: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
+    countryCode: faker.helpers.arrayElement(Object.values(ORDERED_SUPPORTED_COUNTRIES)),
   } satisfies Omit<
     Prisma.UserActionCreateInput,
     'userId' | 'nftMintId' | 'userCryptoAddressId' | 'userSessionId' | 'userEmailAddressId' | 'user'


### PR DESCRIPTION
## What changed? Why?

This PR creates a new column called countryCode that will replace the tenantId column. Initially it is temporary, but we will want to make it required and with no default value after we complete the entire process

## PlanetScale deploy request

Deploy request: https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/107

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
