### PR TITLE
chore: disables view key races in Australia

### DIFF
--- a/src/app/au/config.tsx
+++ b/src/app/au/config.tsx
@@ -22,10 +22,6 @@ export const navbarConfig: NavbarProps = {
       text: 'Politician scores',
     },
     {
-      href: urls.locationKeyRaces(),
-      text: 'Races',
-    },
-    {
       href: urls.polls(),
       text: 'Polls',
     },

--- a/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
@@ -94,10 +94,10 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
       {
         actionType: UserActionType.VIEW_KEY_RACES,
         campaignName: AUUserActionViewKeyRacesCampaignName.H1_2025,
-        isCampaignActive: true,
+        isCampaignActive: false,
         title: 'View Key Races in Australia',
         description:
-          'View the key races occurring across Australia that will impact the future of crypto.',
+          'Viewed the key races that occurred across Australia that could impact the future of crypto in early 2025.',
         canBeTriggeredMultipleTimes: true,
         WrapperComponent: ({ children }) => <Link href={urls.locationKeyRaces()}>{children}</Link>,
       },


### PR DESCRIPTION
closes #2258 

## What changed? Why?
- Disables the view key races in Australia actions
- Removed `races` from AU navbar

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
