### PR TITLE
Allow custom utm_medium query param in the /join vanity url

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -294,8 +294,28 @@ const nextConfig: NextConfig = {
       // vanity urls
       {
         source: '/join/:referralId',
+        destination:
+          '/action/sign-up?utm_campaign=:referralId&utm_source=swc&utm_medium=:utm_medium',
+        permanent: false,
+        has: [
+          {
+            type: 'query',
+            key: 'utm_medium',
+            value: '(?<utm_medium>.*)',
+          },
+        ],
+      },
+      // Fallback for when utm_medium is not present
+      {
+        source: '/join/:referralId',
         destination: '/action/sign-up?utm_campaign=:referralId&utm_source=swc&utm_medium=referral',
         permanent: false,
+        missing: [
+          {
+            type: 'query',
+            key: 'utm_medium',
+          },
+        ],
       },
       {
         source: '/politicians/person/:slug/questionnaire',

--- a/next.config.ts
+++ b/next.config.ts
@@ -301,11 +301,11 @@ const nextConfig: NextConfig = {
           {
             type: 'query',
             key: 'utm_medium',
-            value: '(?<utm_medium>.*)',
+            value: '(?<utm_medium>.+)',
           },
         ],
       },
-      // Fallback for when utm_medium is not present
+      // Fallback for when utm_medium is not present or empty
       {
         source: '/join/:referralId',
         destination: '/action/sign-up?utm_campaign=:referralId&utm_source=swc&utm_medium=referral',


### PR DESCRIPTION
closes #1977 

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

Previously, all redirects from `/join/:referralId` would set a fixed `utm_medium=referral` value, causing any original utm_medium values to be lost. This change ensures accurate attribution tracking by:
1.  Capturing the original utm_medium value when present
2.  Maintaining the default referral value when no utm_medium is provided

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
