### PR TITLE
feat: add address and district sms variables

### DIFF
--- a/src/utils/server/sms/utils/variables.test.ts
+++ b/src/utils/server/sms/utils/variables.test.ts
@@ -3,21 +3,21 @@ import { describe, expect, it } from '@jest/globals'
 import { applySMSVariables, UserSMSVariables } from '@/utils/server/sms/utils/variables'
 
 describe('applySMSVariables', () => {
-  it('replaces all variables correctly', () => {
+  it('should replace all variables correctly', () => {
     const message = 'Hello <%= firstName %> <%= lastName %>, your session ID is <%= sessionId %>.'
     const variables: UserSMSVariables = { firstName: 'Alice', lastName: 'Doe', sessionId: 'ABC123' }
     const result = applySMSVariables(message, variables)
     expect(result).toBe('Hello Alice Doe, your session ID is ABC123.')
   })
 
-  it('replaces missing variables with an empty string', () => {
+  it('should replace missing variables with an empty string', () => {
     const message = 'Hello <%= firstName %> <%= lastName %>, user ID: <%= userId %>.'
     const variables: UserSMSVariables = { firstName: 'Bob' }
     const result = applySMSVariables(message, variables)
     expect(result).toBe('Hello Bob , user ID: .')
   })
 
-  it('uses default values when variables are missing', () => {
+  it('should use default values when variables are missing', () => {
     const message = 'Hello <%= firstName %>, session: <%= sessionId %>.'
     // Set default values in variables before calling the function
     const variables: UserSMSVariables = { firstName: 'Alice', sessionId: 'N/A' }
@@ -25,11 +25,33 @@ describe('applySMSVariables', () => {
     expect(result).toBe('Hello Alice, session: N/A.')
   })
 
-  it('displays conditional content based on variable presence', () => {
+  it('should display conditional content based on variable presence', () => {
     const message =
       "Hello <%= firstName %>, <%= userId ? 'your user ID is ' + userId : 'no user ID available' %>."
     const variables: UserSMSVariables = { firstName: 'Bob', userId: 'USER123' }
     const result = applySMSVariables(message, variables)
     expect(result).toBe('Hello Bob, your user ID is USER123.')
+  })
+
+  it('should display variables inside objects', () => {
+    const message = 'Your district is <%= address.district %>.'
+    const variables: UserSMSVariables = {
+      address: {
+        district: 'CA-12',
+      },
+    }
+    const result = applySMSVariables(message, variables)
+    expect(result).toBe('Your district is CA-12.')
+  })
+
+  it('should not break if accessing a variable inside a missing object', () => {
+    const message = 'Your state is <%= address?.state?.name %>.'
+    const variables: UserSMSVariables = {
+      address: {
+        district: 'CA-12',
+      },
+    }
+    const result = applySMSVariables(message, variables)
+    expect(result).toBe('Your state is .')
   })
 })

--- a/src/utils/server/sms/utils/variables.ts
+++ b/src/utils/server/sms/utils/variables.ts
@@ -2,9 +2,23 @@ import { template } from 'lodash-es'
 
 interface SMSVariables {
   userId: string | undefined
+  referralId: string | undefined
   sessionId: string | undefined
   firstName: string | undefined
   lastName: string | undefined
+  address:
+    | {
+        district?: string
+        state?:
+          | {
+              name?: string
+              code?: string
+            }
+          | undefined
+      }
+    | undefined
+  stateName: string | undefined
+  districtRank: number | undefined
 }
 
 export type UserSMSVariables = Partial<SMSVariables>
@@ -15,6 +29,10 @@ export function applySMSVariables(message: string, userSMSVariables: UserSMSVari
     lastName: undefined,
     sessionId: undefined,
     userId: undefined,
+    referralId: undefined,
+    address: undefined,
+    districtRank: undefined,
+    stateName: undefined,
   }
   const compiled = template(message)
   return compiled({ ...variables, ...userSMSVariables })

--- a/src/utils/server/sms/utils/variables.ts
+++ b/src/utils/server/sms/utils/variables.ts
@@ -17,7 +17,6 @@ interface SMSVariables {
           | undefined
       }
     | undefined
-  stateName: string | undefined
   districtRank: number | undefined
 }
 
@@ -32,7 +31,6 @@ export function applySMSVariables(message: string, userSMSVariables: UserSMSVari
     referralId: undefined,
     address: undefined,
     districtRank: undefined,
-    stateName: undefined,
   }
   const compiled = template(message)
   return compiled({ ...variables, ...userSMSVariables })


### PR DESCRIPTION
## What changed? Why?

Adds 5 new sms variables
1. referralId
2. address.district.name
3. address.district.rank
4. address.state.name
5. address.state code

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [X] Unit test
- [ ] Functional test
