### PR TITLE
fix: politicians page static generation

### DIFF
--- a/src/app/[countryCode]/politicians/person/[dtsiSlug]/opengraph-image.tsx
+++ b/src/app/[countryCode]/politicians/person/[dtsiSlug]/opengraph-image.tsx
@@ -1,12 +1,13 @@
-import {
-  alt,
-  contentType,
-  dynamic,
-  generateOgImage,
-  runtime,
-  size,
-} from '@/components/app/pagePoliticianDetails/common/generateOgImage'
+import { generateOgImage } from '@/components/app/pagePoliticianDetails/common/generateOgImage'
 
-export { alt, contentType, dynamic, runtime, size }
+export const dynamic = 'error'
+export const runtime = 'edge'
+export const alt = 'Image of politician and their stance on crypto'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
 
 export default generateOgImage

--- a/src/app/[countryCode]/politicians/person/[dtsiSlug]/page.tsx
+++ b/src/app/[countryCode]/politicians/person/[dtsiSlug]/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   }
 }
 export async function generateStaticParams() {
-  const slugs = await queryDTSIAllPeopleSlugs().then(x =>
+  const slugs = await queryDTSIAllPeopleSlugs({ countryCode }).then(x =>
     x.people.map(({ slug: dtsiSlug }) => ({ dtsiSlug })),
   )
   if (toBool(process.env.MINIMIZE_PAGE_PRE_GENERATION)) {

--- a/src/app/[countryCode]/politicians/person/[dtsiSlug]/twitter-image.tsx
+++ b/src/app/[countryCode]/politicians/person/[dtsiSlug]/twitter-image.tsx
@@ -1,12 +1,13 @@
-import {
-  alt,
-  contentType,
-  dynamic,
-  generateOgImage,
-  runtime,
-  size,
-} from '@/components/app/pagePoliticianDetails/common/generateOgImage'
+import { generateOgImage } from '@/components/app/pagePoliticianDetails/common/generateOgImage'
 
-export { alt, contentType, dynamic, runtime, size }
+export const dynamic = 'error'
+export const runtime = 'edge'
+export const alt = 'Image of politician and their stance on crypto'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
 
 export default generateOgImage

--- a/src/app/au/politicians/person/[dtsiSlug]/opengraph-image.tsx
+++ b/src/app/au/politicians/person/[dtsiSlug]/opengraph-image.tsx
@@ -1,12 +1,13 @@
-import {
-  alt,
-  contentType,
-  dynamic,
-  generateOgImage,
-  runtime,
-  size,
-} from '@/components/app/pagePoliticianDetails/common/generateOgImage'
+import { generateOgImage } from '@/components/app/pagePoliticianDetails/common/generateOgImage'
 
-export { alt, contentType, dynamic, runtime, size }
+export const dynamic = 'error'
+export const runtime = 'edge'
+export const alt = 'Image of politician and their stance on crypto'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
 
 export default generateOgImage

--- a/src/app/au/politicians/person/[dtsiSlug]/page.tsx
+++ b/src/app/au/politicians/person/[dtsiSlug]/page.tsx
@@ -7,11 +7,13 @@ import { getPoliticianDetailsPageDescription } from '@/components/app/pagePoliti
 import { queryDTSIAllPeopleSlugs } from '@/data/dtsi/queries/queryDTSIAllPeopleSlugs'
 import { PageProps } from '@/types'
 import { dtsiPersonFullName } from '@/utils/dtsi/dtsiPersonUtils'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { toBool } from '@/utils/shared/toBool'
 
 export const revalidate = 86400 // 1 day
 export const dynamic = 'error'
 export const dynamicParams = true
+const countryCode = SupportedCountryCodes.AU
 
 type Props = PageProps<{ dtsiSlug: string }>
 
@@ -27,7 +29,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   }
 }
 export async function generateStaticParams() {
-  const slugs = await queryDTSIAllPeopleSlugs().then(x =>
+  const slugs = await queryDTSIAllPeopleSlugs({ countryCode }).then(x =>
     x.people.map(({ slug: dtsiSlug }) => ({ dtsiSlug })),
   )
   if (toBool(process.env.MINIMIZE_PAGE_PRE_GENERATION)) {

--- a/src/app/au/politicians/person/[dtsiSlug]/twitter-image.tsx
+++ b/src/app/au/politicians/person/[dtsiSlug]/twitter-image.tsx
@@ -1,12 +1,13 @@
-import {
-  alt,
-  contentType,
-  dynamic,
-  generateOgImage,
-  runtime,
-  size,
-} from '@/components/app/pagePoliticianDetails/common/generateOgImage'
+import { generateOgImage } from '@/components/app/pagePoliticianDetails/common/generateOgImage'
 
-export { alt, contentType, dynamic, runtime, size }
+export const dynamic = 'error'
+export const runtime = 'edge'
+export const alt = 'Image of politician and their stance on crypto'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
 
 export default generateOgImage

--- a/src/app/ca/politicians/person/[dtsiSlug]/opengraph-image.tsx
+++ b/src/app/ca/politicians/person/[dtsiSlug]/opengraph-image.tsx
@@ -1,12 +1,13 @@
-import {
-  alt,
-  contentType,
-  dynamic,
-  generateOgImage,
-  runtime,
-  size,
-} from '@/components/app/pagePoliticianDetails/common/generateOgImage'
+import { generateOgImage } from '@/components/app/pagePoliticianDetails/common/generateOgImage'
 
-export { alt, contentType, dynamic, runtime, size }
+export const dynamic = 'error'
+export const runtime = 'edge'
+export const alt = 'Image of politician and their stance on crypto'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
 
 export default generateOgImage

--- a/src/app/ca/politicians/person/[dtsiSlug]/page.tsx
+++ b/src/app/ca/politicians/person/[dtsiSlug]/page.tsx
@@ -7,11 +7,13 @@ import { getPoliticianDetailsPageDescription } from '@/components/app/pagePoliti
 import { queryDTSIAllPeopleSlugs } from '@/data/dtsi/queries/queryDTSIAllPeopleSlugs'
 import { PageProps } from '@/types'
 import { dtsiPersonFullName } from '@/utils/dtsi/dtsiPersonUtils'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { toBool } from '@/utils/shared/toBool'
 
 export const revalidate = 86400 // 1 day
 export const dynamic = 'error'
 export const dynamicParams = true
+const countryCode = SupportedCountryCodes.CA
 
 type Props = PageProps<{ dtsiSlug: string }>
 
@@ -27,7 +29,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   }
 }
 export async function generateStaticParams() {
-  const slugs = await queryDTSIAllPeopleSlugs().then(x =>
+  const slugs = await queryDTSIAllPeopleSlugs({ countryCode }).then(x =>
     x.people.map(({ slug: dtsiSlug }) => ({ dtsiSlug })),
   )
   if (toBool(process.env.MINIMIZE_PAGE_PRE_GENERATION)) {

--- a/src/app/ca/politicians/person/[dtsiSlug]/twitter-image.tsx
+++ b/src/app/ca/politicians/person/[dtsiSlug]/twitter-image.tsx
@@ -1,12 +1,13 @@
-import {
-  alt,
-  contentType,
-  dynamic,
-  generateOgImage,
-  runtime,
-  size,
-} from '@/components/app/pagePoliticianDetails/common/generateOgImage'
+import { generateOgImage } from '@/components/app/pagePoliticianDetails/common/generateOgImage'
 
-export { alt, contentType, dynamic, runtime, size }
+export const dynamic = 'error'
+export const runtime = 'edge'
+export const alt = 'Image of politician and their stance on crypto'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
 
 export default generateOgImage

--- a/src/app/gb/politicians/person/[dtsiSlug]/opengraph-image.tsx
+++ b/src/app/gb/politicians/person/[dtsiSlug]/opengraph-image.tsx
@@ -1,12 +1,13 @@
-import {
-  alt,
-  contentType,
-  dynamic,
-  generateOgImage,
-  runtime,
-  size,
-} from '@/components/app/pagePoliticianDetails/common/generateOgImage'
+import { generateOgImage } from '@/components/app/pagePoliticianDetails/common/generateOgImage'
 
-export { alt, contentType, dynamic, runtime, size }
+export const dynamic = 'error'
+export const runtime = 'edge'
+export const alt = 'Image of politician and their stance on crypto'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
 
 export default generateOgImage

--- a/src/app/gb/politicians/person/[dtsiSlug]/page.tsx
+++ b/src/app/gb/politicians/person/[dtsiSlug]/page.tsx
@@ -7,11 +7,13 @@ import { GbPagePoliticianDetails } from '@/components/app/pagePoliticianDetails/
 import { queryDTSIAllPeopleSlugs } from '@/data/dtsi/queries/queryDTSIAllPeopleSlugs'
 import { PageProps } from '@/types'
 import { dtsiPersonFullName } from '@/utils/dtsi/dtsiPersonUtils'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { toBool } from '@/utils/shared/toBool'
 
 export const revalidate = 86400 // 1 day
 export const dynamic = 'error'
 export const dynamicParams = true
+const countryCode = SupportedCountryCodes.GB
 
 type Props = PageProps<{ dtsiSlug: string }>
 
@@ -27,7 +29,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   }
 }
 export async function generateStaticParams() {
-  const slugs = await queryDTSIAllPeopleSlugs().then(x =>
+  const slugs = await queryDTSIAllPeopleSlugs({ countryCode }).then(x =>
     x.people.map(({ slug: dtsiSlug }) => ({ dtsiSlug })),
   )
   if (toBool(process.env.MINIMIZE_PAGE_PRE_GENERATION)) {

--- a/src/app/gb/politicians/person/[dtsiSlug]/twitter-image.tsx
+++ b/src/app/gb/politicians/person/[dtsiSlug]/twitter-image.tsx
@@ -1,12 +1,13 @@
-import {
-  alt,
-  contentType,
-  dynamic,
-  generateOgImage,
-  runtime,
-  size,
-} from '@/components/app/pagePoliticianDetails/common/generateOgImage'
+import { generateOgImage } from '@/components/app/pagePoliticianDetails/common/generateOgImage'
 
-export { alt, contentType, dynamic, runtime, size }
+export const dynamic = 'error'
+export const runtime = 'edge'
+export const alt = 'Image of politician and their stance on crypto'
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
 
 export default generateOgImage

--- a/src/bin/oneTimeScripts/detectAndRemoveInvalidDTSISlugs.ts
+++ b/src/bin/oneTimeScripts/detectAndRemoveInvalidDTSISlugs.ts
@@ -2,6 +2,7 @@ import { runBin } from '@/bin/runBin'
 import { queryDTSIAllPeopleSlugs } from '@/data/dtsi/queries/queryDTSIAllPeopleSlugs'
 import { prismaClient } from '@/utils/server/prismaClient'
 import { getLogger } from '@/utils/shared/logger'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 const logger = getLogger('bin:oneTimeScripts:detectAndRemoveInvalidDTSISlugs')
 
@@ -14,9 +15,18 @@ async function run() {
 
   logger.info('Querying all DTSI slugs')
 
-  const allSlugs = await queryDTSIAllPeopleSlugs()
+  const allUSSlugs = await queryDTSIAllPeopleSlugs({ countryCode: SupportedCountryCodes.US })
+  const allCASlugs = await queryDTSIAllPeopleSlugs({ countryCode: SupportedCountryCodes.CA })
+  const allGBSlugs = await queryDTSIAllPeopleSlugs({ countryCode: SupportedCountryCodes.GB })
+  const allAUSlugs = await queryDTSIAllPeopleSlugs({ countryCode: SupportedCountryCodes.AU })
+  const allSlugs = [
+    ...(allUSSlugs.people || []),
+    ...(allCASlugs.people || []),
+    ...(allGBSlugs.people || []),
+    ...(allAUSlugs.people || []),
+  ]
 
-  const slugs = allSlugs.people.map(({ slug }) => slug)
+  const slugs = allSlugs.map(({ slug }) => slug)
 
   logger.info(`Found ${slugs.length} slugs`)
 

--- a/src/components/app/pagePoliticianDetails/common/generateOgImage.tsx
+++ b/src/components/app/pagePoliticianDetails/common/generateOgImage.tsx
@@ -10,16 +10,6 @@ import {
 } from '@/utils/dtsi/dtsiStanceScoreUtils'
 import { OPEN_GRAPH_IMAGE_DIMENSIONS } from '@/utils/server/generateOpenGraphImageUrl'
 
-export const dynamic = 'error'
-export const runtime = 'edge'
-export const alt = 'Image of politician and their stance on crypto'
-export const size = {
-  width: 1200,
-  height: 630,
-}
-
-export const contentType = 'image/png'
-
 export async function generateOgImage({ params }: { params: { dtsiSlug: string } }) {
   const person = await getPoliticianDetailsData(params.dtsiSlug)
   const shieldData = await fetch(new URL('./images/shield.png', import.meta.url)).then(res =>

--- a/src/data/dtsi/queries/queryDTSIAllPeopleSlugs.ts
+++ b/src/data/dtsi/queries/queryDTSIAllPeopleSlugs.ts
@@ -2,24 +2,12 @@ import * as Sentry from '@sentry/nextjs'
 
 import { fetchDTSI } from '@/data/dtsi/fetchDTSI'
 import { DTSI_AllPeopleSlugsQuery, DTSI_AllPeopleSlugsQueryVariables } from '@/data/dtsi/generated'
+import { PERSON_ROLE_GROUPINGS_FOR_ALL_PEOPLE_QUERY } from '@/data/dtsi/queries/constants'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 const query = /* GraphQL */ `
-  query AllPeopleSlugs {
-    people(
-      limit: 1500
-      offset: 0
-      personRoleGroupingOr: [
-        CURRENT_US_HOUSE_OF_REPS
-        CURRENT_US_SENATE
-        US_PRESIDENT
-        RUNNING_FOR_PRESIDENT
-        RUNNING_FOR_US_HOUSE_OF_REPS
-        RUNNING_FOR_US_SENATE
-        NEXT_PRESIDENT
-        NEXT_US_HOUSE_OF_REPS
-        NEXT_US_SENATE
-      ]
-    ) {
+  query AllPeopleSlugs($personRoleGroupingOr: [PersonGrouping!]) {
+    people(limit: 1500, offset: 0, personRoleGroupingOr: $personRoleGroupingOr) {
       slug
     }
   }
@@ -27,9 +15,16 @@ const query = /* GraphQL */ `
 /*
 Because this request returns so many results, we should ensure we're only triggering this logic in cached endpoints/routes
 */
-export const queryDTSIAllPeopleSlugs = async () => {
+export const queryDTSIAllPeopleSlugs = async ({
+  countryCode,
+}: {
+  countryCode: SupportedCountryCodes
+}) => {
   const results = await fetchDTSI<DTSI_AllPeopleSlugsQuery, DTSI_AllPeopleSlugsQueryVariables>(
     query,
+    {
+      personRoleGroupingOr: PERSON_ROLE_GROUPINGS_FOR_ALL_PEOPLE_QUERY[countryCode],
+    },
   )
   if (results.people.length === 1500) {
     Sentry.captureMessage(


### PR DESCRIPTION
## What changed? Why?

This PR fixes the issue of builder politician detail pages that would never exist in a specific country.

![image](https://github.com/user-attachments/assets/b42288fd-51dd-4465-9943-b6c38692031f)

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
