### PR TITLE
feat: add country code filter on partners data model

### DIFF
--- a/src/app/(builder)/[countryCode]/partners/page.tsx
+++ b/src/app/(builder)/[countryCode]/partners/page.tsx
@@ -18,7 +18,7 @@ export default async function PartnersPage(props: PageProps) {
   const { countryCode } = await props.params
 
   const content = await getPageContent(PAGE_MODEL, PATHNAME, countryCode)
-  const partners = await getPartners()
+  const partners = await getPartners({ countryCode })
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>

--- a/src/app/[countryCode]/page.tsx
+++ b/src/app/[countryCode]/page.tsx
@@ -14,13 +14,14 @@ export const dynamicParams = false
 
 export default async function Home(props: PageProps) {
   const params = await props.params
+  const { countryCode } = params
   const asyncProps = await getHomepageData({
     recentActivityLimit: 30,
     restrictToUS: true,
-    countryCode: params.countryCode,
+    countryCode,
   })
   const advocatePerStateDataProps = await getAdvocatesMapData()
-  const partners = await getPartners()
+  const partners = await getPartners({ countryCode })
   const leaderboardData = await getDistrictsLeaderboardData({ limit: 10 })
 
   /*
@@ -28,7 +29,7 @@ export default async function Home(props: PageProps) {
   a path that includes a "." like /requestProvider.js.map nextjs will try to render the page with that as the locality
   Adding this check here fixes that issue
   */
-  if (!ORDERED_SUPPORTED_COUNTRIES.includes(params.countryCode)) {
+  if (!ORDERED_SUPPORTED_COUNTRIES.includes(countryCode)) {
     notFound()
   }
 

--- a/src/components/app/homepageDialogDeeplinkLayout.tsx
+++ b/src/components/app/homepageDialogDeeplinkLayout.tsx
@@ -34,7 +34,8 @@ export async function HomepageDialogDeeplinkLayout({
   dialogContentClassName,
   className,
 }: HomepageDialogDeeplinkLayoutProps) {
-  const urls = getIntlUrls(pageParams.countryCode)
+  const { countryCode } = pageParams
+  const urls = getIntlUrls(countryCode)
   const [
     { sumDonations, countUsers, countPolicymakerContacts },
     advocatePerStateDataProps,
@@ -43,7 +44,7 @@ export async function HomepageDialogDeeplinkLayout({
   ] = await Promise.all([
     getHomepageTopLevelMetrics(),
     getAdvocatesMapData(),
-    getPartners(),
+    getPartners({ countryCode }),
     getDistrictsLeaderboardData({ limit: 10 }),
   ])
 

--- a/src/utils/server/builder/models/data/partners.ts
+++ b/src/utils/server/builder/models/data/partners.ts
@@ -6,17 +6,29 @@ import { BuilderDataModelIdentifiers } from '@/utils/server/builder/models/data/
 import { SWCPartners, zodPartnerSchemaValidation } from '@/utils/shared/getSWCPartners'
 import { getLogger } from '@/utils/shared/logger'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 const logger = getLogger(`builderIOPartners`)
 
 const LIMIT = 100
 
-async function getAllPartnersWithOffset(offset: number) {
+async function getAllPartnersWithOffset({
+  offset,
+  countryCode,
+}: {
+  offset: number
+  countryCode: SupportedCountryCodes
+}) {
   return await pRetry(
     () =>
       builderSDKClient.getAll(BuilderDataModelIdentifiers.PARTNERS, {
         query: {
           ...(NEXT_PUBLIC_ENVIRONMENT === 'production' && { published: 'published' }),
+          'data.countryCode': {
+            $elemMatch: {
+              $eq: countryCode.toUpperCase(),
+            },
+          },
         },
         includeUnpublished: NEXT_PUBLIC_ENVIRONMENT !== 'production',
         cacheSeconds: 60,
@@ -31,15 +43,15 @@ async function getAllPartnersWithOffset(offset: number) {
   )
 }
 
-export async function getPartners() {
+export async function getPartners({ countryCode }: { countryCode: SupportedCountryCodes }) {
   try {
     let offset = 0
 
-    const entries = await getAllPartnersWithOffset(offset)
+    const entries = await getAllPartnersWithOffset({ offset, countryCode })
 
     while (entries.length === LIMIT + offset) {
       offset += entries.length
-      entries.push(...(await getAllPartnersWithOffset(offset)))
+      entries.push(...(await getAllPartnersWithOffset({ offset, countryCode })))
     }
 
     const filteredIncompletePartners = entries


### PR DESCRIPTION
closes [#2003](https://github.com/Stand-With-Crypto/swc-web/issues/2003)

## What changed? Why?

* Adds country code filter to the partners data model. 
* The new field has a type of tags, which allows users to select multiple country codes, so I'm using [$elemMatch](https://www.builder.io/c/docs/querying#code-elem-match-code) to filter 

## How has it been tested?

- [X] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
