### PR TITLE
Fix utm_medium param

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -295,13 +295,13 @@ const nextConfig: NextConfig = {
       {
         source: '/join/:referralId',
         destination:
-          '/action/sign-up?utm_campaign=:referralId&utm_source=swc&utm_medium=:utm_medium',
+          '/action/sign-up?utm_campaign=:referralId&utm_source=swc&utm_medium=:utmMedium',
         permanent: false,
         has: [
           {
             type: 'query',
             key: 'utm_medium',
-            value: '(?<utm_medium>.+)',
+            value: '(?<utmMedium>.+)',
           },
         ],
       },


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

Changed the regex group name to `utmMedium` from `utm_medium`. That fixes the bug where the replaced utm_medium would end up like `utm_medium=%3Autm_medium`

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
