### PR TITLE
chore: disable key races action in Canada

### DIFF
--- a/src/app/ca/config.tsx
+++ b/src/app/ca/config.tsx
@@ -23,21 +23,16 @@ export const navbarConfig: NavbarProps = {
       text: 'Politician scores',
     },
     {
-      href: urls.locationKeyRaces(),
-      text: 'Races',
-    },
-    {
       href: urls.polls(),
       text: 'Polls',
     },
     {
+      href: urls.manifesto(),
+      text: 'Manifesto',
+    },
+    {
       text: 'Resources',
       children: [
-        {
-          href: urls.manifesto(),
-          text: 'Manifesto',
-          icon: <Icons.MissionIcon />,
-        },
         {
           href: urls.community(),
           text: 'Community',

--- a/src/components/app/userActionGridCTAs/constants/ca/caCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/ca/caCtas.tsx
@@ -97,10 +97,10 @@ export const CA_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
       {
         actionType: UserActionType.VIEW_KEY_RACES,
         campaignName: CAUserActionViewKeyRacesCampaignName.H1_2025,
-        isCampaignActive: true,
+        isCampaignActive: false,
         title: 'View Key Races in Canada',
         description:
-          'View the key races occurring across Canada that will impact the future of crypto.',
+          'Viewed the key races occurring across Canada that would impact the future of crypto in early 2025.',
         canBeTriggeredMultipleTimes: true,
         WrapperComponent: ({ children }) => <Link href={urls.locationKeyRaces()}>{children}</Link>,
       },


### PR DESCRIPTION
closes #2249 

## What changed? Why?

This PR removes the key races action in Canada and also removes the Key Races link in Canada's navbar.
## PlanetScale deploy request

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
