### PR TITLE
fix: update terminology from "Britons" to "Brits" in homepage section

### DIFF
--- a/src/components/app/pageHome/gb/index.tsx
+++ b/src/components/app/pageHome/gb/index.tsx
@@ -39,7 +39,7 @@ export function GbPageHome({
 
       <HomePageSection>
         <HomePageSection.Title>
-          <span className="text-primary-cta">Britons</span> believe in crypto
+          <span className="text-primary-cta">Brits</span> believe in crypto
         </HomePageSection.Title>
         <HomePageSection.Subtitle>
           See how the community is taking a stand to safeguard the future of crypto in the UK.

--- a/src/components/app/recentActivityRow/variantRecentActivityRow.tsx
+++ b/src/components/app/recentActivityRow/variantRecentActivityRow.tsx
@@ -24,7 +24,10 @@ import { getRoleNameResolver } from '@/utils/dtsi/dtsiPersonRoleUtils'
 import { dtsiPersonFullName } from '@/utils/dtsi/dtsiPersonUtils'
 import { SupportedFiatCurrencyCodes } from '@/utils/shared/currency'
 import { gracefullyError } from '@/utils/shared/gracefullyError'
-import { getStateNameResolver } from '@/utils/shared/stateUtils'
+import {
+  getElectoralZoneDescriptorByCountryCode,
+  getStateNameResolver,
+} from '@/utils/shared/stateUtils'
 import { COUNTRY_CODE_TO_LOCALE, SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { getIntlUrls } from '@/utils/shared/urls'
 import {
@@ -280,7 +283,12 @@ export const VariantRecentActivityRow = function VariantRecentActivityRow({
       case UserActionType.VIEW_KEY_RACES: {
         return {
           onFocusContent: undefined,
-          children: <MainText>Someone investigated the key races in their district</MainText>,
+          children: (
+            <MainText>
+              Someone investigated the key races in their{' '}
+              {getElectoralZoneDescriptorByCountryCode(countryCode)}
+            </MainText>
+          ),
         }
       }
       case UserActionType.VOTING_INFORMATION_RESEARCHED: {

--- a/src/utils/shared/stateUtils.ts
+++ b/src/utils/shared/stateUtils.ts
@@ -26,3 +26,14 @@ const TERRITORY_DIVISION_BY_COUNTRY_CODE: Record<SupportedCountryCodes, string> 
 export function getTerritoryDivisionByCountryCode(countryCode: SupportedCountryCodes) {
   return TERRITORY_DIVISION_BY_COUNTRY_CODE[countryCode]
 }
+
+const ELECTORAL_ZONE_DESCRIPTOR_BY_COUNTRY_CODE: Record<SupportedCountryCodes, string> = {
+  [SupportedCountryCodes.US]: 'district',
+  [SupportedCountryCodes.GB]: 'constituency',
+  [SupportedCountryCodes.CA]: 'constituency',
+  [SupportedCountryCodes.AU]: 'constituency',
+}
+
+export function getElectoralZoneDescriptorByCountryCode(countryCode: SupportedCountryCodes) {
+  return ELECTORAL_ZONE_DESCRIPTOR_BY_COUNTRY_CODE[countryCode]
+}


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
