### PR TITLE
Fix REFER action analytics

### DIFF
--- a/src/utils/server/referral/triggerReferralSteps.ts
+++ b/src/utils/server/referral/triggerReferralSteps.ts
@@ -52,8 +52,7 @@ export function triggerReferralSteps({
   after(async () => {
     const result = await actionCreateUserActionReferral({
       referralId,
-      userId: newUser.id,
-      localUser,
+      newUserId: newUser.id,
     })
 
     if (result.errors) return

--- a/src/utils/server/serverLocalUser.ts
+++ b/src/utils/server/serverLocalUser.ts
@@ -57,6 +57,7 @@ export function getLocalUserFromUser(user: User): ServerLocalUser {
 
 export function mapLocalUserToUserDatabaseFields(
   localUser: ServerLocalUser | null,
+  searchParams?: Record<string, string>,
 ): Pick<
   User,
   | 'acquisitionReferer'
@@ -69,14 +70,17 @@ export function mapLocalUserToUserDatabaseFields(
     // We are trimming the char input in case it is greater than the DB limit (191 characters)
     acquisitionReferer: localUser?.persisted?.initialReferer?.slice(0, 191) || '',
     acquisitionSource:
+      searchParams?.utm_source?.slice(0, 191) ||
       localUser?.persisted?.initialSearchParams.utm_source?.slice(0, 191) ||
       localUser?.currentSession.searchParamsOnLoad.utm_source?.slice(0, 191) ||
       '',
     acquisitionMedium:
+      searchParams?.utm_medium?.slice(0, 191) ||
       localUser?.persisted?.initialSearchParams.utm_medium?.slice(0, 191) ||
       localUser?.currentSession.searchParamsOnLoad.utm_medium?.slice(0, 191) ||
       '',
     acquisitionCampaign:
+      searchParams?.utm_campaign?.slice(0, 191) ||
       localUser?.persisted?.initialSearchParams.utm_campaign?.slice(0, 191) ||
       localUser?.currentSession.searchParamsOnLoad.utm_campaign?.slice(0, 191) ||
       '',

--- a/src/utils/server/thirdweb/onLogin.ts
+++ b/src/utils/server/thirdweb/onLogin.ts
@@ -380,6 +380,7 @@ export async function onNewLogin(props: NewLoginParams) {
       hasSignedInWithEmail,
       sessionId: await props.getUserSessionId(),
       countryCode,
+      searchParams,
     }).catch(error => {
       log(
         `createUser: error creating user\n ${JSON.stringify(
@@ -610,11 +611,13 @@ async function createUser({
   hasSignedInWithEmail,
   sessionId,
   countryCode,
+  searchParams,
 }: {
   localUser: ServerLocalUser | null
   hasSignedInWithEmail: boolean
   sessionId: string | null
   countryCode: string
+  searchParams: Record<string, string>
 }) {
   return prismaClient.user.create({
     include: {
@@ -630,7 +633,7 @@ async function createUser({
       smsStatus: SMSStatus.NOT_OPTED_IN,
       referralId: generateReferralId(),
       userSessions: { create: { id: sessionId ?? undefined } },
-      ...mapLocalUserToUserDatabaseFields(localUser),
+      ...mapLocalUserToUserDatabaseFields(localUser, searchParams),
       countryCode,
     },
   })


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

- Added `searchParams` to `mapLocalUserToUserDatabaseFields`
  - When a User follows a referral link, `triggerReferralSteps` detects the referral and correctly creates/increments the Referrer's REFER action, but the new User might not get properly attributed with referral acquisition parameters (acquisitionSource, acquisitionMedium, acquisitionCampaign) due to `mapLocalUserToUserDatabaseFields` only extracting the data from the `localUser` (which might not have it). 
- Bind the analytics events to the Referrer
  - Currently the REFER action creation events are being incorrectly attributed to the newly created User instead of the Referrer

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

1. ✅ REFER actions are correctly created and attributed to right Referrer
2. ⚠️ Mixpanel events `User Action Created` for `REFER` are attributed to the wrong User

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
