### PR TITLE
feat: creates new tweet redirect login

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -596,6 +596,11 @@ const nextConfig: NextConfig = {
         permanent: false,
       },
       {
+        source: '/tweet/case-dismissed/:state',
+        destination: '/api/public/x-redirect/:state',
+        permanent: false,
+      },
+      {
         source: '/oh/1',
         destination:
           'https://americalovescryptooh.splashthat.com?utm_source=swc&utm_medium=sms&utm_campaign=oh_1&utm_id=ss',

--- a/src/app/api/public/x-redirect/[state]/route.ts
+++ b/src/app/api/public/x-redirect/[state]/route.ts
@@ -1,0 +1,26 @@
+import 'server-only'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { createTweetLink } from '@/utils/web/createTweetLink'
+import { getUSStateNameFromStateCode } from '@/utils/shared/usStateUtils'
+
+export const revalidate = 60 * 60 * 24
+export const dynamic = 'error'
+
+const zodParams = z.object({
+  state: z.string().length(2),
+})
+
+export async function GET(_request: NextRequest, props: { params: Promise<{ state: string }> }) {
+  const params = await props.params
+  const { state } = zodParams.parse(params)
+
+  const tweetLink = createTweetLink({
+    url: 'https://standwithcrypto.org',
+    message: `${getUSStateNameFromStateCode(state)} just scored a HUGE win for crypto! The state is dropping its staking case against Coinbase, which means YOU can soon stake your crypto freely. Repost and spread the word: https://standwithcrypto.org/tweet/case-dismissed/${state}\n\n`,
+  })
+
+  return NextResponse.redirect(tweetLink)
+}

--- a/src/app/api/public/x-redirect/[state]/route.ts
+++ b/src/app/api/public/x-redirect/[state]/route.ts
@@ -3,11 +3,8 @@ import 'server-only'
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 
-import { createTweetLink } from '@/utils/web/createTweetLink'
 import { getUSStateNameFromStateCode } from '@/utils/shared/usStateUtils'
-
-export const revalidate = 60 * 60 * 24
-export const dynamic = 'error'
+import { createTweetLink } from '@/utils/web/createTweetLink'
 
 const zodParams = z.object({
   state: z.string().length(2),

--- a/src/app/api/public/x-redirect/[state]/route.ts
+++ b/src/app/api/public/x-redirect/[state]/route.ts
@@ -10,13 +10,12 @@ const zodParams = z.object({
   state: z.string().length(2),
 })
 
-export async function GET(_request: NextRequest, props: { params: Promise<{ state: string }> }) {
+export async function GET(_: NextRequest, props: { params: Promise<{ state: string }> }) {
   const params = await props.params
   const { state } = zodParams.parse(params)
 
   const tweetLink = createTweetLink({
-    url: 'https://standwithcrypto.org',
-    message: `${getUSStateNameFromStateCode(state)} just scored a HUGE win for crypto! The state is dropping its staking case against Coinbase, which means YOU can soon stake your crypto freely. Repost and spread the word: https://standwithcrypto.org/tweet/case-dismissed/${state}\n\n`,
+    message: `${getUSStateNameFromStateCode(state)} just scored a HUGE win for crypto! The state is dropping its staking case against Coinbase, which means YOU can soon stake your crypto freely. Click here to spread the word: https://standwithcrypto.org/tweet/case-dismissed/${state}\n`,
   })
 
   return NextResponse.redirect(tweetLink)

--- a/src/app/api/public/x-redirect/[state]/route.ts
+++ b/src/app/api/public/x-redirect/[state]/route.ts
@@ -15,6 +15,7 @@ export async function GET(_: NextRequest, props: { params: Promise<{ state: stri
   const { state } = zodParams.parse(params)
 
   const tweetLink = createTweetLink({
+    url: 'https://standwithcrypto.org',
     message: `${getUSStateNameFromStateCode(state)} just scored a HUGE win for crypto! The state is dropping its staking case against Coinbase, which means YOU can soon stake your crypto freely. Click here to spread the word: https://standwithcrypto.org/tweet/case-dismissed/${state}\n`,
   })
 

--- a/src/app/api/public/x-redirect/[state]/route.ts
+++ b/src/app/api/public/x-redirect/[state]/route.ts
@@ -16,8 +16,7 @@ export async function GET(_: NextRequest, props: { params: Promise<{ state: stri
 
   const tweetLink = createTweetLink({
     url: 'https://standwithcrypto.org',
-    message: `${getUSStateNameFromStateCode(state)} just scored a HUGE win for crypto! The state is dropping its staking case against Coinbase, which means YOU can soon stake your crypto freely. Click here to spread the word: https://standwithcrypto.org/tweet/case-dismissed/${state}\n`,
+    message: `${getUSStateNameFromStateCode(state)} just scored a HUGE win for crypto! The state is dropping its staking case against Coinbase, which means people in the state can soon stake their crypto freely. Click here to applaud ${state.toUpperCase()} for a job well done: https://standwithcrypto.org/tweet/case-dismissed/${state}\n`,
   })
-
   return NextResponse.redirect(tweetLink)
 }

--- a/src/app/api/public/x-redirect/[state]/route.ts
+++ b/src/app/api/public/x-redirect/[state]/route.ts
@@ -16,7 +16,7 @@ export async function GET(_: NextRequest, props: { params: Promise<{ state: stri
 
   const tweetLink = createTweetLink({
     url: 'https://standwithcrypto.org',
-    message: `${getUSStateNameFromStateCode(state)} just scored a HUGE win for crypto! The state is dropping its staking case against Coinbase, which means people in the state can soon stake their crypto freely. Click here to applaud ${state.toUpperCase()} for a job well done: https://standwithcrypto.org/tweet/case-dismissed/${state}\n`,
+    message: `${getUSStateNameFromStateCode(state)} just scored a HUGE win for crypto! The state is dropping its staking case against Coinbase, which means people in the state can soon stake their crypto freely. Click here to applaud ${state.toUpperCase()} for a job well done: https://standwithcrypto.org/tweet/case-dismissed/${state}\n\n`,
   })
   return NextResponse.redirect(tweetLink)
 }


### PR DESCRIPTION
## What changed? Why?

This PR implements a direct product request to support a campaign in which they want to post a tweet that has a link that if someone clicks, redirects the user to also post the same tweet with the same link for other users. The idea is to create some sort of infinite loop where every tweet has a link for someone to post the same tweet.


## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
