### PR TITLE
refactor: enhance GeoGate component

### DIFF
--- a/cypress/e2e/03-page-politicians.cy.ts
+++ b/cypress/e2e/03-page-politicians.cy.ts
@@ -20,11 +20,11 @@ it('page - politicians interactions', () => {
   cy.get('[data-testid="state-filter-trigger"]').as('stateFilterTrigger').scrollIntoView()
   cy.get('@stateFilterTrigger').should('be.visible')
   cy.get('@stateFilterTrigger').click()
-  cy.get('[role="option"]').contains('div', 'AK').as('stateOption')
+  cy.get('[role="option"]').contains('div', 'Alaska').as('stateOption')
   cy.get('@stateOption').should('be.visible').click({
     // force: true // Bypass visibility checks, not ideal
   })
-  cy.get('@stateFilterTrigger').children().should('contain', 'AK')
+  cy.get('@stateFilterTrigger').children().should('contain', 'Alaska')
   // cy.get('tbody').find('tr').should('have.length', 4)
   cy.get('tbody')
     .find('td:nth-child(4)')

--- a/src/components/app/geoGate.test.tsx
+++ b/src/components/app/geoGate.test.tsx
@@ -6,7 +6,21 @@ import { describe, expect, it } from '@jest/globals'
 import { render } from '@testing-library/react'
 
 import { GeoGate } from '@/components/app/geoGate'
+// Import the mocked hook
+import { useSession } from '@/hooks/useSession'
 import { USER_ACCESS_LOCATION_COOKIE_NAME } from '@/utils/shared/userAccessLocation'
+
+// Mock the useSession hook
+jest.mock('@/hooks/useSession', () => ({
+  useSession: jest.fn().mockReturnValue({
+    isLoading: false,
+    isUserProfileLoading: false,
+    isLoggedIn: false,
+    isLoggedInThirdweb: false,
+    user: null,
+    hasOptInUserAction: false,
+  }),
+}))
 
 const BlockedContent = (_?: any) => <h1>Blocked</h1>
 const AllowedContent = (_?: any) => <h1>Allowed</h1>
@@ -14,38 +28,60 @@ const AllowedContent = (_?: any) => <h1>Allowed</h1>
 // there are cases where users in the US are getting blocked if they are close to the US border so we want to be more permissive with Canada
 describe('GeoGate', () => {
   it.each`
-    countryCode | accessLocation | expectedContent
-    ${'us'}     | ${'us'}        | ${'Allowed'}
-    ${'us'}     | ${'br'}        | ${'Blocked'}
-    ${'us'}     | ${'au'}        | ${'Blocked'}
-    ${'us'}     | ${'ca'}        | ${'Allowed'}
-    ${'us'}     | ${'gb'}        | ${'Blocked'}
-    ${'ca'}     | ${'ca'}        | ${'Allowed'}
-    ${'ca'}     | ${'us'}        | ${'Blocked'}
-    ${'ca'}     | ${'br'}        | ${'Blocked'}
-    ${'ca'}     | ${'au'}        | ${'Blocked'}
-    ${'ca'}     | ${'gb'}        | ${'Blocked'}
-    ${'au'}     | ${'au'}        | ${'Allowed'}
-    ${'au'}     | ${'us'}        | ${'Blocked'}
-    ${'au'}     | ${'br'}        | ${'Blocked'}
-    ${'au'}     | ${'ca'}        | ${'Blocked'}
-    ${'au'}     | ${'gb'}        | ${'Blocked'}
-    ${'gb'}     | ${'gb'}        | ${'Allowed'}
-    ${'gb'}     | ${'us'}        | ${'Blocked'}
-    ${'gb'}     | ${'br'}        | ${'Blocked'}
-    ${'gb'}     | ${'ca'}        | ${'Blocked'}
-    ${'gb'}     | ${'au'}        | ${'Blocked'}
+    pageCountryCode | accessLocation | userCountryCode | expectedContent
+    ${'us'}         | ${'us'}        | ${'logged-out'} | ${'Allowed'}
+    ${'us'}         | ${'br'}        | ${'logged-out'} | ${'Blocked'}
+    ${'us'}         | ${'au'}        | ${'logged-out'} | ${'Blocked'}
+    ${'us'}         | ${'ca'}        | ${'logged-out'} | ${'Allowed'}
+    ${'us'}         | ${'gb'}        | ${'logged-out'} | ${'Blocked'}
+    ${'ca'}         | ${'ca'}        | ${'logged-out'} | ${'Allowed'}
+    ${'ca'}         | ${'us'}        | ${'logged-out'} | ${'Blocked'}
+    ${'ca'}         | ${'br'}        | ${'logged-out'} | ${'Blocked'}
+    ${'ca'}         | ${'au'}        | ${'logged-out'} | ${'Blocked'}
+    ${'ca'}         | ${'gb'}        | ${'logged-out'} | ${'Blocked'}
+    ${'au'}         | ${'au'}        | ${'logged-out'} | ${'Allowed'}
+    ${'au'}         | ${'us'}        | ${'logged-out'} | ${'Blocked'}
+    ${'au'}         | ${'br'}        | ${'logged-out'} | ${'Blocked'}
+    ${'au'}         | ${'ca'}        | ${'logged-out'} | ${'Blocked'}
+    ${'au'}         | ${'gb'}        | ${'logged-out'} | ${'Blocked'}
+    ${'gb'}         | ${'gb'}        | ${'logged-out'} | ${'Allowed'}
+    ${'gb'}         | ${'us'}        | ${'logged-out'} | ${'Blocked'}
+    ${'gb'}         | ${'br'}        | ${'logged-out'} | ${'Blocked'}
+    ${'gb'}         | ${'ca'}        | ${'logged-out'} | ${'Blocked'}
+    ${'gb'}         | ${'au'}        | ${'logged-out'} | ${'Blocked'}
+    ${'us'}         | ${'us'}        | ${'gb'}         | ${'Blocked'}
+    ${'us'}         | ${'us'}        | ${'us'}         | ${'Allowed'}
+    ${'us'}         | ${'us'}        | ${'ca'}         | ${'Allowed'}
+    ${'gb'}         | ${'gb'}        | ${'us'}         | ${'Blocked'}
+    ${'gb'}         | ${'gb'}        | ${'gb'}         | ${'Allowed'}
+    ${'ca'}         | ${'ca'}        | ${'au'}         | ${'Blocked'}
+    ${'ca'}         | ${'ca'}        | ${'ca'}         | ${'Allowed'}
+    ${'au'}         | ${'au'}        | ${'us'}         | ${'Blocked'}
+    ${'au'}         | ${'au'}        | ${'au'}         | ${'Allowed'}
   `(
-    'returns $expectedContent for countryCode: $countryCode and accessLocation: $accessLocation',
+    'returns $expectedContent for pageCountryCode: $pageCountryCode, accessLocation: $accessLocation, userCountryCode: $userCountryCode',
     (arg: Record<string, string>) => {
-      const { countryCode, accessLocation, expectedContent } = arg
+      const { pageCountryCode, accessLocation, expectedContent, userCountryCode } = arg
+
+      if (userCountryCode !== 'logged-out') {
+        const mockUseSession = useSession as jest.Mock
+        mockUseSession.mockReturnValue({
+          isLoading: false,
+          isUserProfileLoading: false,
+          isLoggedIn: true,
+          isLoggedInThirdweb: true,
+          user: { countryCode: userCountryCode },
+          hasOptInUserAction: true,
+        })
+      }
+
       Object.defineProperty(window.document, 'cookie', {
         writable: true,
         value: `${USER_ACCESS_LOCATION_COOKIE_NAME}=${accessLocation}`,
       })
 
       const { queryByText } = render(
-        <GeoGate countryCode={countryCode} unavailableContent={<BlockedContent />}>
+        <GeoGate countryCode={pageCountryCode} unavailableContent={<BlockedContent />}>
           <AllowedContent />
         </GeoGate>,
       )


### PR DESCRIPTION
## What changed? Why?

This PR updates the GeoGate logic to also compare the user.countryCode with the access location and the page country code to decide if the user is allowed to access the content or not.

This is needed because of the following scenario: A US user is traveling to UK. Upon reaching GB, the user tries to open the SWC website (redirected to GB if the access location cookie is not set anymore). The user sign in to SWC and while being an US account, the user won't be able to complete actions in the US but would be available to complete actions in the UK.

This PR fixes that by adding user.countryCode to the comparison


## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
