### PR TITLE
feat: add country code tracking to server analytics

### DIFF
--- a/src/utils/server/externalOptIn/handleExternalUserActionOptIn.ts
+++ b/src/utils/server/externalOptIn/handleExternalUserActionOptIn.ts
@@ -209,6 +209,7 @@ export async function handleExternalUserActionOptIn(
       reason: 'Already Exists',
       userState,
       ...input.additionalAnalyticsProperties,
+      countryCode,
     })
     waitUntil(flushAnalytics())
     return {
@@ -250,6 +251,7 @@ export async function handleExternalUserActionOptIn(
     userState,
     ...input.additionalAnalyticsProperties,
     ...addressAnalyticsProperties,
+    countryCode,
   })
   peopleAnalytics.set({
     ...addressAnalyticsProperties,

--- a/src/utils/server/serverAnalytics/serverAnalytics.ts
+++ b/src/utils/server/serverAnalytics/serverAnalytics.ts
@@ -1,6 +1,7 @@
 import { UserActionType } from '@prisma/client'
 import * as Sentry from '@sentry/nextjs'
 import { PropertyDict } from 'mixpanel'
+import { cookies } from 'next/headers'
 import { promisify } from 'util'
 
 import {
@@ -11,10 +12,9 @@ import {
 import { getLogger } from '@/utils/shared/logger'
 import { resolveWithTimeout } from '@/utils/shared/resolveWithTimeout'
 import { AnalyticProperties } from '@/utils/shared/sharedAnalytics'
+import { SWC_CURRENT_PAGE_COUNTRY_CODE_COOKIE_NAME } from '@/utils/shared/supportedCountries'
 
 import { ANALYTICS_FLUSH_TIMEOUT_MS, mixpanel } from './shared'
-import { cookies } from 'next/headers'
-import { SWC_CURRENT_PAGE_COUNTRY_CODE_COOKIE_NAME } from '@/utils/shared/supportedCountries'
 
 const logger = getLogger('serverAnalytics')
 


### PR DESCRIPTION
## What changed? Why?

This PR re-adds the logic to track the country code in server analytics.

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
