### PR TITLE
fix: AU politicians role filter

### DIFF
--- a/src/components/app/dtsiClientPersonDataTable/au/filters.ts
+++ b/src/components/app/dtsiClientPersonDataTable/au/filters.ts
@@ -110,7 +110,7 @@ export function getPartyOptionDisplayName(party: string) {
 
 export const ROLE_OPTIONS = {
   ALL: 'All',
-  HOUSE_OF_COMMONS: DTSI_PersonRoleCategory.HOUSE_OF_COMMONS,
+  HOUSE_OF_COMMONS: DTSI_PersonRoleCategory.CONGRESS,
   ALL_OTHER: 'ALL_OTHER',
 }
 export function getRoleOptionDisplayName(role: string) {


### PR DESCRIPTION
## What changed? Why?

This PR fixes the AU politicians role filtering by changing the filter value that is send to DTSI

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
