### PR TITLE
fix: key races CTA redirecting to email flow

### DIFF
--- a/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
@@ -90,7 +90,6 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     campaignsModalDescription:
       'View the key races occurring across Australia that will impact the future of crypto.',
     image: '/au/actionTypeIcons/view-key-races.png',
-    link: ({ children }) => <Link href={urls.emailDeeplink()}>{children}</Link>,
     campaigns: [
       {
         actionType: UserActionType.VIEW_KEY_RACES,


### PR DESCRIPTION
## What changed? Why?

This PR fixes the key races australia CTA that was redirecting the user to the email flow instead of the races page.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
