### PR TITLE
redirects for upcoming advertising banners

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -290,6 +290,16 @@ const nextConfig: NextConfig = {
         destination: '/action/nft-mint',
         permanent: true,
       },
+      {
+        source: '/australia',
+        destination: 'https://au.standwithcrypto.org',
+        permanent: false,
+      },
+      {
+        source: '/canada',
+        destination: 'https://ca.standwithcrypto.org',
+        permanent: false,
+      },
       // vanity urls
       {
         source: '/join/:referralId',


### PR DESCRIPTION
Want to ensure that non of the international team's advertising breaks if we need to wait to merge international work.

