### PR TITLE
feat: update community feed query to filter data by countryCode

### DIFF
--- a/src/app/[countryCode]/community/[[...page]]/page.tsx
+++ b/src/app/[countryCode]/community/[[...page]]/page.tsx
@@ -61,6 +61,7 @@ export default async function CommunityRecentActivityPage(props: Props) {
   const publicRecentActivity = await getPublicRecentActivity({
     limit: itemsPerPage,
     offset,
+    countryCode: params.countryCode,
   })
 
   const dataProps: PageLeaderboardInferredProps = {

--- a/src/app/api/public/recent-activity/[...config]/route.ts
+++ b/src/app/api/public/recent-activity/[...config]/route.ts
@@ -4,13 +4,14 @@ import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 
 import { getPublicRecentActivity } from '@/data/recentActivity/getPublicRecentActivity'
+import { zodSupportedCountryCode } from '@/validation/fields/zodSupportedCountryCode'
 
 export const revalidate = 30 // 30 seconds
 export const dynamic = 'error'
 
 const zodParams = z.object({
   limit: z.string().pipe(z.coerce.number().int().gte(0).lt(100)),
-  restrictToUS: z.string().optional(),
+  countryCode: zodSupportedCountryCode,
 })
 
 export async function GET(
@@ -18,16 +19,16 @@ export async function GET(
   props: { params: Promise<{ config: [string, string?] }> },
 ) {
   const params = await props.params
-  const [rawLimit, rawRestrictToUS] = params.config
+  const [rawLimit, rawCountryCode] = params.config
 
-  const { limit, restrictToUS } = zodParams.parse({
+  const { limit, countryCode } = zodParams.parse({
     limit: rawLimit,
-    restrictToUS: rawRestrictToUS,
+    countryCode: rawCountryCode,
   })
 
   const data = await getPublicRecentActivity({
     limit,
-    restrictToUS: !!restrictToUS,
+    countryCode,
   })
   return NextResponse.json(data)
 }

--- a/src/components/app/pageHome/delayedRecentActivity.tsx
+++ b/src/components/app/pageHome/delayedRecentActivity.tsx
@@ -16,6 +16,7 @@ import { useIntlUrls } from '@/hooks/useIntlUrls'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { ErrorBoundary } from '@/utils/web/errorBoundary'
+import { getCountryCodeOnClient } from '@/utils/web/getCountryCodeOnClient'
 
 export function DelayedRecentActivityWithMap(props: {
   actions: PublicRecentActivity
@@ -23,7 +24,8 @@ export function DelayedRecentActivityWithMap(props: {
   countryCode: SupportedCountryCodes
   advocatesMapPageData: Awaited<ReturnType<typeof getAdvocatesMapData>>
 }) {
-  const recentActivity = useApiRecentActivity(props.actions, { limit: 30, restrictToUS: true })
+  const countryCode = getCountryCodeOnClient()
+  const recentActivity = useApiRecentActivity(props.actions, { limit: 30, countryCode })
   const ref = useRef(null)
   const isInView = useInView(ref, { margin: '-50%', once: true })
   const visibleActions = recentActivity.data.slice(isInView ? 0 : 1, recentActivity.data.length)

--- a/src/components/app/pageLeaderboard/dynamicRecentActivity.tsx
+++ b/src/components/app/pageLeaderboard/dynamicRecentActivity.tsx
@@ -4,12 +4,15 @@ import { COMMUNITY_PAGINATION_DATA } from '@/components/app/pageLeaderboard/cons
 import { RecentActivityRowAnimatedContainer } from '@/components/app/recentActivityRow/recentActivityRowAnimatedContainer'
 import { PublicRecentActivity } from '@/data/recentActivity/getPublicRecentActivity'
 import { useApiRecentActivity } from '@/hooks/useApiRecentActivity'
+import { getCountryCodeOnClient } from '@/utils/web/getCountryCodeOnClient'
 
 export function DynamicRecentActivity(props: { actions: PublicRecentActivity }) {
   const { itemsPerPage } =
     COMMUNITY_PAGINATION_DATA[RecentActivityAndLeaderboardTabs.RECENT_ACTIVITY]
+  const countryCode = getCountryCodeOnClient()
   const actions = useApiRecentActivity(props.actions, {
     limit: itemsPerPage,
+    countryCode,
   }).data
   return <RecentActivityRowAnimatedContainer actions={actions} />
 }

--- a/src/data/pageSpecific/getHomepageData.ts
+++ b/src/data/pageSpecific/getHomepageData.ts
@@ -43,7 +43,7 @@ export async function getHomepageData(props: GetHomePageDataProps) {
     getHomepageTopLevelMetrics({ countryCode: props.countryCode }),
     getPublicRecentActivity({
       limit: props?.recentActivityLimit ?? 10,
-      restrictToUS: props?.restrictToUS,
+      countryCode: props.countryCode,
     }),
     queryDTSIHomepagePeople(),
     getSumDonationsByUser({ limit: 10, pageNum: 1 }),

--- a/src/hooks/useApiRecentActivity.ts
+++ b/src/hooks/useApiRecentActivity.ts
@@ -8,7 +8,7 @@ import { apiUrls } from '@/utils/shared/urls'
 
 export function useApiRecentActivity(
   fallbackData: PublicRecentActivity,
-  args: { limit: number; restrictToUS?: boolean },
+  args: { limit: number; countryCode: string },
   config?: Pick<FullConfiguration, 'revalidateOnFocus'> & { refreshManually?: boolean },
 ) {
   return useSWR(

--- a/src/utils/shared/urls/index.ts
+++ b/src/utils/shared/urls/index.ts
@@ -129,8 +129,8 @@ export const apiUrls = {
   userFullProfileInfo: () => `/api/identified-user/full-profile-info`,
   detectWipedDatabase: () => `/api/identified-user/detect-wiped-database`,
   dtsiAllPeople: () => `/api/public/dtsi/all-people`,
-  recentActivity: ({ limit, restrictToUS }: { limit: number; restrictToUS?: boolean }) =>
-    `/api/public/recent-activity/${limit}${restrictToUS ? '/restrictToUS' : ''}`,
+  recentActivity: ({ limit, countryCode }: { limit: number; countryCode: string }) =>
+    `/api/public/recent-activity/${limit}/${countryCode}`,
   homepageTopLevelMetrics: (countryCode: SupportedCountryCodes) =>
     `/api/public/homepage/top-level-metrics/${countryCode}`,
   unidentifiedUser: ({ sessionId }: { sessionId: string }) => `/api/unidentified-user/${sessionId}`,


### PR DESCRIPTION
closes #1786 

## What changed? Why?

This PR updates the recent activity query in the community feed to filter data by countryCode.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
