### PR TITLE
refactor: limits use of `getCountryCodeOnClient` function to analytics only

### DIFF
--- a/src/app/[countryCode]/topLevelClientLogic.tsx
+++ b/src/app/[countryCode]/topLevelClientLogic.tsx
@@ -17,15 +17,17 @@ import { getUserIdOnClient } from '@/utils/shared/userId'
 import { maybeInitClientAnalytics, trackClientAnalytic } from '@/utils/web/clientAnalytics'
 import { bootstrapLocalUser } from '@/utils/web/clientLocalUser'
 import { getUserSessionIdOnClient } from '@/utils/web/clientUserSessionId'
-import { getCountryCodeOnClient } from '@/utils/web/getCountryCodeOnClient'
 import { identifyUserOnClient } from '@/utils/web/identifyUser'
 
-const InitialOrchestration = () => {
+interface InitialOrchestrationProps {
+  countryCode: SupportedCountryCodes
+}
+
+const InitialOrchestration = ({ countryCode }: InitialOrchestrationProps) => {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const router = useRouter()
   const authUser = useThirdwebAuthUser()
-  const countryCode = getCountryCodeOnClient()
 
   useReloadDueToInactivity({ timeInMinutes: 25 })
 
@@ -104,7 +106,7 @@ export function TopLevelClientLogic({
       <ThirdwebProvider>
         {/* https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout */}
         <Suspense>
-          <InitialOrchestration />
+          <InitialOrchestration countryCode={countryCode} />
         </Suspense>
         {children}
       </ThirdwebProvider>

--- a/src/components/app/pageAdvocatesHeatmap/advocateHeatmapOdometer.tsx
+++ b/src/components/app/pageAdvocatesHeatmap/advocateHeatmapOdometer.tsx
@@ -31,9 +31,10 @@ export function AdvocateHeatmapOdometer({
     () => mockDecreaseInValuesOnInitialLoadSoWeCanAnimateIncrease(countUsers),
     [countUsers],
   )
-  const values = useApiHomepageTopLevelMetrics(
-    decreasedInitialValues as GetHomepageTopLevelMetricsResponse,
-  ).data
+  const values = useApiHomepageTopLevelMetrics({
+    initial: decreasedInitialValues as GetHomepageTopLevelMetricsResponse,
+    countryCode,
+  }).data
   const formatted = useMemo(() => {
     return {
       countUsers: {

--- a/src/components/app/pageHome/delayedRecentActivity.tsx
+++ b/src/components/app/pageHome/delayedRecentActivity.tsx
@@ -16,7 +16,6 @@ import { useIntlUrls } from '@/hooks/useIntlUrls'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { ErrorBoundary } from '@/utils/web/errorBoundary'
-import { getCountryCodeOnClient } from '@/utils/web/getCountryCodeOnClient'
 
 export function DelayedRecentActivityWithMap(props: {
   actions: PublicRecentActivity
@@ -24,8 +23,10 @@ export function DelayedRecentActivityWithMap(props: {
   countryCode: SupportedCountryCodes
   advocatesMapPageData: Awaited<ReturnType<typeof getAdvocatesMapData>>
 }) {
-  const countryCode = getCountryCodeOnClient()
-  const recentActivity = useApiRecentActivity(props.actions, { limit: 30, countryCode })
+  const recentActivity = useApiRecentActivity(props.actions, {
+    limit: 30,
+    countryCode: props.countryCode,
+  })
   const ref = useRef(null)
   const isInView = useInView(ref, { margin: '-50%', once: true })
   const visibleActions = recentActivity.data.slice(isInView ? 0 : 1, recentActivity.data.length)

--- a/src/components/app/pageHome/topLevelMetrics.tsx
+++ b/src/components/app/pageHome/topLevelMetrics.tsx
@@ -52,7 +52,10 @@ export function TopLevelMetrics({
     () => mockDecreaseInValuesOnInitialLoadSoWeCanAnimateIncrease(data),
     [data],
   )
-  const values = useApiHomepageTopLevelMetrics(decreasedInitialValues).data
+  const values = useApiHomepageTopLevelMetrics({
+    initial: decreasedInitialValues,
+    countryCode,
+  }).data
 
   const formatCurrency = useCallback(
     (

--- a/src/components/app/pageLeaderboard/dynamicRecentActivity.tsx
+++ b/src/components/app/pageLeaderboard/dynamicRecentActivity.tsx
@@ -4,15 +4,18 @@ import { COMMUNITY_PAGINATION_DATA } from '@/components/app/pageLeaderboard/cons
 import { RecentActivityRowAnimatedContainer } from '@/components/app/recentActivityRow/recentActivityRowAnimatedContainer'
 import { PublicRecentActivity } from '@/data/recentActivity/getPublicRecentActivity'
 import { useApiRecentActivity } from '@/hooks/useApiRecentActivity'
-import { getCountryCodeOnClient } from '@/utils/web/getCountryCodeOnClient'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-export function DynamicRecentActivity(props: { actions: PublicRecentActivity }) {
+export function DynamicRecentActivity(props: {
+  actions: PublicRecentActivity
+  countryCode: SupportedCountryCodes
+}) {
   const { itemsPerPage } =
     COMMUNITY_PAGINATION_DATA[RecentActivityAndLeaderboardTabs.RECENT_ACTIVITY]
-  const countryCode = getCountryCodeOnClient()
+
   const actions = useApiRecentActivity(props.actions, {
     limit: itemsPerPage,
-    countryCode,
+    countryCode: props.countryCode,
   }).data
   return <RecentActivityRowAnimatedContainer actions={actions} />
 }

--- a/src/components/app/pageLeaderboard/index.tsx
+++ b/src/components/app/pageLeaderboard/index.tsx
@@ -82,7 +82,7 @@ export function PageLeaderboard({
       <div className="space-y-8 lg:space-y-10">
         {tab === RecentActivityAndLeaderboardTabs.RECENT_ACTIVITY ? (
           pageNum === 1 ? (
-            <DynamicRecentActivity actions={publicRecentActivity} />
+            <DynamicRecentActivity actions={publicRecentActivity} countryCode={countryCode} />
           ) : (
             <>
               {publicRecentActivity.map(action => (

--- a/src/hooks/useApiHomepageTopLevelMetrics.ts
+++ b/src/hooks/useApiHomepageTopLevelMetrics.ts
@@ -6,12 +6,18 @@ import { GetHomepageTopLevelMetricsResponse } from '@/data/pageSpecific/getHomep
 import { fetchReq } from '@/utils/shared/fetchReq'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { apiUrls } from '@/utils/shared/urls'
-import { getCountryCodeOnClient } from '@/utils/web/getCountryCodeOnClient'
 
-export function useApiHomepageTopLevelMetrics(initial: GetHomepageTopLevelMetricsResponse) {
+interface UseApiHomepageTopLevelMetricsProps {
+  countryCode: SupportedCountryCodes
+  initial: GetHomepageTopLevelMetricsResponse
+}
+
+export function useApiHomepageTopLevelMetrics({
+  initial,
+  countryCode,
+}: UseApiHomepageTopLevelMetricsProps) {
   const initialDelayToShowAnimation = 1500
   const [refreshInterval, setRefreshInterval] = useState(initialDelayToShowAnimation)
-  const countryCode = getCountryCodeOnClient()
   /*
     After we initially fetch data we can slow down how often we check for additional data
   */
@@ -22,7 +28,7 @@ export function useApiHomepageTopLevelMetrics(initial: GetHomepageTopLevelMetric
     return () => clearTimeout(timeout)
   }, [initialDelayToShowAnimation])
   return useSWR(
-    apiUrls.homepageTopLevelMetrics(countryCode as SupportedCountryCodes),
+    apiUrls.homepageTopLevelMetrics(countryCode),
     url =>
       fetchReq(url)
         .then(res => res.json())

--- a/src/utils/web/clientAnalytics.ts
+++ b/src/utils/web/clientAnalytics.ts
@@ -7,7 +7,7 @@ import { requiredEnv } from '@/utils/shared/requiredEnv'
 import { AnalyticProperties } from '@/utils/shared/sharedAnalytics'
 import { getClientCookieConsent } from '@/utils/web/clientCookieConsent'
 import { getLocalUser } from '@/utils/web/clientLocalUser'
-import { getCountryCodeOnClient } from '@/utils/web/getCountryCodeOnClient'
+import { getCountryCodeForClientAnalytics } from '@/utils/web/getCountryCodeForClientAnalytics'
 
 const NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN = requiredEnv(
   process.env.NEXT_PUBLIC_MIXPANEL_PROJECT_TOKEN,
@@ -52,7 +52,7 @@ export function trackClientAnalytic(
   _eventProperties?: AnalyticProperties,
   optionsOrCallback?: RequestOptions | Callback,
 ) {
-  const countryCode = getCountryCodeOnClient()
+  const countryCode = getCountryCodeForClientAnalytics()
   const eventProperties = { ...getExperimentProperties(), ..._eventProperties, countryCode }
   customLogger(
     {

--- a/src/utils/web/clientLocalUser.ts
+++ b/src/utils/web/clientLocalUser.ts
@@ -11,7 +11,7 @@ import {
 import { getLogger } from '@/utils/shared/logger'
 import { getClientCookieConsent } from '@/utils/web/clientCookieConsent'
 import { getAllExperiments } from '@/utils/web/clientExperiments'
-import { getCountryCodeOnClient } from '@/utils/web/getCountryCodeOnClient'
+import { getCountryCodeForClientAnalytics } from '@/utils/web/getCountryCodeForClientAnalytics'
 
 const getPersistedLocalUser = () => {
   const val = Cookies.get(LOCAL_USER_PERSISTED_KEY)
@@ -65,7 +65,7 @@ export const getLocalUser = (): LocalUser => {
   const canUsePersistedData =
     getClientCookieConsent().targeting && getClientCookieConsent().functional
 
-  const countryCode = getCountryCodeOnClient()
+  const countryCode = getCountryCodeForClientAnalytics()
 
   if (localUser) {
     if (!canUsePersistedData) {

--- a/src/utils/web/getCountryCodeForClientAnalytics.ts
+++ b/src/utils/web/getCountryCodeForClientAnalytics.ts
@@ -3,7 +3,7 @@ import Cookies from 'js-cookie'
 import { isBrowser } from '@/utils/shared/executionEnvironment'
 import { SWC_CURRENT_PAGE_COUNTRY_CODE_COOKIE_NAME } from '@/utils/shared/supportedCountries'
 
-export function getCountryCodeOnClient() {
+export function getCountryCodeForClientAnalytics() {
   if (!isBrowser) return ''
 
   const countryCode = Cookies.get(SWC_CURRENT_PAGE_COUNTRY_CODE_COOKIE_NAME)

--- a/src/utils/web/getCountryCodeOnClient.ts
+++ b/src/utils/web/getCountryCodeOnClient.ts
@@ -1,11 +1,7 @@
-import * as Sentry from '@sentry/nextjs'
 import Cookies from 'js-cookie'
 
 import { isBrowser } from '@/utils/shared/executionEnvironment'
-import {
-  COUNTRY_CODE_REGEX_PATTERN,
-  SWC_CURRENT_PAGE_COUNTRY_CODE_COOKIE_NAME,
-} from '@/utils/shared/supportedCountries'
+import { SWC_CURRENT_PAGE_COUNTRY_CODE_COOKIE_NAME } from '@/utils/shared/supportedCountries'
 
 export function getCountryCodeOnClient() {
   if (!isBrowser) return ''
@@ -14,12 +10,6 @@ export function getCountryCodeOnClient() {
 
   if (!countryCode) {
     return 'not-set'
-  }
-
-  if (!COUNTRY_CODE_REGEX_PATTERN.test(countryCode)) {
-    const error = new Error('Found invalid country code cookie on client.')
-    Sentry.captureException(error, { tags: { countryCode } })
-    throw error
   }
 
   return countryCode


### PR DESCRIPTION
## What changed? Why?

This PR refactors the use of the getCountryCodeOnClient function to be only in analytics environments where having the default 'not-set' property is not a problem.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
