### PR TITLE
feat: add error message for 500 response from recent activity API

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -39,6 +39,7 @@ const COMMON_ERROR_MESSAGES_TO_GROUP = [
   'null is not an object',
   'Unknown root exit status',
   'Connection closed',
+  '500 from GET /api/public/recent-activity/30/restrictToUS',
 ]
 
 const COMMON_TRANSACTION_NAMES_TO_GROUP = ['node_modules/@thirdweb-dev', 'maps/api/js']


### PR DESCRIPTION
## What changed? Why?

This PR groups error messages created on edge environment.

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
