### PR TITLE
feat: adds access location override on login

### DIFF
--- a/src/utils/server/thirdweb/onLogin.ts
+++ b/src/utils/server/thirdweb/onLogin.ts
@@ -56,8 +56,15 @@ import { mapPersistedLocalUserToAnalyticsProperties } from '@/utils/shared/local
 import { logger } from '@/utils/shared/logger'
 import { prettyLog } from '@/utils/shared/prettyLog'
 import { generateReferralId } from '@/utils/shared/referralId'
-import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import {
+  COUNTRY_CODE_REGEX_PATTERN,
+  SupportedCountryCodes,
+} from '@/utils/shared/supportedCountries'
 import { THIRDWEB_AUTH_TOKEN_COOKIE_PREFIX } from '@/utils/shared/thirdwebAuthToken'
+import {
+  OVERRIDE_USER_ACCESS_LOCATION_COOKIE_NAME,
+  USER_ACCESS_LOCATION_COOKIE_NAME,
+} from '@/utils/shared/userAccessLocation'
 import { UserActionOptInCampaignName } from '@/utils/shared/userActionCampaigns/common'
 import { COUNTRY_USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP } from '@/utils/shared/userActionCampaigns/index'
 
@@ -88,7 +95,10 @@ export async function login(
   const log = getLog(cryptoAddress)
 
   const existingVerifiedUser = await prismaClient.user.findFirst({
-    include: { userActions: { select: { actionType: true } } },
+    include: {
+      userActions: { select: { actionType: true } },
+      address: { select: { countryCode: true } },
+    },
     where: { userCryptoAddresses: { some: { cryptoAddress, hasBeenVerifiedViaAuth: true } } },
   })
 
@@ -123,6 +133,8 @@ export async function login(
     })
 
     currentCookies.set(THIRDWEB_AUTH_TOKEN_COOKIE_PREFIX, jwt)
+
+    await overrideAccessLocation({ user: existingVerifiedUser })
 
     return
   }
@@ -208,6 +220,25 @@ async function onExistingUserLogin({
     }
     log(`onExistingUserLogin: merging user ${userToDelete.user.id} into user ${userToKeepId}`)
     await mergeUsers({ persist: true, userToKeepId, userToDeleteId: userToDelete.user.id })
+  }
+}
+
+async function overrideAccessLocation({
+  user,
+}: {
+  user: User & { address: { countryCode: string | null } | null }
+}) {
+  const currentCookies = await cookies()
+  const accessLocationCookie = currentCookies.get(USER_ACCESS_LOCATION_COOKIE_NAME)?.value
+
+  const userAddressCountryCode = user?.address?.countryCode?.toLowerCase()
+  const shouldOverrideAccessLocation =
+    userAddressCountryCode &&
+    userAddressCountryCode !== accessLocationCookie &&
+    COUNTRY_CODE_REGEX_PATTERN.test(userAddressCountryCode)
+
+  if (shouldOverrideAccessLocation) {
+    currentCookies.set(OVERRIDE_USER_ACCESS_LOCATION_COOKIE_NAME, userAddressCountryCode)
   }
 }
 

--- a/src/utils/server/thirdweb/onLogout.ts
+++ b/src/utils/server/thirdweb/onLogout.ts
@@ -8,6 +8,7 @@ import { cookies } from 'next/headers'
 import { getServerAnalytics } from '@/utils/server/serverAnalytics'
 import { parseLocalUserFromCookies } from '@/utils/server/serverLocalUser'
 import { THIRDWEB_AUTH_TOKEN_COOKIE_PREFIX } from '@/utils/shared/thirdwebAuthToken'
+import { OVERRIDE_USER_ACCESS_LOCATION_COOKIE_NAME } from '@/utils/shared/userAccessLocation'
 
 export async function onLogout() {
   const currentCookies = await cookies()
@@ -31,5 +32,6 @@ export async function onLogout() {
     })
   } finally {
     currentCookies.delete(THIRDWEB_AUTH_TOKEN_COOKIE_PREFIX)
+    currentCookies.delete(OVERRIDE_USER_ACCESS_LOCATION_COOKIE_NAME)
   }
 }


### PR DESCRIPTION
## What changed? Why?

This PR implements logic to override the access location on login if the user has a saved address and the address.countryCode is different from the page they are currently visiting.

Ex: US user traveling to UK and visiting SWC on a new device. The user would be redirected to SWC UK and if the user tried to change to the US website, they would not be able to complete actions because access location would be `gb`. This PR fixes this by checking if the user has an address and compares the address country code with the access location country code. If it is different, we use the same access location override from the internal pages for the user.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
