### PR TITLE
feat: add accessibility title to PopoverContent component

### DIFF
--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -38,8 +38,10 @@ const PopoverTrigger = PopoverPrimitive.Trigger
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
+    a11yTitle: string
+  }
+>(({ className, align = 'center', sideOffset = 4, a11yTitle, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       align={align}
@@ -49,6 +51,7 @@ const PopoverContent = React.forwardRef<
       )}
       ref={ref}
       sideOffset={sideOffset}
+      title={a11yTitle}
       {...props}
     />
   </PopoverPrimitive.Portal>

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -39,7 +39,7 @@ const PopoverTrigger = PopoverPrimitive.Trigger
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & {
-    a11yTitle: string
+    a11yTitle?: string
   }
 >(({ className, align = 'center', sideOffset = 4, a11yTitle, ...props }, ref) => (
   <PopoverPrimitive.Portal>


### PR DESCRIPTION
## What changed? Why?

Removes a11yTitle from prop spreading in the Popover element to fix the following error

![image](https://github.com/user-attachments/assets/d27e624b-d143-46e5-b450-8e3eaa299eaf)

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
