### PR TITLE
fix: change representatives endpoint to divisions

### DIFF
--- a/src/components/app/userActionFormCallCongressperson/sections/suggestedScript.tsx
+++ b/src/components/app/userActionFormCallCongressperson/sections/suggestedScript.tsx
@@ -23,7 +23,6 @@ import { useIsMobile } from '@/hooks/useIsMobile'
 import { UseSectionsReturn } from '@/hooks/useSections'
 import { dtsiPersonFullName } from '@/utils/dtsi/dtsiPersonUtils'
 import { BILLS_IDS } from '@/utils/shared/constants'
-import { getGoogleCivicOfficialByDTSIName } from '@/utils/shared/googleCivicInfo'
 import { formatPhoneNumber } from '@/utils/shared/phoneNumber'
 import { convertAddressToAnalyticsProperties } from '@/utils/shared/sharedAnalytics'
 import { USUserActionCallCampaignName } from '@/utils/shared/userActionCampaigns/us/usUserActionCampaigns'
@@ -132,7 +131,7 @@ export function SuggestedScript({
   CallCongresspersonActionSharedData,
   'user' | 'congressPersonData' | keyof UseSectionsReturn<SectionNames>
 >) {
-  const { dtsiPeople, addressSchema, googleCivicData } = congressPersonData
+  const { dtsiPeople, addressSchema } = congressPersonData
 
   const isMobile = useIsMobile()
   const responsiveContent = RESPONSIVE_CONTENT[isMobile ? 'mobile' : 'desktop']
@@ -141,15 +140,10 @@ export function SuggestedScript({
 
   const dtsiPerson = dtsiPeople[0]
   const phoneNumber = React.useMemo(() => {
-    const official = getGoogleCivicOfficialByDTSIName(dtsiPerson, googleCivicData)
-
-    if (!official) {
-      toastGenericError()
-      return null
-    }
-
-    return official.phones[0]
-  }, [dtsiPerson, googleCivicData])
+    // TODO: get the official phone number information once we have it from quorum
+    toastGenericError()
+    return null
+  }, [])
 
   const { data: congresspersonBillVote } = useCongresspersonBillVote({
     slug: dtsiPerson.slug,

--- a/src/utils/shared/googleCivicInfo.ts
+++ b/src/utils/shared/googleCivicInfo.ts
@@ -1,8 +1,4 @@
-import * as Sentry from '@sentry/nextjs'
-
-import { convertToOnlyEnglishCharacters } from '@/utils/shared/convertToOnlyEnglishCharacters'
 import { fetchReq } from '@/utils/shared/fetchReq'
-import { logger } from '@/utils/shared/logger'
 import { requiredEnv } from '@/utils/shared/requiredEnv'
 import { fullUrl } from '@/utils/shared/urls'
 
@@ -104,9 +100,7 @@ export interface GoogleCivicInfoOfficial {
 
 export interface GoogleCivicInfoResponse {
   normalizedInput: GoogleCivicInfoAddress
-  kind: 'civicinfo#representativeInfoResponse'
   divisions: Record<string, { name: string }>
-  officials: GoogleCivicInfoOfficial[]
 }
 
 interface GoogleCivicErrorResponse {


### PR DESCRIPTION
closes Stand-With-Crypto/swc-internal#368 

## What changed? Why?

Changed the endpoint we're using to access the divisions information based on [this comment](https://groups.google.com/g/google-civicinfo-api/c/9fwFn-dhktA)

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
