### PR TITLE
feat: transform country code to support UK as 'gb' in validation

### DIFF
--- a/src/validation/fields/zodSupportedCountryCode.ts
+++ b/src/validation/fields/zodSupportedCountryCode.ts
@@ -2,9 +2,14 @@ import { string } from 'zod'
 
 import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
-export const zodSupportedCountryCode = string().refine(
-  value => ORDERED_SUPPORTED_COUNTRIES.includes(value?.toLowerCase()),
-  {
+export const zodSupportedCountryCode = string()
+  .transform(value => {
+    const lowerCaseCountryCode = value?.toLowerCase()
+
+    // TODO(@twistershark): After we start supporting UK, we should return SupportedCountryCodes.UK instead of 'uk'
+    if (lowerCaseCountryCode === 'gb') return 'uk'
+    return lowerCaseCountryCode
+  })
+  .refine(value => ORDERED_SUPPORTED_COUNTRIES.includes(value), {
     message: 'Invalid country code',
-  },
-)
+  })


### PR DESCRIPTION
closes #1911 

## What changed? Why?

This PR creates some logic to support cases where the country code for the United Kingdom to be GB instead of UK

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

Check the last case in this [issue](https://github.com/Stand-With-Crypto/swc-web/issues/1898) for proof of working

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
