### PR TITLE
feat: prevents empty country code in cookie

### DIFF
--- a/src/utils/server/getCountryCode.ts
+++ b/src/utils/server/getCountryCode.ts
@@ -19,7 +19,8 @@ const defaultCountryCode = ['local', 'testing'].includes(NEXT_PUBLIC_ENVIRONMENT
 
 export const getCountryCode = (request: NextRequest) => {
   const { country: userCountryCode } = geolocation(request)
-  const pageCountryCode = extractCountryCode(request.nextUrl.pathname) ?? SupportedCountryCodes.US
+  const pageCountryCode =
+    extractCountryCode(request.nextUrl.pathname)?.toLowerCase() ?? SupportedCountryCodes.US
 
   return userCountryCode || defaultCountryCode || pageCountryCode
 }

--- a/src/utils/server/getCountryCode.ts
+++ b/src/utils/server/getCountryCode.ts
@@ -4,7 +4,7 @@ import { NextRequest } from 'next/server'
 
 import { extractCountryCode } from '@/utils/server/obfuscateURLCountryCode'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
-import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { DEFAULT_SUPPORTED_COUNTRY_CODE } from '@/utils/shared/supportedCountries'
 
 export const USER_COUNTRY_CODE_COOKIE_NAME = 'USER_COUNTRY_CODE'
 
@@ -20,7 +20,7 @@ const defaultCountryCode = ['local', 'testing'].includes(NEXT_PUBLIC_ENVIRONMENT
 export const getCountryCode = (request: NextRequest) => {
   const { country: userCountryCode } = geolocation(request)
   const pageCountryCode =
-    extractCountryCode(request.nextUrl.pathname)?.toLowerCase() ?? SupportedCountryCodes.US
+    extractCountryCode(request.nextUrl.pathname)?.toLowerCase() ?? DEFAULT_SUPPORTED_COUNTRY_CODE
 
   return userCountryCode || defaultCountryCode || pageCountryCode
 }

--- a/src/utils/server/getCountryCode.ts
+++ b/src/utils/server/getCountryCode.ts
@@ -2,8 +2,9 @@ import * as Sentry from '@sentry/nextjs'
 import { geolocation } from '@vercel/functions'
 import { NextRequest } from 'next/server'
 
+import { extractCountryCode } from '@/utils/server/obfuscateURLCountryCode'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
-import { DEFAULT_SUPPORTED_COUNTRY_CODE } from '@/utils/shared/supportedCountries'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 export const USER_COUNTRY_CODE_COOKIE_NAME = 'USER_COUNTRY_CODE'
 
@@ -13,13 +14,14 @@ interface UserCountryCodeCookie {
 }
 
 const defaultCountryCode = ['local', 'testing'].includes(NEXT_PUBLIC_ENVIRONMENT)
-  ? process.env.USER_COUNTRY_CODE || DEFAULT_SUPPORTED_COUNTRY_CODE
+  ? process.env.USER_COUNTRY_CODE
   : ''
 
 export const getCountryCode = (request: NextRequest) => {
   const { country: userCountryCode } = geolocation(request)
+  const pageCountryCode = extractCountryCode(request.nextUrl.pathname) ?? SupportedCountryCodes.US
 
-  return userCountryCode || defaultCountryCode
+  return userCountryCode || defaultCountryCode || pageCountryCode
 }
 
 export const parseUserCountryCodeCookie = (cookieValue?: string | null) => {

--- a/src/utils/server/obfuscateURLCountryCode/index.ts
+++ b/src/utils/server/obfuscateURLCountryCode/index.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_SUPPORTED_COUNTRY_CODE,
 } from '@/utils/shared/supportedCountries'
 
-function extractCountryCode(pathname: string) {
+export function extractCountryCode(pathname: string) {
   const segments = pathname.split('/').filter(Boolean)
   const firstSegment = segments[0]
   return COUNTRY_CODE_REGEX_PATTERN.test(firstSegment) ? firstSegment : null


### PR DESCRIPTION
closes #2009 
## What changed? Why?

This PR updates the function that returns the countryCode based on the IP location to always return a countryCode.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
