### PR TITLE
feat: add countryCode filter to Builder.io page model

### DIFF
--- a/src/app/(builder)/[countryCode]/about/page.tsx
+++ b/src/app/(builder)/[countryCode]/about/page.tsx
@@ -19,7 +19,7 @@ export default async function AboutPage(props: PageProps) {
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }

--- a/src/app/(builder)/[countryCode]/advocacy-toolkit/page.tsx
+++ b/src/app/(builder)/[countryCode]/advocacy-toolkit/page.tsx
@@ -19,7 +19,7 @@ export default async function AdvocacyToolkitPage(props: PageProps) {
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }

--- a/src/app/(builder)/[countryCode]/builder/test/page.tsx
+++ b/src/app/(builder)/[countryCode]/builder/test/page.tsx
@@ -25,7 +25,7 @@ export default async function BuilderTestPage(props: PageProps) {
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }

--- a/src/app/(builder)/[countryCode]/builder/test/page.tsx
+++ b/src/app/(builder)/[countryCode]/builder/test/page.tsx
@@ -1,0 +1,42 @@
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+
+import { BuilderPageLayout, RenderBuilderContent } from '@/components/app/builder'
+import { PageProps } from '@/types'
+import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/constants'
+import { getPageContent, getPageDetails } from '@/utils/server/builder/models/page/utils'
+import { generateMetadataDetails } from '@/utils/server/metadataUtils'
+import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
+
+export const dynamic = 'error'
+export const revalidate = 3600 // 1 hour
+
+const PAGE_MODEL = BuilderPageModelIdentifiers.PAGE
+const PATHNAME = '/builder/test'
+
+export default async function BuilderTestPage(props: PageProps) {
+  if (NEXT_PUBLIC_ENVIRONMENT === 'production') {
+    return notFound()
+  }
+
+  const { countryCode } = await props.params
+
+  const content = await getPageContent(PAGE_MODEL, PATHNAME, countryCode)
+
+  return (
+    <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
+      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
+    </BuilderPageLayout>
+  )
+}
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { countryCode } = await props.params
+
+  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME, countryCode)
+
+  return generateMetadataDetails({
+    title: metadata.title,
+    description: metadata.description,
+  })
+}

--- a/src/app/(builder)/[countryCode]/content/[[...page]]/page.tsx
+++ b/src/app/(builder)/[countryCode]/content/[[...page]]/page.tsx
@@ -25,7 +25,7 @@ export default async function Page(props: DynamicPageProps) {
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={pathname}>
-      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }

--- a/src/app/(builder)/[countryCode]/partners/page.tsx
+++ b/src/app/(builder)/[countryCode]/partners/page.tsx
@@ -22,7 +22,7 @@ export default async function PartnersPage(props: PageProps) {
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} model={PAGE_MODEL} />
       <div className="standard-spacing-from-navbar container space-y-20">
         <PartnerGrid partners={partners} />
       </div>

--- a/src/app/(builder)/[countryCode]/press/[...page]/page.tsx
+++ b/src/app/(builder)/[countryCode]/press/[...page]/page.tsx
@@ -6,6 +6,7 @@ import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/
 import { getPageContent, getPageDetails } from '@/utils/server/builder/models/page/utils'
 import { getPagePaths } from '@/utils/server/builder/models/page/utils/getPagePaths'
 import { generateMetadataDetails } from '@/utils/server/metadataUtils'
+import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 export const dynamic = 'error'
 export const dynamicParams = true
@@ -46,12 +47,19 @@ export async function generateMetadata(props: PressReleasePageProps): Promise<Me
 }
 
 export async function generateStaticParams() {
-  const paths = await getPagePaths({
-    pageModelName: PAGE_MODEL,
-    limit: 10,
-  })
+  const countryPagePathsPromises = ORDERED_SUPPORTED_COUNTRIES.map(countryCode =>
+    getPagePaths({
+      pageModelName: PAGE_MODEL,
+      limit: 10,
+      countryCode,
+    }),
+  )
 
-  return paths.map(path => {
+  const countryPagePaths = await Promise.all(countryPagePathsPromises)
+
+  console.log(countryPagePaths.flat())
+
+  return countryPagePaths.flat().map(path => {
     return {
       params: {
         page: path?.replace(PAGE_PREFIX, '').split('/'),

--- a/src/app/(builder)/[countryCode]/press/[...page]/page.tsx
+++ b/src/app/(builder)/[countryCode]/press/[...page]/page.tsx
@@ -28,7 +28,7 @@ export default async function Page(props: PressReleasePageProps) {
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={pathname}>
-      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }

--- a/src/app/(builder)/[countryCode]/press/[...page]/page.tsx
+++ b/src/app/(builder)/[countryCode]/press/[...page]/page.tsx
@@ -57,8 +57,6 @@ export async function generateStaticParams() {
 
   const countryPagePaths = await Promise.all(countryPagePathsPromises)
 
-  console.log(countryPagePaths.flat())
-
   return countryPagePaths.flat().map(path => {
     return {
       params: {

--- a/src/app/(builder)/[countryCode]/press/page.tsx
+++ b/src/app/(builder)/[countryCode]/press/page.tsx
@@ -24,7 +24,7 @@ export default async function PressPage(props: PageProps) {
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} model={PAGE_MODEL} />
       <NewsList countryCode={countryCode} initialNews={news} />
     </BuilderPageLayout>
   )

--- a/src/app/(builder)/[countryCode]/privacy/page.tsx
+++ b/src/app/(builder)/[countryCode]/privacy/page.tsx
@@ -19,7 +19,7 @@ export default async function PrivacyPage(props: PageProps) {
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }

--- a/src/app/(builder)/[countryCode]/terms-of-service/page.tsx
+++ b/src/app/(builder)/[countryCode]/terms-of-service/page.tsx
@@ -19,7 +19,7 @@ export default async function TermsOfServicePage(props: PageProps) {
 
   return (
     <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
-      <RenderBuilderContent content={content} countryCode={countryCode} model={PAGE_MODEL} />
+      <RenderBuilderContent content={content} model={PAGE_MODEL} />
     </BuilderPageLayout>
   )
 }

--- a/src/components/app/builder/builderComponent.tsx
+++ b/src/components/app/builder/builderComponent.tsx
@@ -5,9 +5,9 @@ import { Builder, BuilderComponent } from '@builder.io/react'
 import { notFound } from 'next/navigation'
 
 import { useSession } from '@/hooks/useSession'
-import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/constants'
+// import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/constants'
 import {
-  DEFAULT_SUPPORTED_COUNTRY_CODE,
+  // DEFAULT_SUPPORTED_COUNTRY_CODE,
   SupportedCountryCodes,
 } from '@/utils/shared/supportedCountries'
 import { BuilderState } from '@/utils/web/builder/types'
@@ -17,7 +17,7 @@ type BuilderPageProps = ComponentProps<typeof BuilderComponent> & {
 }
 
 export function RenderBuilderContent({
-  countryCode = DEFAULT_SUPPORTED_COUNTRY_CODE,
+  // countryCode = DEFAULT_SUPPORTED_COUNTRY_CODE,
   ...props
 }: BuilderPageProps) {
   const session = useSession()
@@ -28,23 +28,8 @@ export function RenderBuilderContent({
     mockIsAuthenticated: session.isLoggedIn,
   }
 
-  const getModelName = () => {
-    if (
-      props.model === BuilderPageModelIdentifiers.PAGE &&
-      countryCode !== DEFAULT_SUPPORTED_COUNTRY_CODE
-    ) {
-      // TODO: remove this once we add more SupportedCountryCodes
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      return `page-${countryCode}`
-    }
-
-    return props.model
-  }
-
-  const modelName = getModelName()
-
   if (props.content || Builder.isEditing) {
-    return <BuilderComponent {...props} data={builderData} model={modelName} />
+    return <BuilderComponent {...props} data={builderData} />
   }
 
   return notFound()

--- a/src/components/app/builder/builderComponent.tsx
+++ b/src/components/app/builder/builderComponent.tsx
@@ -5,21 +5,11 @@ import { Builder, BuilderComponent } from '@builder.io/react'
 import { notFound } from 'next/navigation'
 
 import { useSession } from '@/hooks/useSession'
-// import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/constants'
-import {
-  // DEFAULT_SUPPORTED_COUNTRY_CODE,
-  SupportedCountryCodes,
-} from '@/utils/shared/supportedCountries'
 import { BuilderState } from '@/utils/web/builder/types'
 
-type BuilderPageProps = ComponentProps<typeof BuilderComponent> & {
-  countryCode: SupportedCountryCodes
-}
+type BuilderPageProps = ComponentProps<typeof BuilderComponent>
 
-export function RenderBuilderContent({
-  // countryCode = DEFAULT_SUPPORTED_COUNTRY_CODE,
-  ...props
-}: BuilderPageProps) {
+export function RenderBuilderContent({ ...props }: BuilderPageProps) {
   const session = useSession()
 
   const builderData: BuilderState = {

--- a/src/utils/server/builder/models/page/constants.ts
+++ b/src/utils/server/builder/models/page/constants.ts
@@ -1,11 +1,3 @@
-import {
-  DEFAULT_SUPPORTED_COUNTRY_CODE,
-  SupportedCountryCodes,
-} from '@/utils/shared/supportedCountries'
-
-export type InternationalBuilderPageModel =
-  `page-${Exclude<SupportedCountryCodes, typeof DEFAULT_SUPPORTED_COUNTRY_CODE>}`
-
 export enum BuilderPageModelIdentifiers {
   CONTENT = 'content',
   PAGE = 'page',

--- a/src/utils/server/builder/models/page/utils/getPageContent.ts
+++ b/src/utils/server/builder/models/page/utils/getPageContent.ts
@@ -1,35 +1,21 @@
 import { builderSDKClient } from '@/utils/server/builder/builderSDKClient'
-import {
-  BuilderPageModelIdentifiers,
-  InternationalBuilderPageModel,
-} from '@/utils/server/builder/models/page/constants'
-import {
-  DEFAULT_SUPPORTED_COUNTRY_CODE,
-  SupportedCountryCodes,
-} from '@/utils/shared/supportedCountries'
+import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/constants'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 export function getPageContent(
   pageModelName: BuilderPageModelIdentifiers,
   pathname: string,
   countryCode: SupportedCountryCodes,
 ) {
-  let urlPath = pathname
-  let pageModel: BuilderPageModelIdentifiers | InternationalBuilderPageModel = pageModelName
-
-  if (
-    pageModelName === BuilderPageModelIdentifiers.PAGE &&
-    countryCode !== DEFAULT_SUPPORTED_COUNTRY_CODE
-  ) {
-    // TODO: remove this once we add more SupportedCountryCodes
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    urlPath = `/${countryCode}${pathname}`
-    pageModel = ('page-' + countryCode) as InternationalBuilderPageModel
-  }
-
   return builderSDKClient
-    .get(pageModel, {
+    .get(pageModelName, {
+      query: {
+        data: {
+          countryCode: countryCode.toUpperCase(),
+        },
+      },
       userAttributes: {
-        urlPath,
+        urlPath: pathname,
       },
       // Set prerender to false to return JSON instead of HTML
       prerender: false,

--- a/src/utils/server/builder/models/page/utils/getPagePaths.ts
+++ b/src/utils/server/builder/models/page/utils/getPagePaths.ts
@@ -1,15 +1,26 @@
 import { builderSDKClient } from '@/utils/server/builder/builderSDKClient'
 import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/constants'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 interface GetPagePathsInput {
   pageModelName: BuilderPageModelIdentifiers
   limit?: number
+  countryCode?: SupportedCountryCodes
 }
 
 /** Retrieves a list of all existing routes under a specific page model  */
-export async function getPagePaths({ pageModelName, limit }: GetPagePathsInput): Promise<string[]> {
+export async function getPagePaths({
+  pageModelName,
+  limit,
+  countryCode,
+}: GetPagePathsInput): Promise<string[]> {
   return builderSDKClient
     .getAll(pageModelName, {
+      query: {
+        data: {
+          countryCode: countryCode?.toUpperCase(),
+        },
+      },
       options: {
         noTargeting: true,
       },


### PR DESCRIPTION
## What changed? Why?

Removed support for International Page Model and added new countryCode propriety to all Page Models

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
