### PR TITLE
fix: add error handling to queryDTSIBillDetails

### DIFF
--- a/src/data/dtsi/queries/queryDTSIBillDetails/index.ts
+++ b/src/data/dtsi/queries/queryDTSIBillDetails/index.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/nextjs'
+
 import { fetchDTSI } from '@/data/dtsi/fetchDTSI'
 import { DTSI_BillDetailsQuery, DTSI_BillDetailsQueryVariables } from '@/data/dtsi/generated'
 import { dtsiBillDetailsQueryString } from '@/data/dtsi/queries/queryDTSIBillDetails/dtsiBillDetailsQueryString'
@@ -9,4 +11,10 @@ export const queryDTSIBillDetails = (id: string) =>
     id,
   })
     .then(res => res.bill)
-    .catch(() => null)
+    .catch(error => {
+      Sentry.captureException(error, {
+        extra: { id },
+        tags: { domain: 'queryDTSIBillDetails' },
+      })
+      return null
+    })

--- a/src/data/dtsi/queries/queryDTSIBillDetails/index.ts
+++ b/src/data/dtsi/queries/queryDTSIBillDetails/index.ts
@@ -4,13 +4,9 @@ import { dtsiBillDetailsQueryString } from '@/data/dtsi/queries/queryDTSIBillDet
 
 export type DTSIBillDetails = DTSI_BillDetailsQuery['bill']
 
-export const queryDTSIBillDetails = async (id: string) => {
-  const results = await fetchDTSI<DTSI_BillDetailsQuery, DTSI_BillDetailsQueryVariables>(
-    dtsiBillDetailsQueryString,
-    {
-      id,
-    },
-  )
-
-  return results.bill
-}
+export const queryDTSIBillDetails = (id: string) =>
+  fetchDTSI<DTSI_BillDetailsQuery, DTSI_BillDetailsQueryVariables>(dtsiBillDetailsQueryString, {
+    id,
+  })
+    .then(res => res.bill)
+    .catch(() => null)


### PR DESCRIPTION
fixes [PROD-SWC-WEB-5TD](https://stand-with-crypto.sentry.io/issues/6302930936/events/527f367097264a86a95f3c627f6abab4/)

## What changed? Why?

Added a catch to queryDTSIBillDetails so the page redirects to 404 instead of crashing when accessing a invalid bill

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
