### PR TITLE
feat: add redirects for country-specific manifesto and mission pages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -666,6 +666,16 @@ const nextConfig: NextConfig = {
         destination: '/politicians',
         permanent: true,
       },
+      {
+        source: '/:country/manifesto',
+        destination: '/:country/about',
+        permanent: true,
+      },
+      {
+        source: '/:country/mission',
+        destination: '/:country/about',
+        permanent: true,
+      },
     ]
   },
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -667,8 +667,18 @@ const nextConfig: NextConfig = {
         permanent: true,
       },
       {
+        source: '/manifesto',
+        destination: '/about',
+        permanent: true,
+      },
+      {
         source: '/:country/manifesto',
         destination: '/:country/about',
+        permanent: true,
+      },
+      {
+        source: '/mission',
+        destination: '/about',
         permanent: true,
       },
       {


### PR DESCRIPTION
closes [#2033](https://github.com/Stand-With-Crypto/swc-web/issues/2033)

## What changed? Why?

add redirects from `/manifesto` and `/mission` to `/about`

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
