### PR TITLE
feat: display politicalAffiliation on party column when affiliation category is OTHER

### DIFF
--- a/src/components/app/dtsiClientPersonDataTable/au/filters.ts
+++ b/src/components/app/dtsiClientPersonDataTable/au/filters.ts
@@ -89,6 +89,8 @@ export const PARTY_OPTIONS = {
   LIBERAL: DTSI_PersonPoliticalAffiliationCategory.LIBERAL,
   GREEN: DTSI_PersonPoliticalAffiliationCategory.GREEN,
   INDEPENDENT: DTSI_PersonPoliticalAffiliationCategory.INDEPENDENT,
+  NATIONALS: DTSI_PersonPoliticalAffiliationCategory.NATIONALS,
+  ONE_NATION: DTSI_PersonPoliticalAffiliationCategory.ONE_NATION,
   OTHER: DTSI_PersonPoliticalAffiliationCategory.OTHER,
 }
 export function getPartyOptionDisplayName(party: string) {
@@ -101,6 +103,10 @@ export function getPartyOptionDisplayName(party: string) {
       return 'Australian Greens'
     case PARTY_OPTIONS.INDEPENDENT:
       return 'Independent members of Parliament'
+    case PARTY_OPTIONS.NATIONALS:
+      return 'National Party'
+    case PARTY_OPTIONS.ONE_NATION:
+      return 'One Nation'
     case PARTY_OPTIONS.OTHER:
       return 'Other Parties'
     default:

--- a/src/components/app/dtsiClientPersonDataTable/common/columns.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/common/columns.tsx
@@ -8,6 +8,7 @@ import { SortableHeader } from '@/components/app/dtsiClientPersonDataTable/commo
 import { StanceHiddenCard } from '@/components/app/dtsiClientPersonDataTable/stanceHidden'
 import { InternalLink } from '@/components/ui/link'
 import { LinkBox, linkBoxLinkClassName } from '@/components/ui/linkBox'
+import { DTSI_PersonPoliticalAffiliationCategory } from '@/data/dtsi/generated'
 import { queryDTSIAllPeople } from '@/data/dtsi/queries/queryDTSIAllPeople'
 import { getDTSIPersonRoleCategoryDisplayName } from '@/utils/dtsi/dtsiPersonRoleUtils'
 import {
@@ -163,15 +164,25 @@ export const getDTSIClientPersonDataTableColumns = ({
       header: ({ column }) => {
         return <SortableHeader column={column}>Party</SortableHeader>
       },
-      cell: ({ row }) => (
-        <>
-          {row.original.politicalAffiliationCategory
-            ? dtsiPersonPoliticalAffiliationCategoryDisplayName(
-                row.original.politicalAffiliationCategory,
-              )
-            : '-'}
-        </>
-      ),
+      cell: ({ row }) => {
+        const shouldShowPartyName =
+          row.original.politicalAffiliationCategory ===
+          DTSI_PersonPoliticalAffiliationCategory.OTHER
+
+        if (shouldShowPartyName) {
+          return row.original.politicalAffiliation
+        }
+
+        return (
+          <>
+            {row.original.politicalAffiliationCategory
+              ? dtsiPersonPoliticalAffiliationCategoryDisplayName(
+                  row.original.politicalAffiliationCategory,
+                )
+              : '-'}
+          </>
+        )
+      },
     }),
   ]
 }

--- a/src/components/app/dtsiClientPersonDataTable/common/filters.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/common/filters.tsx
@@ -128,7 +128,7 @@ function GlobalFiltersPartySelect({
       }
       value={namedColumns?.[PERSON_TABLE_COLUMNS_IDS.PARTY]?.getFilterValue() as string}
     >
-      <SelectTrigger className="w-[120px] flex-shrink-0" data-testid="party-filter-trigger">
+      <SelectTrigger className="w-[144px] flex-shrink-0" data-testid="party-filter-trigger">
         <span className="mr-2 inline-block flex-shrink-0 font-bold">Party</span>
         <SelectValue />
       </SelectTrigger>

--- a/src/components/app/dtsiPersonHeroCard/dtsiPersonHeroCard.stories.tsx
+++ b/src/components/app/dtsiPersonHeroCard/dtsiPersonHeroCard.stories.tsx
@@ -21,6 +21,7 @@ const getDefaultProps = () => {
     lastName: 'Biden',
     firstNickname: 'Joe',
     nameSuffix: '',
+    politicalAffiliation: 'Democrat',
     politicalAffiliationCategory: DTSI_PersonPoliticalAffiliationCategory.DEMOCRAT,
     computedStanceScore: 0,
     computedSumStanceScoreWeight: 5,

--- a/src/data/dtsi/fragments/fragmentDTSIPersonCard.ts
+++ b/src/data/dtsi/fragments/fragmentDTSIPersonCard.ts
@@ -6,6 +6,7 @@ export const fragmentDTSIPersonCard = /* GraphQL */ `
     lastName
     firstNickname
     nameSuffix
+    politicalAffiliation
     politicalAffiliationCategory
     computedStanceScore
     computedSumStanceScoreWeight

--- a/src/data/dtsi/schema.graphql
+++ b/src/data/dtsi/schema.graphql
@@ -195,8 +195,10 @@ enum PersonPoliticalAffiliationCategory {
   LIBERAL
   LIBERAL_DEMOCRAT
   LIBERTARIAN
+  NATIONALS
   NATIONAL_LIBERAL
   NDP
+  ONE_NATION
   OTHER
   PPC
   REFORM
@@ -367,6 +369,7 @@ type PublicUser {
 }
 
 type Query {
+  INTERNAL__testSentry: Boolean
   bill(id: String!): Bill!
   bills: [Bill!]!
   congressPeople(chamber: CongressionalChamber!, session: CongressionalSession!): [Person!]! @deprecated(reason: "Use people instead")

--- a/src/utils/dtsi/dtsiPersonUtils.ts
+++ b/src/utils/dtsi/dtsiPersonUtils.ts
@@ -64,6 +64,10 @@ export const dtsiPersonPoliticalAffiliationCategoryDisplayName = (
       return 'Reform'
     case DTSI_PersonPoliticalAffiliationCategory.SOCIALIST:
       return 'Socialist'
+    case DTSI_PersonPoliticalAffiliationCategory.NATIONALS:
+      return 'National Party'
+    case DTSI_PersonPoliticalAffiliationCategory.ONE_NATION:
+      return 'One Nation'
   }
 }
 


### PR DESCRIPTION
## What changed? Why?

This PR does the following:
- Adds two new party filters for AU
- Displays the party name on the party column when the party category is OTHER from DTSI

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
