### PR TITLE
fix: remove thirdweb cookie revalidation when fetching auth user on a SSR page

### DIFF
--- a/src/actions/actionCreateUserActionNFTMint.ts
+++ b/src/actions/actionCreateUserActionNFTMint.ts
@@ -17,7 +17,7 @@ import { getServerAnalytics } from '@/utils/server/serverAnalytics'
 import { parseLocalUserFromCookies } from '@/utils/server/serverLocalUser'
 import { getUserSessionId } from '@/utils/server/serverUserSessionId'
 import { withServerActionMiddleware } from '@/utils/server/serverWrappers/withServerActionMiddleware'
-import { appRouterGetThirdwebAuthUser } from '@/utils/server/thirdweb/appRouterGetThirdwebAuthUser'
+import { getThirdwebAuthUser } from '@/utils/server/thirdweb/getThirdwebAuthUser'
 import { thirdwebBaseRPCClient } from '@/utils/server/thirdweb/thirdwebRPCClients'
 import { createCountryCodeValidation } from '@/utils/server/userActionValidation/checkCountryCode'
 import { withValidations } from '@/utils/server/userActionValidation/withValidations'
@@ -65,7 +65,7 @@ async function _actionCreateUserActionMintNFT(input: CreateActionMintNFTInput) {
   const localUser = await parseLocalUserFromCookies()
   const sessionId = await getUserSessionId()
 
-  const authUser = await appRouterGetThirdwebAuthUser()
+  const authUser = await getThirdwebAuthUser()
   if (!authUser) {
     const error = new Error('Create User Action NFT Mint - Not authenticated')
     Sentry.captureException(error, {

--- a/src/components/app/pageUserProfile/getAuthenticatedData.tsx
+++ b/src/components/app/pageUserProfile/getAuthenticatedData.tsx
@@ -8,11 +8,11 @@ import { getClientUserCryptoAddress } from '@/clientModels/clientUser/clientUser
 import { getSensitiveDataClientUserWithENSData } from '@/clientModels/clientUser/sensitiveDataClientUser'
 import { getSensitiveDataClientUserAction } from '@/clientModels/clientUserAction/sensitiveDataClientUserAction'
 import { getENSDataFromCryptoAddressAndFailGracefully } from '@/data/web3/getENSDataFromCryptoAddress'
-import { appRouterGetAuthUser } from '@/utils/server/authentication/appRouterGetAuthUser'
+import { getAuthUserSSR } from '@/utils/server/authentication/getAuthUserSSR'
 import { prismaClient } from '@/utils/server/prismaClient'
 
 export async function getAuthenticatedData() {
-  const authUser = await appRouterGetAuthUser()
+  const authUser = await getAuthUserSSR()
   if (!authUser) {
     return null
   }

--- a/src/utils/server/authentication/getAuthUser.ts
+++ b/src/utils/server/authentication/getAuthUser.ts
@@ -1,0 +1,53 @@
+import 'server-only'
+
+import { UserActionType } from '@prisma/client'
+import { cookies } from 'next/headers'
+
+import { parseThirdwebAddress } from '@/hooks/useThirdwebAddress/parseThirdwebAddress'
+import { prismaClient } from '@/utils/server/prismaClient'
+import { USER_SESSION_ID_COOKIE_NAME } from '@/utils/shared/userSessionId'
+
+export interface ServerAuthUser {
+  userId: string
+  address: string | null
+}
+
+export async function getAuthUser(): Promise<ServerAuthUser | null> {
+  const currentCookies = await cookies()
+
+  const sessionId = currentCookies.get(USER_SESSION_ID_COOKIE_NAME)?.value
+  if (!sessionId) {
+    return null
+  }
+
+  const user = await prismaClient.user.findFirst({
+    select: {
+      id: true,
+      primaryUserCryptoAddress: {
+        select: {
+          cryptoAddress: true,
+        },
+      },
+      userActions: true,
+    },
+    where: {
+      userSessions: {
+        some: {
+          id: sessionId,
+        },
+      },
+    },
+  })
+
+  const hasOptedIn = user?.userActions.some(action => action.actionType === UserActionType.OPT_IN)
+
+  if (!user || !hasOptedIn) {
+    return null
+  }
+
+  const cryptoAddress = user.primaryUserCryptoAddress
+  return {
+    userId: user.id,
+    address: cryptoAddress ? parseThirdwebAddress(cryptoAddress.cryptoAddress) : null,
+  }
+}

--- a/src/utils/server/authentication/getAuthUserSSR.ts
+++ b/src/utils/server/authentication/getAuthUserSSR.ts
@@ -3,8 +3,8 @@ import 'server-only'
 import { getAuthUser } from '@/utils/server/authentication/getAuthUser'
 import { getThirdwebAuthUser } from '@/utils/server/thirdweb/getThirdwebAuthUser'
 
-export async function appRouterGetAuthUser() {
-  const thirdwebAuthData = await getThirdwebAuthUser()
+export async function getAuthUserSSR() {
+  const thirdwebAuthData = await getThirdwebAuthUser({ isSSR: true })
 
   if (thirdwebAuthData) {
     return thirdwebAuthData


### PR DESCRIPTION
fixes [PROD-SWC-WEB-5P0](https://stand-with-crypto.sentry.io/issues/6226592079/events/299b29ef2f754bf88ac0017088a40ff3/)

## What changed? Why?

Added a new function to fetch the authenticated user without revalidating the Thirdweb token.

Previously, we were fetching the authenticated user during SSR, which caused the page to crash. This happened because Next.js does not allow setting or deleting cookies in an SSR context.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
