### PR TITLE
feat: add international redirect handler for specific country codes in next.config.ts

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -284,6 +284,20 @@ const nextConfig: NextConfig = {
         destination: '/action/nft-mint',
         permanent: true,
       },
+      // international redirect handler
+      {
+        source: '/:path*',
+        has: [
+          {
+            type: 'query',
+            key: 'countryCode',
+            // Only match SupportedCountryCode values, excluding US
+            value: '^(ca|gb|au)$',
+          },
+        ],
+        destination: '/:redirectInternational/:path*:query',
+        permanent: false,
+      },
       // vanity urls
       {
         source: '/join/:referralId',

--- a/next.config.ts
+++ b/next.config.ts
@@ -290,12 +290,12 @@ const nextConfig: NextConfig = {
         has: [
           {
             type: 'query',
-            key: 'countryCode',
+            key: 'ccRedirect',
             // Only match SupportedCountryCode values, excluding US
             value: '^(ca|gb|au)$',
           },
         ],
-        destination: '/:redirectInternational/:path*:query',
+        destination: '/:ccRedirect/:path*:query',
         permanent: false,
       },
       // vanity urls


### PR DESCRIPTION
closes #2017 

## What changed? Why?

This PR adds new redirect logic that will be used in the retail app to redirect users to the corresponding country page

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
