### PR TITLE
Show governor and attorney in politicians section

### DIFF
--- a/src/actions/actionCreateUserActionEmailCongressperson.ts
+++ b/src/actions/actionCreateUserActionEmailCongressperson.ts
@@ -255,6 +255,8 @@ function getCapitalCanaryCampaignId(politicianCategory: YourPoliticianCategory) 
         return SandboxCapitolCanaryCampaignId.DEFAULT_EMAIL_REPRESENTATIVE
       case 'senate-and-house':
         return SandboxCapitolCanaryCampaignId.DEFAULT_EMAIL_REPRESENTATIVE_AND_SENATORS
+      case 'legislative-and-executive':
+        return SandboxCapitolCanaryCampaignId.DEFAULT_EMAIL_REPRESENTATIVE_AND_SENATORS
     }
   }
 
@@ -264,6 +266,8 @@ function getCapitalCanaryCampaignId(politicianCategory: YourPoliticianCategory) 
     case 'house':
       return CapitolCanaryCampaignId.DEFAULT_EMAIL_REPRESENTATIVE
     case 'senate-and-house':
+      return CapitolCanaryCampaignId.DEFAULT_EMAIL_REPRESENTATIVE_AND_SENATORS
+    case 'legislative-and-executive':
       return CapitolCanaryCampaignId.DEFAULT_EMAIL_REPRESENTATIVE_AND_SENATORS
   }
 }

--- a/src/components/app/clientCurrentUserDTSIPersonCardOrCTA.tsx
+++ b/src/components/app/clientCurrentUserDTSIPersonCardOrCTA.tsx
@@ -9,6 +9,7 @@ import { DTSIPersonHeroCard } from '@/components/app/dtsiPersonHeroCard'
 import { DTSIPersonHeroCardRow } from '@/components/app/dtsiPersonHeroCard/dtsiPersonHeroCardRow'
 import { GooglePlacesSelect, GooglePlacesSelectProps } from '@/components/ui/googlePlacesSelect'
 import { PageSubTitle } from '@/components/ui/pageSubTitle'
+import { DTSI_PersonRoleCategory } from '@/data/dtsi/generated'
 import { useMutableCurrentUserAddress } from '@/hooks/useCurrentUserAddress'
 import {
   formatGetDTSIPeopleFromAddressNotFoundReason,
@@ -43,7 +44,7 @@ export function ClientCurrentUserDTSIPersonCardOrCTA(props: {
   )
 }
 
-const POLITICIAN_CATEGORY: YourPoliticianCategory = 'senate-and-house'
+const POLITICIAN_CATEGORY: YourPoliticianCategory = 'legislative-and-executive'
 
 function SuspenseClientCurrentUserDTSIPersonCardOrCTA({
   countryCode,
@@ -76,6 +77,7 @@ function SuspenseClientCurrentUserDTSIPersonCardOrCTA({
   }
   const people = res.data.dtsiPeople
   const categoryDisplayName = getYourPoliticianCategoryDisplayName(POLITICIAN_CATEGORY)
+
   return (
     <div>
       <p className="mb-3 text-center text-sm text-fontcolor-muted">
@@ -90,15 +92,20 @@ function SuspenseClientCurrentUserDTSIPersonCardOrCTA({
       >
         Your {categoryDisplayName}
       </p>
-      <DTSIPersonHeroCardRow>
+      <DTSIPersonHeroCardRow className="lg:grid lg:grid-cols-[repeat(auto-fit,minmax(0px,1fr))] lg:gap-2 lg:px-0">
         {people.map(person => (
           <DTSIPersonHeroCard
+            className="lg:w-auto xl:w-auto"
             countryCode={countryCode}
             cryptoStanceGrade={DTSIFormattedLetterGrade}
             key={person.id}
             person={person}
-            shouldHideStanceScores={false}
+            shouldHideStanceScores={
+              person.primaryRole?.roleCategory === DTSI_PersonRoleCategory.GOVERNOR ||
+              person.primaryRole?.roleCategory === DTSI_PersonRoleCategory.ATTORNEY_GENERAL
+            }
             subheader="role"
+            wrapperClassName="lg:h-auto lg:w-auto xl:h-auto xl:w-auto"
           />
         ))}
       </DTSIPersonHeroCardRow>

--- a/src/components/app/dtsiPersonHeroCard/dtsiPersonHeroCardRow.tsx
+++ b/src/components/app/dtsiPersonHeroCard/dtsiPersonHeroCardRow.tsx
@@ -4,19 +4,22 @@ import { cn } from '@/utils/web/cn'
 
 export function DTSIPersonHeroCardRow({
   children,
-  className,
   forceMobile = false,
+  className,
 }: {
   children: React.ReactNode
-  className?: string
   forceMobile?: boolean
+  className?: string
 }) {
   return (
-    <section className={cn('text-center', className)}>
+    <section className="text-center">
       <div
         className={cn(
           'flex w-auto flex-col flex-wrap justify-center gap-6 px-2',
-          !forceMobile && 'sm:inline-flex sm:flex-row md:px-4',
+          {
+            'sm:inline-flex sm:flex-row md:px-4': !forceMobile,
+          },
+          className,
         )}
       >
         {children}

--- a/src/components/app/dtsiPersonHeroCard/index.tsx
+++ b/src/components/app/dtsiPersonHeroCard/index.tsx
@@ -35,6 +35,8 @@ export interface DTSIPersonHeroCardProps {
   forceMobile?: boolean
   target?: React.HTMLAttributeAnchorTarget
   shouldHideStanceScores: boolean
+  className?: string
+  wrapperClassName?: string
 }
 
 function getSubHeaderString(props: DTSIPersonHeroCardProps) {
@@ -91,6 +93,8 @@ export function DTSIPersonHeroCard(props: DTSIPersonHeroCardProps) {
     cryptoStanceGrade: CryptoStanceGrade,
     target,
     shouldHideStanceScores,
+    className,
+    wrapperClassName,
   } = props
   const politicalAffiliationCategoryAbbreviation =
     person.politicalAffiliationCategory &&
@@ -100,10 +104,11 @@ export function DTSIPersonHeroCard(props: DTSIPersonHeroCardProps) {
   const politicalAbbrDisplayName = politicalAffiliationCategoryAbbreviation
     ? ` (${politicalAffiliationCategoryAbbreviation})`
     : ''
-  const displayName = `${dtsiPersonFullName(person)}${politicalAbbrDisplayName}`
+  const displayName = `${dtsiPersonFullName(person)}`
 
   return (
     <DtsiPersonHeroCardWrapper
+      className={wrapperClassName}
       countryCode={countryCode}
       forceMobile={forceMobile}
       isClickable={isClickable}
@@ -116,6 +121,7 @@ export function DTSIPersonHeroCard(props: DTSIPersonHeroCardProps) {
             'relative h-36 w-36 shrink-0',
             person.profilePictureUrl || 'bg-black',
             !forceMobile && 'sm:h-52 sm:w-52 xl:h-72 xl:w-72',
+            className,
           )}
         >
           {person.profilePictureUrl ? (
@@ -139,7 +145,7 @@ export function DTSIPersonHeroCard(props: DTSIPersonHeroCardProps) {
           {/* Hidden on mobile */}
           <div
             className={cn(
-              'absolute bottom-0 left-0 right-0 flex items-end justify-between gap-2 px-3 pb-3 pt-16',
+              'absolute bottom-0 left-0 right-0 flex flex-col px-3 pb-3 pt-16',
               forceMobile ? 'hidden' : 'max-sm:hidden',
             )}
             style={{
@@ -147,14 +153,13 @@ export function DTSIPersonHeroCard(props: DTSIPersonHeroCardProps) {
             }}
           >
             <div className="flex flex-grow flex-col justify-end overflow-hidden">
-              {' '}
               <div
-                className={cn(
-                  'block truncate text-sm font-bold text-white',
-                  !forceMobile && 'lg:text-base',
-                )}
+                className={cn('flex flex-row gap-1 text-sm font-bold text-white', {
+                  'lg:text-base': !forceMobile,
+                })}
               >
-                {displayName}
+                <span className={cn('truncate')}>{displayName}</span>
+                <span>{politicalAbbrDisplayName}</span>
               </div>
               {!shouldHideStanceScores && (
                 <div className="text-xs text-white">
@@ -162,6 +167,9 @@ export function DTSIPersonHeroCard(props: DTSIPersonHeroCardProps) {
                   {pluralize({ count: person.stanceCount || 0, singular: 'statement' })}
                 </div>
               )}
+            </div>
+
+            <div className="flex items-center gap-0.5">
               {subheaderString && (
                 <div className="mt-2">
                   <div
@@ -174,12 +182,13 @@ export function DTSIPersonHeroCard(props: DTSIPersonHeroCardProps) {
                   </div>
                 </div>
               )}
+
+              {!shouldHideStanceScores && (
+                <div className="ml-auto h-12 w-10 flex-shrink-0">
+                  <CryptoStanceGrade className="h-full w-full" person={person} />
+                </div>
+              )}
             </div>
-            {!shouldHideStanceScores && (
-              <div className="ml-auto h-12 w-10 flex-shrink-0">
-                <CryptoStanceGrade className="h-full w-full" person={person} />
-              </div>
-            )}
           </div>
         </div>
 
@@ -236,6 +245,7 @@ export function DtsiPersonHeroCardWrapper({
   children,
   forceMobile = false,
   target = '_self',
+  className,
 }: {
   isClickable: boolean
   children: ReactNode
@@ -243,8 +253,9 @@ export function DtsiPersonHeroCardWrapper({
   countryCode: SupportedCountryCodes
   forceMobile?: boolean
   target?: React.HTMLAttributeAnchorTarget
+  className?: string
 }) {
-  const className = cn(
+  const wrapperClassName = cn(
     'block shrink-0 overflow-hidden bg-white text-left shadow-md hover:!no-underline ',
     !isClickable && 'hover:cursor-default',
     forceMobile
@@ -253,12 +264,12 @@ export function DtsiPersonHeroCardWrapper({
   )
 
   if (!isClickable) {
-    return <div className={className}>{children}</div>
+    return <div className={cn(wrapperClassName, className)}>{children}</div>
   }
 
   return (
     <InternalLink
-      className={className}
+      className={cn(wrapperClassName, className)}
       href={getIntlUrls(countryCode).politicianDetails(person.slug)}
       target={target}
     >

--- a/src/data/dtsi/queries/queryDTSIPeopleByCongressionalDistrict.ts
+++ b/src/data/dtsi/queries/queryDTSIPeopleByCongressionalDistrict.ts
@@ -14,6 +14,14 @@ const query = /* GraphQL */ `
     ) {
       ...PersonCard
     }
+    stateReps: people(
+      limit: 999
+      offset: 0
+      personRolePrimaryState: $stateCode
+      personRoleGroupingOr: [CURRENT_US_STATE_ATTORNEY_GENERAL, CURRENT_US_STATE_GOVERNOR]
+    ) {
+      ...PersonCard
+    }
   }
   ${fragmentDTSIPersonCard}
 `
@@ -32,7 +40,12 @@ export const queryDTSIPeopleByCongressionalDistrict = async ({
     stateCode,
     congressionalDistrict: districtNumber,
   })
-  return orderDTSICongressionalDistrictResults(data.peopleByUSCongressionalDistrict)
+  const people = [
+    ...orderDTSICongressionalDistrictResults(data.peopleByUSCongressionalDistrict),
+    ...orderDTSICongressionalDistrictResults(data.stateReps),
+  ]
+
+  return orderDTSICongressionalDistrictResults(people)
 }
 
 export type DTSIPeopleByCongressionalDistrictQueryResult = NonNullable<

--- a/src/hooks/useGetDTSIPeopleFromAddress.ts
+++ b/src/hooks/useGetDTSIPeopleFromAddress.ts
@@ -9,7 +9,10 @@ import {
   GetCongressionalDistrictFromAddressSuccess,
 } from '@/utils/shared/getCongressionalDistrictFromAddress'
 import { apiUrls } from '@/utils/shared/urls'
-import { YourPoliticianCategory } from '@/utils/shared/yourPoliticianCategory'
+import {
+  LEGISLATIVE_AND_EXECUTIVE_ROLE_CATEGORIES,
+  YourPoliticianCategory,
+} from '@/utils/shared/yourPoliticianCategory'
 import { catchUnexpectedServerErrorAndTriggerToast } from '@/utils/web/toastUtils'
 
 export interface DTSIPeopleFromCongressionalDistrict
@@ -38,19 +41,39 @@ async function getDTSIPeopleFromCongressionalDistrict(
     })
   const dtsiPeople = data as DTSIPeopleByCongressionalDistrictQueryResult
 
-  const filteredData =
-    category === 'senate-and-house'
-      ? dtsiPeople
-      : dtsiPeople.filter(
-          person =>
-            person.primaryRole?.roleCategory ===
-            (category === 'senate'
-              ? DTSI_PersonRoleCategory.SENATE
-              : DTSI_PersonRoleCategory.CONGRESS),
-        )
-
   if ('notFoundReason' in data) {
     return data
+  }
+
+  let filteredData: DTSIPeopleByCongressionalDistrictQueryResult = []
+
+  switch (category) {
+    case 'senate':
+      filteredData = dtsiPeople.filter(
+        person => person.primaryRole?.roleCategory === DTSI_PersonRoleCategory.SENATE,
+      )
+      break
+    case 'house':
+      filteredData = dtsiPeople.filter(
+        person => person.primaryRole?.roleCategory === DTSI_PersonRoleCategory.CONGRESS,
+      )
+      break
+    case 'senate-and-house':
+      filteredData = dtsiPeople.filter(
+        person =>
+          person.primaryRole?.roleCategory === DTSI_PersonRoleCategory.SENATE ||
+          person.primaryRole?.roleCategory === DTSI_PersonRoleCategory.CONGRESS,
+      )
+      break
+    case 'legislative-and-executive':
+      filteredData = dtsiPeople.filter(
+        person =>
+          person.primaryRole?.roleCategory &&
+          LEGISLATIVE_AND_EXECUTIVE_ROLE_CATEGORIES.includes(person.primaryRole.roleCategory),
+      )
+      break
+    default:
+      filteredData = dtsiPeople
   }
 
   if (!filteredData.length) {

--- a/src/utils/shared/orderSenatorsByImportanceForOutreach.ts
+++ b/src/utils/shared/orderSenatorsByImportanceForOutreach.ts
@@ -24,7 +24,12 @@ const HIGH_PRIORITY_SENATOR_DTSI_SLUGS_FOR_OUTREACH = [
   'chris---vanhollen',
 ]
 
-const ROLE_PRIORITY = [DTSI_PersonRoleCategory.CONGRESS, DTSI_PersonRoleCategory.SENATE]
+const ROLE_PRIORITY = [
+  DTSI_PersonRoleCategory.GOVERNOR,
+  DTSI_PersonRoleCategory.ATTORNEY_GENERAL,
+  DTSI_PersonRoleCategory.CONGRESS,
+  DTSI_PersonRoleCategory.SENATE,
+]
 
 /*
 

--- a/src/utils/shared/yourPoliticianCategory.ts
+++ b/src/utils/shared/yourPoliticianCategory.ts
@@ -1,9 +1,23 @@
-export type YourPoliticianCategory = 'senate' | 'house' | 'senate-and-house'
+import { DTSI_PersonRoleCategory } from '@/data/dtsi/generated'
+
+export type YourPoliticianCategory =
+  | 'senate'
+  | 'house'
+  | 'senate-and-house'
+  | 'legislative-and-executive'
 
 export const YOUR_POLITICIAN_CATEGORY_OPTIONS: readonly YourPoliticianCategory[] = [
   'senate',
   'house',
   'senate-and-house',
+  'legislative-and-executive',
+]
+
+export const LEGISLATIVE_AND_EXECUTIVE_ROLE_CATEGORIES = [
+  DTSI_PersonRoleCategory.SENATE,
+  DTSI_PersonRoleCategory.CONGRESS,
+  DTSI_PersonRoleCategory.GOVERNOR,
+  DTSI_PersonRoleCategory.ATTORNEY_GENERAL,
 ]
 
 export function getYourPoliticianCategoryDisplayName(
@@ -21,6 +35,8 @@ export function getYourPoliticianCategoryDisplayName(
       return maxCount === 1 ? 'senator' : 'senators'
     case 'senate-and-house':
       return maxCount === 1 ? 'politician' : 'senators and congressperson'
+    case 'legislative-and-executive':
+      return 'politicians'
   }
 }
 export function getYourPoliticianCategoryShortDisplayName(
@@ -38,5 +54,7 @@ export function getYourPoliticianCategoryShortDisplayName(
       return maxCount === 1 ? 'senator' : 'senators'
     case 'senate-and-house':
       return maxCount === 1 ? 'politician' : 'politicians'
+    case 'legislative-and-executive':
+      return 'politicians'
   }
 }


### PR DESCRIPTION
closes #2231

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

- Added `GOVERNOR` and `ATTORNEY_GENERAL` categories to `PeopleByUSCongressionalDistrict` query
- Clean up `PeopleByUSCongressionalDistrict` styles to better fit politician name

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
