### PR TITLE
Optimize district ranking job performance

### DIFF
--- a/src/utils/server/districtRankings/getRankingData.ts
+++ b/src/utils/server/districtRankings/getRankingData.ts
@@ -3,6 +3,7 @@ import { UserActionType } from '@prisma/client'
 import { prismaClient } from '@/utils/server/prismaClient'
 import { logger } from '@/utils/shared/logger'
 import { USStateCode } from '@/utils/shared/stateMappings/usStateUtils'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { zodStateDistrict } from '@/validation/fields/zodAddress'
 
 export type AdvocatesCountResult = {
@@ -54,7 +55,7 @@ export async function getAdvocatesCountByDistrict(
     INNER JOIN user u ON ua.user_id = u.id
     INNER JOIN address a ON u.address_id = a.id
     WHERE ua.action_type = ${UserActionType.OPT_IN}
-      AND a.country_code = 'US'
+      AND a.country_code = ${SupportedCountryCodes.US}
       AND a.administrative_area_level_1 = ${stateCode}
     GROUP BY
       state,
@@ -82,14 +83,14 @@ export async function getReferralsCountByDistrict(
         WHEN a.administrative_area_level_1 = 'DC' THEN '1'
         ELSE a.us_congressional_district
       END as district,
-      COUNT(DISTINCT ua.id) as refer_actions_count, -- Keep original alias if needed downstream
+      COUNT(DISTINCT ua.id) as refer_actions_count,
       SUM(uar.referrals_count) as referrals
     FROM user_action ua
     INNER JOIN user_action_refer uar ON ua.id = uar.id
     INNER JOIN address a ON uar.address_id = a.id
     WHERE ua.action_type = ${UserActionType.REFER}
       AND uar.referrals_count > 0
-      AND a.country_code = 'US'
+      AND a.country_code = ${SupportedCountryCodes.US}
       AND a.administrative_area_level_1 = ${stateCode}
     GROUP BY
       state,

--- a/src/utils/server/districtRankings/getRankingData.ts
+++ b/src/utils/server/districtRankings/getRankingData.ts
@@ -66,34 +66,9 @@ export async function getAdvocatesCountByDistrict(
     .filter(result => isValidDistrict(result.state, result.district))
     .map(({ state, district, count }) => ({
       state: state as USStateCode,
-      district: district!, // District is non-null here due to filter
+      district: district!,
       count: Number(count),
     }))
-}
-
-export async function getAdvocatesCountByDistrictExplain(sampleStateCode: USStateCode = 'CA') {
-  const results = await prismaClient.$queryRaw`
-    EXPLAIN
-    SELECT
-      a.administrative_area_level_1 as state,
-      CASE
-        WHEN a.administrative_area_level_1 = 'DC' THEN '1'
-        ELSE a.us_congressional_district
-      END as district,
-      COUNT(DISTINCT u.id) as count
-    FROM user_action ua
-    INNER JOIN user u ON ua.user_id = u.id
-    INNER JOIN address a ON u.address_id = a.id
-    WHERE ua.action_type = ${UserActionType.OPT_IN}
-      AND a.country_code = 'US'
-      AND a.administrative_area_level_1 = ${sampleStateCode}
-    GROUP BY
-      state,
-      district
-    HAVING COUNT(DISTINCT u.id) > 0
-  `
-
-  return results
 }
 
 export async function getReferralsCountByDistrict(

--- a/src/utils/server/districtRankings/getRankingData.ts
+++ b/src/utils/server/districtRankings/getRankingData.ts
@@ -5,7 +5,7 @@ import { logger } from '@/utils/shared/logger'
 import { USStateCode } from '@/utils/shared/stateMappings/usStateUtils'
 import { zodStateDistrict } from '@/validation/fields/zodAddress'
 
-type Result = {
+export type AdvocatesCountResult = {
   state: USStateCode
   district: string
   count: number
@@ -13,18 +13,18 @@ type Result = {
 
 type AdvocatesCountByDistrictQueryResult = {
   state: string
-  district: string
+  district: string | null
   count: number
 }
 
 type ReferralsCountByDistrictQueryResult = {
   state: string
-  district: string
+  district: string | null
   refer_actions_count: number
   referrals: number
 }
 
-function isValidDistrict(state: string, district: string): boolean {
+function isValidDistrict(state: string, district: string | null): boolean {
   const zodResult = zodStateDistrict.safeParse({ state, district })
   if (!zodResult.success) {
     logger.warn('[District Rankings] Invalid district:', {
@@ -38,57 +38,65 @@ function isValidDistrict(state: string, district: string): boolean {
   return true
 }
 
-export async function getAdvocatesCountByDistrict(): Promise<Result[]> {
+export async function getAdvocatesCountByDistrict(
+  stateCode: USStateCode,
+): Promise<AdvocatesCountResult[]> {
   const results = await prismaClient.$queryRaw<AdvocatesCountByDistrictQueryResult[]>`
-    WITH valid_addresses AS (
-      SELECT
-        a.administrative_area_level_1,
-        a.us_congressional_district,
-        a.id
-      FROM address a
-      WHERE a.country_code = 'US'
-        AND a.us_congressional_district IS NOT NULL
-        AND a.us_congressional_district != ''
-        AND a.us_congressional_district REGEXP '^[0-9]+$'
-        AND a.administrative_area_level_1 IS NOT NULL
-        AND a.administrative_area_level_1 != ''
-        AND a.administrative_area_level_1 != 'DC'
-    )
     SELECT
-      va.administrative_area_level_1 as state,
-      va.us_congressional_district as district,
+      a.administrative_area_level_1 as state,
+      -- Handle NULL district for DC, map it to '1' for consistency
+      CASE
+        WHEN a.administrative_area_level_1 = 'DC' THEN '1'
+        ELSE a.us_congressional_district
+      END as district,
       COUNT(DISTINCT u.id) as count
-    FROM valid_addresses va
-    INNER JOIN user u ON u.address_id = va.id
-    INNER JOIN user_action ua ON ua.user_id = u.id
+    FROM user_action ua
+    INNER JOIN user u ON ua.user_id = u.id
+    INNER JOIN address a ON u.address_id = a.id
     WHERE ua.action_type = ${UserActionType.OPT_IN}
+      AND a.country_code = 'US'
+      AND a.administrative_area_level_1 = ${stateCode}
     GROUP BY
-      va.administrative_area_level_1,
-      va.us_congressional_district
-    HAVING count > 0
-
-    UNION ALL
-
-    SELECT
-      'DC' as state,
-      '1' as district,
-      COUNT(DISTINCT u.id) as count
-    FROM address a
-    INNER JOIN user u ON u.address_id = a.id
-    INNER JOIN user_action ua ON ua.user_id = u.id
-    WHERE a.country_code = 'US'
-      AND a.administrative_area_level_1 = 'DC'
-      AND ua.action_type = ${UserActionType.OPT_IN}
-    HAVING count > 0
+      state,
+      district
+    HAVING COUNT(DISTINCT u.id) > 0
   `
 
   return results
     .filter(result => isValidDistrict(result.state, result.district))
     .map(({ state, district, count }) => ({
       state: state as USStateCode,
-      district,
+      district: district!,
       count: Number(count),
     }))
+}
+
+// Explain needs a sample state
+export async function getAdvocatesCountByDistrictExplain(
+  sampleStateCode: USStateCode = 'CA', // Default to CA for example
+) {
+  const results = await prismaClient.$queryRaw`
+    EXPLAIN
+    SELECT
+      a.administrative_area_level_1 as state,
+      CASE
+        WHEN a.administrative_area_level_1 = 'DC' THEN '1'
+        ELSE a.us_congressional_district
+      END as district,
+      COUNT(DISTINCT u.id) as count
+    FROM user_action ua
+    INNER JOIN user u ON ua.user_id = u.id
+    INNER JOIN address a ON u.address_id = a.id
+    WHERE ua.action_type = ${UserActionType.OPT_IN}
+      AND a.country_code = 'US'
+      AND a.administrative_area_level_1 = ${sampleStateCode}
+    GROUP BY
+      state,
+      district
+    HAVING COUNT(DISTINCT u.id) > 0
+  `
+
+  return results
 }
 
 /*
@@ -96,29 +104,28 @@ export async function getAdvocatesCountByDistrict(): Promise<Result[]> {
  * a referral should be attributed to. Users can have multiple UserActionRefer records if they've
  * made referrals while living in different districts.
  */
-export async function getReferralsCountByDistrict(): Promise<Result[]> {
+export async function getReferralsCountByDistrict(): Promise<AdvocatesCountResult[]> {
+  // NOTE: This function still needs refactoring to the per-state approach
+  // and needs the CASE statement for district if NULLs are possible.
   const results = await prismaClient.$queryRaw<ReferralsCountByDistrictQueryResult[]>`
     SELECT
       a.administrative_area_level_1 as state,
       a.us_congressional_district as district,
       COUNT(DISTINCT ua.id) as refer_actions_count,
       SUM(uar.referrals_count) as referrals
-    FROM user_action_refer uar
-    INNER JOIN user_action ua ON ua.id = uar.id
-    INNER JOIN address a ON a.id = uar.address_id
-    WHERE a.country_code = 'US'
-      AND a.administrative_area_level_1 IS NOT NULL
-      AND a.administrative_area_level_1 != ''
-      AND a.administrative_area_level_1 != 'DC'
-      AND a.us_congressional_district IS NOT NULL
-      AND a.us_congressional_district != ''
-      AND a.us_congressional_district REGEXP '^[0-9]+$'
-      AND ua.action_type = ${UserActionType.REFER}
+    FROM user_action ua
+    INNER JOIN user_action_refer uar ON ua.id = uar.id
+    INNER JOIN address a ON uar.address_id = a.id
+    WHERE ua.action_type = ${UserActionType.REFER}
       AND uar.referrals_count > 0
+      AND a.country_code = 'US'
+      AND a.administrative_area_level_1 != 'DC'
+      AND a.administrative_area_level_1 IS NOT NULL
+      AND a.us_congressional_district IS NOT NULL
     GROUP BY
       a.administrative_area_level_1,
       a.us_congressional_district
-    HAVING referrals > 0
+    HAVING SUM(uar.referrals_count) > 0
 
     UNION ALL
 
@@ -127,21 +134,21 @@ export async function getReferralsCountByDistrict(): Promise<Result[]> {
       '1' as district,
       COUNT(DISTINCT ua.id) as refer_actions_count,
       SUM(uar.referrals_count) as referrals
-    FROM user_action_refer uar
-    INNER JOIN user_action ua ON ua.id = uar.id
-    INNER JOIN address a ON a.id = uar.address_id
-    WHERE a.country_code = 'US'
-      AND a.administrative_area_level_1 = 'DC'
-      AND ua.action_type = ${UserActionType.REFER}
+    FROM user_action ua
+    INNER JOIN user_action_refer uar ON ua.id = uar.id
+    INNER JOIN address a ON uar.address_id = a.id
+    WHERE ua.action_type = ${UserActionType.REFER}
       AND uar.referrals_count > 0
-    HAVING referrals > 0
+      AND a.country_code = 'US'
+      AND a.administrative_area_level_1 = 'DC'
+    HAVING SUM(uar.referrals_count) > 0
   `
 
   return results
     .filter(result => isValidDistrict(result.state, result.district))
     .map(result => ({
       state: result.state as USStateCode,
-      district: result.district,
+      district: result.district!,
       count: Number(result.referrals),
     }))
 }


### PR DESCRIPTION
closes #2243

fixes [PROD-SWC-WEB-5Z9](https://stand-with-crypto.sentry.io/issues/6369092866/events/a7304a87e0244dc594a46185032265d2/)

## What changed? Why?

**Problem:**
The queries fetching advocate and referral counts by district were extremely slow, taking ~140 seconds to finish and sometimes hitting the 3 minutes limit for edge functions. Initial attempts to optimize the single SQL query through indexing, join order hints, and clause simplification failed to significantly improve performance due to the large data volume involved in joins and aggregations.

**Solution:**
Refactored the data fetching approach to run queries in parallel on a per-state basis:

1.  Modified `getAdvocatesCountByDistrict` and `getReferralsCountByDistrict` to accept a `stateCode` and query data only for that specific state.
2.  Updated the `updateDistrictsRankings` Inngest job.
    - Query each state count in parallel, greatly reducing total job time.

**Rationale & Alternatives Considered:**

*   **Single Query Optimization:** Attempting to optimize the original query proved insufficient. Despite indexing, query restructuring, and optimizer hints, the inherent complexity of joining and aggregating/grouping across the large `user_action`, `user`, and `address` tables yielded no tangible improvements.
*   **App-Level Grouping:** Rejected as it would require transferring massive amounts of data from the DB to the application, causing network bottlenecks and likely exceeding application memory/CPU limits.
*   **Per-District Queries:** Rejected due to the high overhead of network latency and query planning for hundreds of individual database calls.

The chosen per-state parallel query approach effectively breaks down the work, allowing the database to handle smaller, faster queries concurrently.

**Impact:**

Reduces the total time to process district ranking data from ~140 seconds to **~7 seconds**, based on benchmark results.

<img width="666" alt="image" src="https://github.com/user-attachments/assets/e1b194f1-86fc-4efd-b355-3308808e0509" />
 
<img width="664" alt="image" src="https://github.com/user-attachments/assets/1c8930c8-b537-489a-a568-e4146497537f" />

- Execution Plan Confirmation: `EXPLAIN ANALYZE` output on the refactored per-state queries confirms the database now efficiently uses the `address_administrative_area_level_1_country_code_idx` index for the initial filtering.

<img width="435" alt="image" src="https://github.com/user-attachments/assets/46ce85c1-2b31-40af-95ea-25edc66eec25" />

<img width="549" alt="image" src="https://github.com/user-attachments/assets/e1715af0-7ea3-4797-8890-2f55d3e1abb3" />




<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
