### PR TITLE
Backfill users script

### DIFF
--- a/src/actions/actionUpdateUserProfile.ts
+++ b/src/actions/actionUpdateUserProfile.ts
@@ -37,6 +37,7 @@ import {
 } from '@/utils/shared/getCongressionalDistrictFromAddress'
 import { getLogger } from '@/utils/shared/logger'
 import { convertAddressToAnalyticsProperties } from '@/utils/shared/sharedAnalytics'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { userFullName } from '@/utils/shared/userFullName'
 import { zodUpdateUserProfileFormAction } from '@/validation/forms/zodUpdateUserProfile/zodUpdateUserProfileFormAction'
 
@@ -113,7 +114,7 @@ async function actionUpdateUserProfileWithoutMiddleware(
     : null
 
   if (address && user.countryCode.toLowerCase() !== address.countryCode.toLowerCase()) {
-    await actionUpdateUserCountryCodeWithoutMiddleware(address.countryCode)
+    await actionUpdateUserCountryCodeWithoutMiddleware(address.countryCode as SupportedCountryCodes)
   }
 
   const existingUserEmailAddress = emailAddress

--- a/src/app/[countryCode]/internal/user-settings/userConfig.tsx
+++ b/src/app/[countryCode]/internal/user-settings/userConfig.tsx
@@ -25,9 +25,10 @@ import {
   parseUserCountryCodeCookie,
   USER_COUNTRY_CODE_COOKIE_NAME,
 } from '@/utils/server/getCountryCode'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 type FormFields = {
-  countryCode: string
+  countryCode: SupportedCountryCodes
 }
 
 export function UserConfig() {
@@ -45,13 +46,15 @@ export function UserConfig() {
 
   const form = useForm<FormFields>({
     defaultValues: {
-      countryCode: parsedExistingCountryCode?.countryCode,
+      countryCode: parsedExistingCountryCode?.countryCode as SupportedCountryCodes,
     },
   })
 
   const handleCountryCodeSubmit = async (values: FormFields) => {
     if (isLoggedIn) {
-      const result = await actionUpdateUserCountryCode(values.countryCode.toLowerCase())
+      const result = await actionUpdateUserCountryCode(
+        values.countryCode.toLowerCase() as SupportedCountryCodes,
+      )
 
       if (result?.errors) {
         const [errorMessage] = result.errors.countryCode ?? ['Unknown error']

--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -4,6 +4,8 @@ import { airdropNFTWithInngest } from '@/inngest/functions/airdropNFT/airdropNFT
 import { backfillCongressionalDistrictCronJob } from '@/inngest/functions/backfillCongressionalDistrictCronJob'
 import { backfillCountryCodesInngest } from '@/inngest/functions/backfillCountryCodes'
 import { backfillFailedNFT } from '@/inngest/functions/backfillFailedNFTCronJob'
+import { backfillIntlUsersWithInngest } from '@/inngest/functions/backfillIntlUsers'
+import { processIntlUsersBatch } from '@/inngest/functions/backfillIntlUsers/logic'
 import { backfillNFTWithInngest } from '@/inngest/functions/backfillNFT'
 import { backfillNFTInngestCronJob } from '@/inngest/functions/backfillNFTCronJob'
 import { backfillSessionIdCronJob } from '@/inngest/functions/backfillSessionId'
@@ -79,5 +81,7 @@ export const { GET, POST, PUT } = serve({
     cleanupDatadogSyntheticTestsWithInngest,
     updateDistrictsRankings,
     backfillUserCountryCodeEmptyWithInngest,
+    backfillIntlUsersWithInngest,
+    processIntlUsersBatch,
   ],
 })

--- a/src/bin/smokeTests/verifiedSWCPartners/userActionOptIn.ts
+++ b/src/bin/smokeTests/verifiedSWCPartners/userActionOptIn.ts
@@ -7,6 +7,7 @@ import { createBasicAuthHeader } from '@/utils/server/basicAuth'
 import { VerifiedSWCPartner } from '@/utils/server/verifiedSWCPartner/constants'
 import { fetchReq } from '@/utils/shared/fetchReq'
 import { requiredEnv } from '@/utils/shared/requiredEnv'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 /*
 Run this script only after you have the app running on localhost:3000
@@ -43,7 +44,7 @@ async function smokeTestUserActionOptIn() {
       isVerifiedEmailAddress: true,
       campaignName: 'foobar',
       hasOptedInToEmails: true,
-      countryCode: 'us',
+      countryCode: SupportedCountryCodes.US,
     } satisfies Omit<Parameters<typeof verifiedSWCPartnersUserActionOptIn>[0], 'partner'>),
   }).catch(e => {
     console.error(e)

--- a/src/inngest/functions/backfillIntlUsers/index.ts
+++ b/src/inngest/functions/backfillIntlUsers/index.ts
@@ -1,0 +1,137 @@
+import { NonRetriableError } from 'inngest'
+import { chunk } from 'lodash-es'
+import { read, utils } from 'xlsx'
+import { z } from 'zod'
+
+import { inngest } from '@/inngest/inngest'
+import { onScriptFailure } from '@/inngest/onScriptFailure'
+import { logger } from '@/utils/shared/logger'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { zodEmailAddress } from '@/validation/fields/zodEmailAddress'
+import { zodFirstName, zodLastName } from '@/validation/fields/zodName'
+import { zodPhoneNumberWithCountryCode } from '@/validation/fields/zodPhoneNumber'
+import { zodSupportedCountryCode } from '@/validation/fields/zodSupportedCountryCode'
+
+import { processIntlUsersBatch } from './logic'
+
+export const BACKFILL_INTL_USERS_INNGEST_EVENT_NAME = 'script/backfill-intl-users'
+export const BACKFILL_INTL_USERS_FUNCTION_ID = 'script.backfill-intl-users'
+
+const BATCH_SIZE = 2000
+
+const createUserDataSchema = (countryCode: SupportedCountryCodes) => {
+  return z.object({
+    firstName: zodFirstName.optional().transform(v => v || ''),
+    lastName: zodLastName.optional().transform(v => v || ''),
+    email: zodEmailAddress,
+    phoneNumber: z.union([zodPhoneNumberWithCountryCode(countryCode), z.literal('')]).optional(),
+  })
+}
+
+export type UserData = z.infer<ReturnType<typeof createUserDataSchema>>
+
+const eventPayloadSchema = z.object({
+  countryCode: zodSupportedCountryCode,
+  csvData: z.string().min(1, 'CSV data is required'),
+})
+
+export type BackfillIntlUsersSchema = {
+  name: typeof BACKFILL_INTL_USERS_INNGEST_EVENT_NAME
+  data: z.infer<typeof eventPayloadSchema>
+}
+
+export const backfillIntlUsersWithInngest = inngest.createFunction(
+  {
+    id: BACKFILL_INTL_USERS_FUNCTION_ID,
+    onFailure: onScriptFailure,
+  },
+  { event: BACKFILL_INTL_USERS_INNGEST_EVENT_NAME },
+  async ({ event, step }) => {
+    const payloadValidation = eventPayloadSchema.safeParse(event.data)
+    if (!payloadValidation.success) {
+      throw new NonRetriableError(`Invalid event payload: ${payloadValidation.error.message}`)
+    }
+
+    const { countryCode, csvData } = payloadValidation.data
+
+    const { users, totalUsers, invalidCount } = await step.run('parse-csv', async () => {
+      try {
+        const buffer = Buffer.from(csvData, 'base64')
+        const workbook = read(buffer, { type: 'buffer' })
+        const firstSheetName = workbook.SheetNames[0]
+        const worksheet = workbook.Sheets[firstSheetName]
+        const rawUsers = utils.sheet_to_json<Record<string, unknown>>(worksheet)
+
+        const userDataSchema = createUserDataSchema(countryCode)
+        const validatedResults = rawUsers.map(rawUser => {
+          const result = userDataSchema.safeParse(rawUser)
+          return {
+            isValid: result.success,
+            data: result.success ? result.data : null,
+            error: !result.success ? result.error.message : null,
+            rawData: rawUser,
+          }
+        })
+
+        const invalidUsers = validatedResults.filter(r => !r.isValid)
+        const validUsers = validatedResults.filter(r => r.isValid).map(r => r.data) as UserData[]
+
+        if (invalidUsers.length > 0) {
+          logger.warn(`Found ${invalidUsers.length} invalid user records that will be skipped`)
+          invalidUsers.slice(0, 5).forEach(invalid => {
+            logger.warn(
+              `Invalid user: ${JSON.stringify(invalid.rawData)}, Error: ${invalid.error || 'Unknown validation error'}`,
+            )
+          })
+        }
+
+        logger.info(
+          `Found ${validUsers.length} valid users to process for country code ${countryCode}`,
+        )
+        return {
+          users: validUsers,
+          totalUsers: validUsers.length,
+          invalidCount: invalidUsers.length,
+        }
+      } catch (error) {
+        logger.error(
+          `Error parsing data: ${error instanceof Error ? error.message : String(error)}`,
+        )
+        throw error
+      }
+    })
+
+    if (totalUsers === 0) {
+      return {
+        message: `No valid users found to process for country code ${countryCode}`,
+        countryCode,
+        totalUsers: 0,
+        invalidCount,
+      }
+    }
+
+    const batches = chunk(users, BATCH_SIZE)
+    logger.info(`Split data into ${batches.length} batches for processing`)
+
+    for (const [batchIndex, batch] of batches.entries()) {
+      logger.info(`Dispatching batch ${batchIndex + 1}/${batches.length}`)
+      await step.invoke(`dispatch-batch-of-users-${batchIndex}`, {
+        function: processIntlUsersBatch,
+        data: {
+          countryCode,
+          users: batch,
+          batchIndex: batchIndex + 1,
+          totalBatches: batches.length,
+        },
+      })
+    }
+
+    return {
+      message: `Processing ${totalUsers} valid users for country code ${countryCode} in ${batches.length} batches`,
+      countryCode,
+      totalUsers,
+      invalidCount,
+      batches: batches.length,
+    }
+  },
+)

--- a/src/inngest/functions/backfillIntlUsers/index.ts
+++ b/src/inngest/functions/backfillIntlUsers/index.ts
@@ -17,7 +17,7 @@ import { processIntlUsersBatch } from './logic'
 export const BACKFILL_INTL_USERS_INNGEST_EVENT_NAME = 'script/backfill-intl-users'
 export const BACKFILL_INTL_USERS_FUNCTION_ID = 'script.backfill-intl-users'
 
-const BATCH_SIZE = 2000
+const BATCH_SIZE = 1000
 
 const createUserDataSchema = (countryCode: SupportedCountryCodes) => {
   return z.object({

--- a/src/inngest/functions/backfillIntlUsers/index.ts
+++ b/src/inngest/functions/backfillIntlUsers/index.ts
@@ -20,28 +20,27 @@ export const BACKFILL_INTL_USERS_FUNCTION_ID = 'script.backfill-intl-users'
 const BATCH_SIZE = 1000
 
 const createUserDataSchema = (countryCode: SupportedCountryCodes) => {
-  // Map common CSV column variations to our expected field names
+  // Map  CSV columns to our expected field names
   return z.preprocess(
     data => {
       if (typeof data !== 'object' || data === null) return data
 
       const csvFieldNames: Record<string, string> = { ...data }
 
-      if ('phone' in csvFieldNames) {
-        csvFieldNames.phoneNumber = csvFieldNames.phone
+      if ('What is your name?' in csvFieldNames) {
+        csvFieldNames.firstName = csvFieldNames['What is your name?']
+        csvFieldNames.lastName = ''
       }
 
-      if ('fullName' in csvFieldNames) {
-        const [firstName, lastName] = csvFieldNames.fullName.split(' ')
-        csvFieldNames.firstName = firstName
-        csvFieldNames.lastName = lastName
+      if ('What is your email?' in csvFieldNames) {
+        csvFieldNames.email = csvFieldNames['What is your email?']
       }
 
       return csvFieldNames
     },
     z.object({
-      firstName: zodFirstName.optional(),
-      lastName: zodLastName.optional(),
+      firstName: z.union([zodFirstName.optional(), z.literal('')]),
+      lastName: z.union([zodLastName.optional(), z.literal('')]),
       email: zodEmailAddress,
       phoneNumber: z.union([zodPhoneNumberWithCountryCode(countryCode), z.literal('')]).optional(),
     }),

--- a/src/inngest/functions/backfillIntlUsers/logic.ts
+++ b/src/inngest/functions/backfillIntlUsers/logic.ts
@@ -4,6 +4,7 @@ import {
   User,
   UserActionOptInType,
   UserActionType,
+  UserEmailAddressSource,
   UserInformationVisibility,
 } from '@prisma/client'
 import { NonRetriableError } from 'inngest'
@@ -178,8 +179,8 @@ async function createUserWithCountryCode(
         const emailRecord = await tx.userEmailAddress.create({
           data: {
             emailAddress,
-            isVerified: Boolean(emailAddress),
-            source: 'VERIFIED_THIRD_PARTY',
+            isVerified: false,
+            source: UserEmailAddressSource.USER_ENTERED,
             dataCreationMethod: DataCreationMethod.INITIAL_BACKFILL,
             userId: user.id,
           },

--- a/src/inngest/functions/backfillIntlUsers/logic.ts
+++ b/src/inngest/functions/backfillIntlUsers/logic.ts
@@ -42,7 +42,7 @@ type UserProcessingResult = {
 }
 
 const getLog = (persist: boolean) => {
-  return getLogger(`backfill-intl-users ${persist ? '' : '[DRY RUN]'}:`)
+  return getLogger(`backfill-intl-users ${persist ? '' : '[DRY RUN]'}`)
 }
 
 export const processIntlUsersBatch = inngest.createFunction(
@@ -196,6 +196,7 @@ async function createUserWithCountryCode(
             user: { connect: { id: user.id } },
             actionType: UserActionType.OPT_IN,
             campaignName: UserActionOptInCampaignName.DEFAULT,
+            dataCreationMethod: DataCreationMethod.INITIAL_BACKFILL,
             countryCode,
             userActionOptIn: {
               create: {
@@ -209,7 +210,7 @@ async function createUserWithCountryCode(
       })
     }
 
-    logger.info(`Created new user from international backfill: ${emailAddress}`)
+    logger.info(`Created new user: ${emailAddress}`)
     return {
       action: 'created',
       userId: newUser?.id,

--- a/src/inngest/functions/backfillIntlUsers/logic.ts
+++ b/src/inngest/functions/backfillIntlUsers/logic.ts
@@ -64,7 +64,7 @@ export const processIntlUsersBatch = inngest.createFunction(
 
     const stats = await step.run(`process-users-batch-${batchIndex}`, async () => {
       logger.info(
-        `Processing batch ${batchIndex + 1}/${totalBatches} with ${users.length} users for country code ${validCountryCode}`,
+        `Processing batch ${batchIndex}/${totalBatches} with ${users.length} users for country code ${validCountryCode}`,
       )
 
       const results = {
@@ -109,7 +109,6 @@ export const processIntlUsersBatch = inngest.createFunction(
 
     return {
       batchIndex,
-      totalBatches,
       countryCode: validCountryCode,
       stats,
     }

--- a/src/inngest/types.ts
+++ b/src/inngest/types.ts
@@ -4,6 +4,8 @@ import type { AirdropNftInngestSchema } from '@/inngest/functions/airdropNFT/air
 import type { BackfillUsCongressionalDistrictsInngestCronJobSchema } from '@/inngest/functions/backfillCongressionalDistrictCronJob'
 import type { BackfillCountryCodesEventSchema } from '@/inngest/functions/backfillCountryCodes'
 import type { BackfillFailedNftInngestSchema } from '@/inngest/functions/backfillFailedNFTCronJob'
+import { BackfillIntlUsersSchema } from '@/inngest/functions/backfillIntlUsers'
+import { ProcessBatchSchema } from '@/inngest/functions/backfillIntlUsers/logic'
 import type { BackfillNftInngestSchema } from '@/inngest/functions/backfillNFT'
 import type { BackfillNftInngestCronJobSchema } from '@/inngest/functions/backfillNFTCronJob'
 import type { BackfillSessionIdInngestSchema } from '@/inngest/functions/backfillSessionId'
@@ -64,5 +66,7 @@ type EventTypes =
   | BackfillOptedOutUsersSchema
   | UpdateDistrictsRankingsCronJobSchema
   | BackfillUserCountryCodeEmptyInngestSchema
+  | BackfillIntlUsersSchema
+  | ProcessBatchSchema
 
 export const INNGEST_SCHEMAS = new EventSchemas().fromUnion<EventTypes>()

--- a/src/validation/fields/zodPhoneNumber.ts
+++ b/src/validation/fields/zodPhoneNumber.ts
@@ -1,9 +1,19 @@
-import { literal, string, union } from 'zod'
+import { literal, string, union, z } from 'zod'
 
 import { normalizePhoneNumber, validatePhoneNumber } from '@/utils/shared/phoneNumber'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 export const zodPhoneNumber = string()
   .refine(validatePhoneNumber, 'Please enter a valid phone number')
   .transform(normalizePhoneNumber)
 
 export const zodOptionalEmptyPhoneNumber = union([zodPhoneNumber, literal('')])
+
+export function zodPhoneNumberWithCountryCode(countryCode: SupportedCountryCodes) {
+  return string()
+    .refine(
+      phoneNumber => validatePhoneNumber(phoneNumber, countryCode),
+      'Please enter a valid phone number',
+    )
+    .transform(normalizePhoneNumber)
+}

--- a/src/validation/fields/zodPhoneNumber.ts
+++ b/src/validation/fields/zodPhoneNumber.ts
@@ -1,4 +1,4 @@
-import { literal, string, union, z } from 'zod'
+import { literal, string, union } from 'zod'
 
 import { normalizePhoneNumber, validatePhoneNumber } from '@/utils/shared/phoneNumber'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'

--- a/src/validation/fields/zodSupportedCountryCode.ts
+++ b/src/validation/fields/zodSupportedCountryCode.ts
@@ -1,7 +1,11 @@
 import { string } from 'zod'
 
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
+import {
+  ORDERED_SUPPORTED_COUNTRIES,
+  SupportedCountryCodes,
+} from '@/utils/shared/supportedCountries'
 
 export const zodSupportedCountryCode = string()
   .transform(value => value?.toLowerCase())
   .refine(value => ORDERED_SUPPORTED_COUNTRIES.includes(value), { message: 'Invalid country code' })
+  .transform(value => value as SupportedCountryCodes)


### PR DESCRIPTION
closes #1914 

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

- Added `zodPhoneNumberWithCountryCode` to parse phone numbers from different countries

Example user backfilled from csv: Name, email, OPT_IN action and sessionId successfully added to the db
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/cf33eade-2936-4137-abfc-40b839338048" />


## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

- 🗒️  ~~When intl team provides the CSVs, the`createUserDataSchema` must be updated to match the columns, or edit the CSV itself~~
- Intl team still has to provide an CSV for AU, current implementation assumes it will have the same columns as UK & CA

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
