### PR TITLE
fix: Builder.io subtitle size not working on text component

### DIFF
--- a/src/components/ui/pageSubTitle/pageSubTitle.builder.tsx
+++ b/src/components/ui/pageSubTitle/pageSubTitle.builder.tsx
@@ -1,5 +1,6 @@
 import { Children, cloneElement, ReactElement } from 'react'
 import { Builder, withChildren } from '@builder.io/react'
+import { merge } from 'lodash-es'
 
 import {
   AsVariantsConfig,
@@ -7,7 +8,6 @@ import {
   subTitleVariantsConfig,
 } from '@/components/ui/pageSubTitle'
 import type { BuilderComponentBaseProps } from '@/utils/web/builder'
-import { merge } from 'lodash-es'
 
 interface BuilderPageSubtitleProps extends BuilderComponentBaseProps {
   as: (typeof AsVariantsConfig)[number]

--- a/src/components/ui/pageSubTitle/pageSubTitle.builder.tsx
+++ b/src/components/ui/pageSubTitle/pageSubTitle.builder.tsx
@@ -1,3 +1,4 @@
+import { Children, cloneElement, ReactElement } from 'react'
 import { Builder, withChildren } from '@builder.io/react'
 
 import {
@@ -6,6 +7,7 @@ import {
   subTitleVariantsConfig,
 } from '@/components/ui/pageSubTitle'
 import type { BuilderComponentBaseProps } from '@/utils/web/builder'
+import { merge } from 'lodash-es'
 
 interface BuilderPageSubtitleProps extends BuilderComponentBaseProps {
   as: (typeof AsVariantsConfig)[number]
@@ -14,17 +16,42 @@ interface BuilderPageSubtitleProps extends BuilderComponentBaseProps {
 }
 
 Builder.registerComponent(
-  withChildren((props: BuilderPageSubtitleProps) => (
-    <PageSubTitle
-      {...props.attributes}
-      as={props.as}
-      key={props.attributes?.key}
-      size={props.size}
-      withoutBalancer={props.withoutBalancer}
-    >
-      {props.children}
-    </PageSubTitle>
-  )),
+  withChildren((props: BuilderPageSubtitleProps) => {
+    const childrenWithProps = Children.map(props.children, child => {
+      const element = child as ReactElement<any>
+
+      return cloneElement(
+        element,
+        merge({}, element.props, {
+          block: {
+            component: {
+              options: {
+                // 1. This is necessary because the text component uses tailwind prose classes
+                // and overrides the font size and line height so the size prop is not respected
+                // 2. Using style because tailwind doesn't have a way to inherit the font size and line height
+                style: {
+                  fontSize: 'inherit',
+                  lineHeight: 'inherit',
+                },
+              },
+            },
+          },
+        }),
+      )
+    })
+
+    return (
+      <PageSubTitle
+        {...props.attributes}
+        as={props.as}
+        key={props.attributes?.key}
+        size={props.size}
+        withoutBalancer={props.withoutBalancer}
+      >
+        {childrenWithProps}
+      </PageSubTitle>
+    )
+  }),
   {
     name: 'PageSubTitle',
     canHaveChildren: true,

--- a/src/utils/web/builder/components/text.builder.tsx
+++ b/src/utils/web/builder/components/text.builder.tsx
@@ -40,12 +40,17 @@ function transformLink(tagName: string, attribs: Record<string, string>) {
 
 interface BuilderTextProps extends BuilderComponentBaseProps {
   text: string
+  style?: React.CSSProperties
 }
 
 Builder.registerComponent(
-  ({ text, attributes }: BuilderTextProps) => (
+  ({ text, attributes, style }: BuilderTextProps) => (
     <div
       {...attributes}
+      style={{
+        ...attributes?.style,
+        ...style,
+      }}
       className={cn('prose max-w-full break-words', attributes?.className)}
       dangerouslySetInnerHTML={{
         __html: sanitizeHtml(text, {

--- a/src/utils/web/builder/components/text.builder.tsx
+++ b/src/utils/web/builder/components/text.builder.tsx
@@ -47,10 +47,6 @@ Builder.registerComponent(
   ({ text, attributes, style }: BuilderTextProps) => (
     <div
       {...attributes}
-      style={{
-        ...attributes?.style,
-        ...style,
-      }}
       className={cn('prose max-w-full break-words', attributes?.className)}
       dangerouslySetInnerHTML={{
         __html: sanitizeHtml(text, {
@@ -67,6 +63,10 @@ Builder.registerComponent(
         }),
       }}
       key={attributes?.key}
+      style={{
+        ...attributes?.style,
+        ...style,
+      }}
     />
   ),
   {


### PR DESCRIPTION
closes [#2005](https://github.com/Stand-With-Crypto/swc-web/issues/2005)

## What changed? Why?

Adds fontSize and lineHeight inherit to PageSubTitle children so they respect the subtitle size prop.

## Notes to reviewers

http://swc-web-git-fix-builder-subtitle-size-coinbase-vercel.vercel.app/builder/test

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
