### PR TITLE
fix: send feedback behavior on desktop

### DIFF
--- a/src/app/[countryCode]/config.tsx
+++ b/src/app/[countryCode]/config.tsx
@@ -129,9 +129,6 @@ export const footerConfig: FooterProps = {
       href: usExternalUrls.discord(),
       text: 'Discord',
     },
-    {
-      href: usExternalUrls.emailFeedback(),
-      text: 'Send feedback',
-    },
   ],
+  sendFeedbackLink: usExternalUrls.emailFeedback(),
 }

--- a/src/app/au/config.tsx
+++ b/src/app/au/config.tsx
@@ -67,9 +67,6 @@ export const footerConfig: FooterProps = {
       href: auExternalUrls.linkedin(),
       text: 'LinkedIn',
     },
-    {
-      href: auExternalUrls.emailFeedback(),
-      text: 'Send feedback',
-    },
   ],
+  sendFeedbackLink: auExternalUrls.emailFeedback(),
 }

--- a/src/app/ca/config.tsx
+++ b/src/app/ca/config.tsx
@@ -70,9 +70,6 @@ export const footerConfig: FooterProps = {
       href: caExternalUrls.linkedin(),
       text: 'LinkedIn',
     },
-    {
-      href: caExternalUrls.emailFeedback(),
-      text: 'Send feedback',
-    },
   ],
+  sendFeedbackLink: caExternalUrls.emailFeedback(),
 }

--- a/src/app/gb/config.tsx
+++ b/src/app/gb/config.tsx
@@ -66,9 +66,6 @@ export const footerConfig: FooterProps = {
       href: gbExternalUrls.linkedin(),
       text: 'LinkedIn',
     },
-    {
-      href: gbExternalUrls.emailFeedback(),
-      text: 'Send feedback',
-    },
   ],
+  sendFeedbackLink: gbExternalUrls.emailFeedback(),
 }

--- a/src/components/app/footer/index.tsx
+++ b/src/components/app/footer/index.tsx
@@ -6,6 +6,13 @@ import { ExternalLink, InternalLink } from '@/components/ui/link'
 import { DEFAULT_PAGE_TITLE_SIZE, PageTitle } from '@/components/ui/pageTitleText'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { cn } from '@/utils/web/cn'
+import { lazy } from 'react'
+
+const SendFeedbackButton = lazy(() =>
+  import('@/components/app/footer/sendFeedback').then(m => ({
+    default: m.SendFeedbackButton,
+  })),
+)
 
 const footerLinkStyles = cn('block text-gray-400')
 
@@ -21,6 +28,7 @@ export interface FooterProps {
     text: string
     href: string
   }[]
+  sendFeedbackLink?: string
   legalText?: string
   footerBanner?: React.ReactNode
 }
@@ -30,6 +38,7 @@ export function Footer({
   subtitle,
   links,
   socialLinks,
+  sendFeedbackLink,
   footerBanner,
   countryCode,
   legalText,
@@ -54,6 +63,7 @@ export function Footer({
                     {text}
                   </ExternalLink>
                 ))}
+                {sendFeedbackLink && <SendFeedbackButton href={sendFeedbackLink} />}
               </div>
               <div className="space-y-3 sm:space-y-6">
                 {links.map(({ text, href }) => (

--- a/src/components/app/footer/index.tsx
+++ b/src/components/app/footer/index.tsx
@@ -1,3 +1,4 @@
+import { lazy } from 'react'
 import { getYear } from 'date-fns'
 
 import { CookieConsentFooterButton } from '@/components/app/cookieConsent/common/cookieConsentFooterButton'
@@ -6,7 +7,6 @@ import { ExternalLink, InternalLink } from '@/components/ui/link'
 import { DEFAULT_PAGE_TITLE_SIZE, PageTitle } from '@/components/ui/pageTitleText'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { cn } from '@/utils/web/cn'
-import { lazy } from 'react'
 
 const SendFeedbackButton = lazy(() =>
   import('@/components/app/footer/sendFeedback').then(m => ({

--- a/src/components/app/footer/sendFeedback.tsx
+++ b/src/components/app/footer/sendFeedback.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import Balancer from 'react-wrap-balancer'
+
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -8,11 +10,10 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
+import { ExternalLink } from '@/components/ui/link'
 import { useCopyTextToClipboard } from '@/hooks/useCopyTextToClipboard'
 import { useDialog } from '@/hooks/useDialog'
 import { useIsDesktop } from '@/hooks/useIsDesktop'
-import { ExternalLink } from '@/components/ui/link'
-import Balancer from 'react-wrap-balancer'
 
 export function SendFeedbackButton({ href }: { href: string }) {
   const isDesktop = useIsDesktop()
@@ -44,9 +45,9 @@ export function SendFeedbackButton({ href }: { href: string }) {
 
           <Button
             className="mt-4"
+            onClick={() => handleCopyToClipboard(href)}
             size="lg"
             variant="primary-cta"
-            onClick={() => handleCopyToClipboard(href)}
           >
             {copiedValue ? 'Copied!' : 'Copy email to clipboard'}
           </Button>

--- a/src/components/app/footer/sendFeedback.tsx
+++ b/src/components/app/footer/sendFeedback.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { useCopyTextToClipboard } from '@/hooks/useCopyTextToClipboard'
+import { useDialog } from '@/hooks/useDialog'
+import { useIsDesktop } from '@/hooks/useIsDesktop'
+import { ExternalLink } from '@/components/ui/link'
+import Balancer from 'react-wrap-balancer'
+
+export function SendFeedbackButton({ href }: { href: string }) {
+  const isDesktop = useIsDesktop()
+  const dialogProps = useDialog({ analytics: 'Send-Feedback-Dialog' })
+  const [copiedValue, handleCopyToClipboard] = useCopyTextToClipboard()
+  const mobileLink = `mailto:${href}`
+
+  if (!isDesktop) {
+    return (
+      <ExternalLink className="block text-gray-400" href={mobileLink}>
+        Send feedback
+      </ExternalLink>
+    )
+  }
+
+  return (
+    <Dialog {...dialogProps}>
+      <DialogTrigger className="block text-gray-400 hover:underline">Send feedback</DialogTrigger>
+      <DialogContent a11yTitle="Send Feedback">
+        <DialogTitle className="text-center text-2xl">Send Feedback</DialogTitle>
+        <DialogBody className="flex flex-col justify-between">
+          <p className="py-6 text-center text-muted-foreground">
+            <Balancer>
+              We’d love to hear from you! If you have any thoughts, suggestions, or comments, feel
+              free to share them with us at the email below.
+            </Balancer>
+          </p>
+          <div className="rounded-md bg-muted p-4 text-center font-semibold">{href}</div>
+
+          <Button
+            className="mt-4"
+            size="lg"
+            variant="primary-cta"
+            onClick={() => handleCopyToClipboard(href)}
+          >
+            {copiedValue ? 'Copied!' : 'Copy email to clipboard'}
+          </Button>
+        </DialogBody>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/app/footer/sendFeedback.tsx
+++ b/src/components/app/footer/sendFeedback.tsx
@@ -10,39 +10,28 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
-import { ExternalLink } from '@/components/ui/link'
 import { useCopyTextToClipboard } from '@/hooks/useCopyTextToClipboard'
 import { useDialog } from '@/hooks/useDialog'
-import { useIsDesktop } from '@/hooks/useIsDesktop'
 
 export function SendFeedbackButton({ href }: { href: string }) {
-  const isDesktop = useIsDesktop()
   const dialogProps = useDialog({ analytics: 'Send-Feedback-Dialog' })
   const [copiedValue, handleCopyToClipboard] = useCopyTextToClipboard()
-  const mobileLink = `mailto:${href}`
-
-  if (!isDesktop) {
-    return (
-      <ExternalLink className="block text-gray-400" href={mobileLink}>
-        Send feedback
-      </ExternalLink>
-    )
-  }
 
   return (
     <Dialog {...dialogProps}>
       <DialogTrigger className="block text-gray-400 hover:underline">Send feedback</DialogTrigger>
-      <DialogContent a11yTitle="Send Feedback">
-        <DialogTitle className="text-center text-2xl">Send Feedback</DialogTitle>
+      <DialogContent a11yTitle="Send Feedback" className="pb-4 pt-0">
         <DialogBody className="flex flex-col justify-between">
-          <p className="py-6 text-center text-muted-foreground">
-            <Balancer>
-              We’d love to hear from you! If you have any thoughts, suggestions, or comments, feel
-              free to share them with us at the email below.
-            </Balancer>
-          </p>
-          <div className="rounded-md bg-muted p-4 text-center font-semibold">{href}</div>
-
+          <div>
+            <DialogTitle className="text-center text-2xl">Send Feedback</DialogTitle>
+            <p className="py-6 text-center text-muted-foreground">
+              <Balancer>
+                We’d love to hear from you! If you have any thoughts, suggestions, or comments, feel
+                free to share them with us at the email below.
+              </Balancer>
+            </p>
+            <div className="rounded-md bg-muted p-4 text-center font-semibold">{href}</div>
+          </div>
           <Button
             className="mt-4"
             onClick={() => handleCopyToClipboard(href)}

--- a/src/utils/shared/urls/externalUrls.ts
+++ b/src/utils/shared/urls/externalUrls.ts
@@ -27,7 +27,7 @@ export const usExternalUrls = {
     NEXT_PUBLIC_ENVIRONMENT === 'production'
       ? 'https://commerce.coinbase.com/checkout/396fc233-3d1f-4dd3-8e82-6efdf78432ad'
       : 'https://commerce.coinbase.com/checkout/582a836d-733c-4a66-84d9-4e3c40c90281',
-  emailFeedback: () => 'mailto:info@standwithcrypto.org',
+  emailFeedback: () => 'info@standwithcrypto.org',
   facebook: () => 'https://www.facebook.com/standwithcrypto',
   instagram: () => 'https://www.instagram.com/standwithcrypto/',
   linkedin: () => 'https://www.linkedin.com/company/standwithcrypto/',
@@ -40,17 +40,17 @@ export const usExternalUrls = {
 export const auExternalUrls = {
   twitter: () => 'https://x.com/StandWCrypto_AU',
   linkedin: () => 'https://www.linkedin.com/company/stand-with-crypto-australia',
-  emailFeedback: () => 'mailto:info@swcinternational.org',
+  emailFeedback: () => 'info@swcinternational.org',
 }
 
 export const gbExternalUrls = {
   twitter: () => 'https://x.com/StandWCrypto_UK',
   linkedin: () => 'https://www.linkedin.com/company/standwithcryptouk',
-  emailFeedback: () => 'mailto:info@swcinternational.org',
+  emailFeedback: () => 'info@swcinternational.org',
 }
 
 export const caExternalUrls = {
   twitter: () => 'https://x.com/StandWCrypto_CA',
   linkedin: () => 'https://www.linkedin.com/company/stand-with-crypto-canada',
-  emailFeedback: () => 'mailto:info@swcinternational.org',
+  emailFeedback: () => 'info@swcinternational.org',
 }


### PR DESCRIPTION
closes #2104 

## What changed? Why?

This PR fixes the wrong behavior in send feedback button for desktop users that usually don't have the email client configured and were redirected to a blank page with no errors or information about what went wrong.

<img width="615" alt="image" src="https://github.com/user-attachments/assets/2dd67eec-dec6-4ec2-918e-4820e458eade" />

![simulator_screenshot_FB40F9EC-6E8F-4701-83D4-05566300DD30](https://github.com/user-attachments/assets/07d54341-a839-467b-beb3-110749e6c353)


## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
