### PR TITLE
fix: join success dialog not closing after clicking on action CTA

### DIFF
--- a/src/components/app/userActionFormJoinSWC/successDialog.tsx
+++ b/src/components/app/userActionFormJoinSWC/successDialog.tsx
@@ -7,6 +7,7 @@ import { UserActionFormSuccessScreenNextActionSkeleton } from '@/components/app/
 import { Dialog, DialogContent, DialogProps } from '@/components/ui/dialog'
 import { useApiResponseForUserPerformedUserActionTypes } from '@/hooks/useApiResponseForUserPerformedUserActionTypes'
 import { useSession } from '@/hooks/useSession'
+import { SWCSuccessDialogContext } from '@/hooks/useSuccessScreenDialogContext'
 
 const UserActionFormJoinSWCSuccess = dynamic(
   () =>
@@ -39,23 +40,27 @@ export function UserActionFormJoinSWCSuccessDialog(props: UserActionFormJoinSWCS
   const performedUserActionTypes = performedUserActionTypesResponse.data?.performedUserActionTypes
 
   return (
-    <Dialog {...dialogProps}>
-      <DialogContent a11yTitle="Joined Stand With Crypto" className="max-w-3xl">
-        <div className="space-y-6">
-          <UserActionFormJoinSWCSuccess />
+    <SWCSuccessDialogContext.Provider
+      value={{ onCtaClick: () => dialogProps?.onOpenChange?.(false) }}
+    >
+      <Dialog {...dialogProps}>
+        <DialogContent a11yTitle="Joined Stand With Crypto" className="max-w-3xl">
+          <div className="space-y-6">
+            <UserActionFormJoinSWCSuccess />
 
-          {session.isLoading || !session.user || performedUserActionTypesResponse.isLoading ? (
-            <UserActionFormSuccessScreenNextActionSkeleton />
-          ) : (
-            <UserActionFormSuccessScreenNextAction
-              data={{
-                userHasEmbeddedWallet: session.user.hasEmbeddedWallet,
-                performedUserActionTypes: performedUserActionTypes || [],
-              }}
-            />
-          )}
-        </div>
-      </DialogContent>
-    </Dialog>
+            {session.isLoading || !session.user || performedUserActionTypesResponse.isLoading ? (
+              <UserActionFormSuccessScreenNextActionSkeleton />
+            ) : (
+              <UserActionFormSuccessScreenNextAction
+                data={{
+                  userHasEmbeddedWallet: session.user.hasEmbeddedWallet,
+                  performedUserActionTypes: performedUserActionTypes || [],
+                }}
+              />
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </SWCSuccessDialogContext.Provider>
   )
 }

--- a/src/components/app/userActionGridCTAs/components/successScreenActionCard.tsx
+++ b/src/components/app/userActionGridCTAs/components/successScreenActionCard.tsx
@@ -1,6 +1,7 @@
 import { CheckIcon } from '@/components/app/userActionGridCTAs/icons/checkIcon'
 import { UserActionCardProps } from '@/components/app/userActionGridCTAs/types'
 import { NextImage } from '@/components/ui/image'
+import { useSuccessScreenDialogContext } from '@/hooks/useSuccessScreenDialogContext'
 import { cn } from '@/utils/web/cn'
 
 export function SuccessScreenActionCard({
@@ -14,8 +15,11 @@ export function SuccessScreenActionCard({
   mobileCTADescription,
   link: _link,
   campaignsModalDescription: _campaignsModalDescription,
+  onClick: _onClick,
   ...rest
 }: Omit<UserActionCardProps, 'WrapperComponent'>) {
+  const { onCtaClick } = useSuccessScreenDialogContext()
+
   const isReadOnly = campaigns.every(
     campaign =>
       !campaign.canBeTriggeredMultipleTimes &&
@@ -37,6 +41,10 @@ export function SuccessScreenActionCard({
         'flex w-full cursor-pointer flex-row-reverse items-stretch rounded-3xl transition-shadow hover:shadow-lg',
         isReadOnly && 'pointer-events-none cursor-default',
       )}
+      onClick={() => {
+        _onClick?.()
+        onCtaClick?.()
+      }}
     >
       <div className="flex h-auto min-h-36 min-w-32 max-w-32 items-center justify-center rounded-br-3xl rounded-tr-3xl bg-[radial-gradient(74.32%_74.32%_at_50.00%_50.00%,#F0E8FF_8.5%,#6B28FF_89%)] px-5 py-9">
         <NextImage alt={title} height={80} objectFit="contain" src={image} width={80} />

--- a/src/components/app/userActionGridCTAs/types/index.ts
+++ b/src/components/app/userActionGridCTAs/types/index.ts
@@ -69,4 +69,5 @@ export interface UserActionCardProps {
   campaigns: Array<UserActionGridCTACampaign>
   link?: (args: { children: React.ReactNode }) => React.ReactNode
   performedUserActions: Record<string, any>
+  onClick?: () => void
 }

--- a/src/hooks/useSuccessScreenDialogContext.ts
+++ b/src/hooks/useSuccessScreenDialogContext.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from 'react'
+
+export const SWCSuccessDialogContext = createContext<{
+  onCtaClick: () => void
+}>({
+  onCtaClick: () => {},
+})
+
+export function useSuccessScreenDialogContext() {
+  return useContext(SWCSuccessDialogContext)
+}


### PR DESCRIPTION
closes #2117 

## What changed? Why?

This PR fixes an issue where after a user joins SWC, if the user clicks on any of the success dialog next actions, the page is redirected to the corresponding action url, but the success dialog stays open as it is rendered in the navbar.

The approach here was to pass the onChange prop down to the CTA card itself. I decided to use a context to prevent prop drilling inside this dialog as we would need to pass this prop down to 5/6 components to reach the CTA card itself.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
