### PR TITLE
Fix missing NFT definition for VOTER_ATTESTATION action type

### DIFF
--- a/src/utils/server/nft/claimNFT.tsx
+++ b/src/utils/server/nft/claimNFT.tsx
@@ -85,6 +85,7 @@ export const ACTION_NFT_SLUG: Record<
   },
   [UserActionType.VOTER_ATTESTATION]: {
     [USUserActionVoterAttestationCampaignName.DEFAULT]: NFTSlug.VOTER_ATTESTATION,
+    [USUserActionVoterAttestationCampaignName.H1_2025]: NFTSlug.VOTER_ATTESTATION,
   },
   [UserActionType.RSVP_EVENT]: {
     [USUserActionRsvpEventCampaignName.DEFAULT]: null,
@@ -161,6 +162,12 @@ export async function claimNFT(
 
   if (userAction.nftMintId !== null) {
     throw Error(`Action ${userAction.id} for campaign ${campaignName} already has an NFT mint.`)
+  }
+
+  if (!nftSlug || !NFT_SLUG_BACKEND_METADATA[nftSlug]) {
+    throw new Error(
+      `Invalid or missing NFT metadata for action ${actionType} with campaign ${campaignName}`,
+    )
   }
 
   try {


### PR DESCRIPTION
closes #2212 

fixes [PROD-SWC-WEB-63H](https://stand-with-crypto.sentry.io/issues/6535682712/events/a4c14bbcf2504ed2b53f614204c379ab/)

## What changed? Why?

- Added checks for `nftSlug` and `NFT_SLUG_BACKEND_METADATA`
- Added NFT for the VOTER_ATTESTATION `H1_2025` campaign

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
