### PR TITLE
feat: update founders data structure to include company name and URL

### DIFF
--- a/src/components/app/pageHome/common/foundersCarousel.tsx
+++ b/src/components/app/pageHome/common/foundersCarousel.tsx
@@ -22,7 +22,7 @@ export function FoundersCarousel({ founders }: { founders: SWCFounders | null })
             })}
             key={founder.data.name}
           >
-            <ExternalLink className="mb-5 block shadow-lg" href={founder.data.founderLink}>
+            <ExternalLink className="mb-5 block shadow-lg" href={founder.data.companyUrl}>
               <div className="flex flex-col">
                 <div className="relative h-72">
                   <NextImage
@@ -36,7 +36,7 @@ export function FoundersCarousel({ founders }: { founders: SWCFounders | null })
                 <div className="p-2 text-left sm:p-4">
                   <p className="text-md text-primary sm:text-lg">{founder.data.name}</p>
                   <p className="mt-2 text-xs text-gray-600 text-secondary-foreground sm:text-sm">
-                    {founder.data.at}
+                    {founder.data.companyName}
                   </p>
                 </div>
               </div>

--- a/src/utils/shared/zod/getSWCFounders.ts
+++ b/src/utils/shared/zod/getSWCFounders.ts
@@ -3,8 +3,8 @@ import { object, string, z } from 'zod'
 export const zodFoundersSchemaValidation = object({
   data: object({
     name: string(),
-    at: string(),
-    founderLink: string().url(),
+    companyName: string(),
+    companyUrl: string().url(),
     image: string().url(),
   }),
 })


### PR DESCRIPTION
## What changed? Why?

Renamed founders fields to `company` and `companyUrl`

## How has it been tested?

- [ ] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
