### PR TITLE
fix: edge functions flooding sentry

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -39,6 +39,7 @@ const COMMON_ERROR_MESSAGES_TO_GROUP = [
   'null is not an object',
   'Unknown root exit status',
   'Connection closed',
+  '500 from GET /api/public/recent-activity/30/restrictToUS',
 ]
 
 const COMMON_TRANSACTION_NAMES_TO_GROUP = ['node_modules/@thirdweb-dev', 'maps/api/js']

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -40,6 +40,7 @@ const COMMON_ERROR_MESSAGES_TO_GROUP = [
   'Unknown root exit status',
   'Connection closed',
   '500 from GET /api/public/recent-activity/30/restrictToUS',
+  '500 from GET /api/public/homepage/top-level-metrics/not-set',
 ]
 
 const COMMON_TRANSACTION_NAMES_TO_GROUP = ['node_modules/@thirdweb-dev', 'maps/api/js']


### PR DESCRIPTION
## What changed? Why?

This PR groups errors caused by the datadog synthetic tests recorder not allowing cookies to be created.

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
