### PR TITLE
chore: add eslint rule to enforce 'interface' usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,5 +93,6 @@ module.exports = {
       },
     ],
     'react/no-unstable-nested-components': ['error', { allowAsProps: true }],
+    '@typescript-eslint/consistent-type-definitions': 'error',
   },
 }

--- a/src/actions/actionCreateUserActionLiveEvent.ts
+++ b/src/actions/actionCreateUserActionLiveEvent.ts
@@ -47,7 +47,7 @@ export const actionCreateUserActionLiveEvent = withServerActionMiddleware(
   _actionCreateUserActionLiveEvent,
 )
 
-type EventDuration = {
+interface EventDuration {
   START_TIME: Date
   END_TIME: Date
 }

--- a/src/actions/actionCreateUserActionPoll.ts
+++ b/src/actions/actionCreateUserActionPoll.ts
@@ -24,7 +24,7 @@ import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
 
 const logger = getLogger(`actionCreateUserActionPoll`)
 
-export type CreatePollVoteInput = {
+export interface CreatePollVoteInput {
   campaignName: string
   answers: { answer: string; isOtherAnswer: boolean }[]
 }

--- a/src/actions/actionCreateUserActionTweetAtPerson.ts
+++ b/src/actions/actionCreateUserActionTweetAtPerson.ts
@@ -54,7 +54,7 @@ export const actionCreateUserActionTweetedAtPerson = withServerActionMiddleware(
   _actionCreateUserActionTweetedAtPerson,
 )
 
-type CampaignDuration = {
+interface CampaignDuration {
   START_TIME: Date | null
   END_TIME: Date | null
 }

--- a/src/app/[countryCode]/(homepageDialogDeeplink)/action/become-member/pageBecomeMember.tsx
+++ b/src/app/[countryCode]/(homepageDialogDeeplink)/action/become-member/pageBecomeMember.tsx
@@ -12,7 +12,7 @@ import { PageTitle } from '@/components/ui/pageTitleText'
 import { useIntlUrls } from '@/hooks/useIntlUrls'
 import { cn } from '@/utils/web/cn'
 
-type Props = {
+interface Props {
   hasOptedInToMembership?: boolean
 }
 

--- a/src/bin/smokeTests/onNewLogin/utils.ts
+++ b/src/bin/smokeTests/onNewLogin/utils.ts
@@ -11,7 +11,7 @@ import { onNewLogin } from '@/utils/server/thirdweb/onLogin'
  */
 type Params = Parameters<typeof onNewLogin>[0]
 export type Issue = string
-export type TestCase = {
+export interface TestCase {
   name: string
   parameters: () => Promise<Params>
   validateResults: (data: Awaited<ReturnType<typeof onNewLogin>>, issues: Issue[]) => void

--- a/src/clientModels/clientUserAction/clientUserAction.ts
+++ b/src/clientModels/clientUserAction/clientUserAction.ts
@@ -69,11 +69,11 @@ type ClientUserActionDatabaseQuery = UserAction & {
 type ClientUserActionEmailRecipient = Pick<UserActionEmailRecipient, 'id'> & {
   person: DTSIPersonForUserActions | null
 }
-type ClientUserActionEmail = {
+interface ClientUserActionEmail {
   userActionEmailRecipients: ClientUserActionEmailRecipient[]
   actionType: typeof UserActionType.EMAIL
 }
-type ClientUserActionCall = {
+interface ClientUserActionCall {
   person: DTSIPersonForUserActions | null
   actionType: typeof UserActionType.CALL
 }
@@ -82,7 +82,7 @@ type ClientUserActionDonation = Pick<UserActionDonation, 'amountCurrencyCode' | 
   amount: number
   amountUsd: number
 }
-type ClientUserActionNFTMint = {
+interface ClientUserActionNFTMint {
   nftMint: ClientNFTMint
   actionType: typeof UserActionType.NFT_MINT
 }
@@ -90,17 +90,21 @@ type ClientUserActionOptIn = Pick<UserActionOptIn, 'optInType'> & {
   actionType: typeof UserActionType.OPT_IN
 }
 // Added here as a placeholder for type inference until we have some tweet-specific fields
-type ClientUserActionTweet = { actionType: typeof UserActionType.TWEET }
+interface ClientUserActionTweet {
+  actionType: typeof UserActionType.TWEET
+}
 // Added here as a placeholder for type inference until we have some linkedin-specific fields
-type ClientUserActionLinkedIn = { actionType: typeof UserActionType.LINKEDIN }
+interface ClientUserActionLinkedIn {
+  actionType: typeof UserActionType.LINKEDIN
+}
 type ClientUserActionVoterRegistration = Pick<UserActionVoterRegistration, 'usaState'> & {
   actionType: typeof UserActionType.VOTER_REGISTRATION
 }
-type ClientUserActionLiveEvent = {
+interface ClientUserActionLiveEvent {
   actionType: typeof UserActionType.LIVE_EVENT
   campaignName: USUserActionLiveEventCampaignName
 }
-type ClientUserActionTweetAtPerson = {
+interface ClientUserActionTweetAtPerson {
   actionType: typeof UserActionType.TWEET_AT_PERSON
   campaignName: USUserActionTweetAtPersonCampaignName
   person: DTSIPersonForUserActions | null
@@ -108,7 +112,7 @@ type ClientUserActionTweetAtPerson = {
 type ClientUserActionVoterAttestation = Pick<UserActionVoterAttestation, 'usaState'> & {
   actionType: typeof UserActionType.VOTER_ATTESTATION
 }
-type ClientUserActionRsvpEvent = {
+interface ClientUserActionRsvpEvent {
   actionType: typeof UserActionType.RSVP_EVENT
   eventSlug: string
   eventState: string
@@ -136,11 +140,11 @@ type ClientUserActionPollAnswer = Pick<
 type ClientUserActionRefer = Pick<UserActionRefer, 'referralsCount'> & {
   actionType: typeof UserActionType.REFER
 }
-type ClientUserActionPoll = {
+interface ClientUserActionPoll {
   actionType: typeof UserActionType.POLL
   userActionPollAnswers: ClientUserActionPollAnswer[]
 }
-type ClientUserActionViewKeyPage = {
+interface ClientUserActionViewKeyPage {
   actionType: typeof UserActionType.VIEW_KEY_PAGE
   path: string
 }

--- a/src/clientModels/clientUserAction/sensitiveDataClientUserAction.ts
+++ b/src/clientModels/clientUserAction/sensitiveDataClientUserAction.ts
@@ -83,7 +83,7 @@ type SensitiveDataClientUserActionDonation = Pick<
   amountUsd: number
   actionType: typeof UserActionType.DONATION
 }
-type SensitiveDataClientUserActionNFTMint = {
+interface SensitiveDataClientUserActionNFTMint {
   nftMint: ClientNFTMint
   actionType: typeof UserActionType.NFT_MINT
 }
@@ -91,21 +91,27 @@ type SensitiveDataClientUserActionOptIn = Pick<UserActionOptIn, 'optInType'> & {
   actionType: typeof UserActionType.OPT_IN
 }
 // Added here as a placeholder for type inference until we have some tweet-specific fields
-type SensitiveDataClientUserActionTweet = { actionType: typeof UserActionType.TWEET }
+interface SensitiveDataClientUserActionTweet {
+  actionType: typeof UserActionType.TWEET
+}
 // Added here as a placeholder for type inference until we have some linkedin-specific fields
-type SensitiveDataClientUserActionLinkedIn = { actionType: typeof UserActionType.LINKEDIN }
+interface SensitiveDataClientUserActionLinkedIn {
+  actionType: typeof UserActionType.LINKEDIN
+}
 type SensitiveDataClientUserActionVoterRegistration = Pick<
   UserActionVoterRegistration,
   'usaState'
 > & {
   actionType: typeof UserActionType.VOTER_REGISTRATION
 }
-type SensitiveDataClientUserActionLiveEvent = { actionType: typeof UserActionType.LIVE_EVENT }
-type SensitiveDataClientUserActionTweetAtPerson = {
+interface SensitiveDataClientUserActionLiveEvent {
+  actionType: typeof UserActionType.LIVE_EVENT
+}
+interface SensitiveDataClientUserActionTweetAtPerson {
   actionType: typeof UserActionType.TWEET_AT_PERSON
   recipientDtsiSlug: string | null
 }
-type SensitiveDataClientUserActionRsvpEvent = {
+interface SensitiveDataClientUserActionRsvpEvent {
   actionType: typeof UserActionType.RSVP_EVENT
   eventSlug: string
   eventState: string
@@ -136,12 +142,12 @@ type SensitiveDataClientUserActionPollAnswer = Pick<
   UserActionPollAnswer,
   'answer' | 'isOtherAnswer' | 'userActionCampaignName'
 >
-type SensitiveDataClientUserActionPoll = {
+interface SensitiveDataClientUserActionPoll {
   actionType: typeof UserActionType.POLL
   userActionPollAnswers: SensitiveDataClientUserActionPollAnswer[]
 }
 
-type SensitiveDataClientUserActionViewKeyPage = {
+interface SensitiveDataClientUserActionViewKeyPage {
   actionType: typeof UserActionType.VIEW_KEY_PAGE
   path: string
 }

--- a/src/components/app/cookieConsent/common/types.d.ts
+++ b/src/components/app/cookieConsent/common/types.d.ts
@@ -1,6 +1,6 @@
 import { CookieConsentPermissions } from '@/utils/shared/cookieConsent'
 
-export type CookieConsentBannerProps = {
+export interface CookieConsentBannerProps {
   onAcceptAll: () => void
   onAcceptSpecificCookies: (permissions: CookieConsentPermissions) => void
   onRejectAll: () => void

--- a/src/components/app/dtsiStanceDetails/types.ts
+++ b/src/components/app/dtsiStanceDetails/types.ts
@@ -12,12 +12,12 @@ import {
 import { PartialButDefined } from '@/types'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-export type DTSIStanceDetailsQuoteProp = {
+export interface DTSIStanceDetailsQuoteProp {
   stanceType: DTSI_PersonStanceType.QUOTE
   quote: Pick<DTSI_PersonStanceQuote, 'richTextDescription' | 'sourceUrl'>
 }
 
-export type DTSIStanceDetailsTweetProp = {
+export interface DTSIStanceDetailsTweetProp {
   stanceType: DTSI_PersonStanceType.TWEET
   tweet: Pick<DTSI_Tweet, 'datetimeCreatedOnTwitter' | 'entities' | 'id' | 'text'> & {
     twitterAccount: Pick<DTSI_TwitterAccount, 'id' | 'username' | 'personId'>
@@ -25,7 +25,7 @@ export type DTSIStanceDetailsTweetProp = {
   }
 }
 
-export type DTSIStanceDetailsBillRelationshipProp = {
+export interface DTSIStanceDetailsBillRelationshipProp {
   stanceType: DTSI_PersonStanceType.BILL_RELATIONSHIP
   billRelationship: Pick<DTSI_BillPersonRelationship, 'id' | 'relationshipType'> & {
     bill: Pick<
@@ -62,7 +62,7 @@ export type DTSIStanceDetailsPersonProp = Pick<
   | 'slug'
 >
 
-export type StanceDetailsProps = {
+export interface StanceDetailsProps {
   countryCode: SupportedCountryCodes
   person: DTSIStanceDetailsPersonProp
   stance: DTSIStanceDetailsStancePassedProp

--- a/src/components/app/nftHub/nftDisplay.tsx
+++ b/src/components/app/nftHub/nftDisplay.tsx
@@ -8,11 +8,11 @@ import { NextImage } from '@/components/ui/image'
 import { NFTSlug } from '@/utils/shared/nft'
 import { NFT_CLIENT_METADATA } from '@/utils/web/nft'
 
-type NFTDisplayProps = {
+interface NFTDisplayProps {
   userActions: SensitiveDataClientUserAction[]
 }
 
-type NFTImages = {
+interface NFTImages {
   name: string
   image: string
   width: number

--- a/src/components/app/pageAdvocatesHeatmap/advocatesHeatmap.types.ts
+++ b/src/components/app/pageAdvocatesHeatmap/advocatesHeatmap.types.ts
@@ -2,7 +2,7 @@ import { getAdvocatesMapData } from '@/data/pageSpecific/getAdvocatesMapData'
 import { getHomepageData } from '@/data/pageSpecific/getHomepageData'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-export type PageAdvocatesHeatmapProps = {
+export interface PageAdvocatesHeatmapProps {
   countryCode: SupportedCountryCodes
   homepageData: Awaited<ReturnType<typeof getHomepageData>>
   advocatesMapPageData: Awaited<ReturnType<typeof getAdvocatesMapData>>

--- a/src/components/app/pageBillDetails/filters.tsx
+++ b/src/components/app/pageBillDetails/filters.tsx
@@ -50,7 +50,7 @@ const PARTY_OPTIONS_DISPLAY_NAME: Record<PARTY_OPTION, string> = {
   [DTSI_PersonPoliticalAffiliationCategory.DEMOCRAT]: 'Democratic',
 }
 
-export type FILTER_KEYS = {
+export interface FILTER_KEYS {
   stance: STANCE_OPTION
   role: ROLE_OPTION
   party: PARTY_OPTION

--- a/src/components/app/pageCommunity/common/constants.tsx
+++ b/src/components/app/pageCommunity/common/constants.tsx
@@ -4,7 +4,7 @@ import { toBool } from '@/utils/shared/toBool'
 const maybeIgnorePreGeneration = (num: number) =>
   toBool(process.env.MINIMIZE_PAGE_PRE_GENERATION) ? 1 : num
 
-type PaginationConfig = {
+interface PaginationConfig {
   totalPages: number
   itemsPerPage: number
   totalPregeneratedPages: number

--- a/src/components/app/pageDonate/faq/faqData.tsx
+++ b/src/components/app/pageDonate/faq/faqData.tsx
@@ -1,6 +1,6 @@
 import { ComponentType } from 'react'
 
-type FAQEntry = {
+interface FAQEntry {
   title: string
   content: ComponentType
 }

--- a/src/components/app/pageHome/common/politiciansSection.tsx
+++ b/src/components/app/pageHome/common/politiciansSection.tsx
@@ -9,7 +9,7 @@ import { DTSI_HomepagePeopleQuery, DTSI_PersonCardFragment } from '@/data/dtsi/g
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { getIntlUrls } from '@/utils/shared/urls'
 
-type HomepagePoliticiansSectionProps = {
+interface HomepagePoliticiansSectionProps {
   dtsiHomepagePoliticians: DTSI_HomepagePeopleQuery
   countryCode: SupportedCountryCodes
   cryptoStanceGrade: React.ComponentType<{

--- a/src/components/app/pageLocationKeyRaces/us/locationStateSpecific/userLocationRaceInfo.tsx
+++ b/src/components/app/pageLocationKeyRaces/us/locationStateSpecific/userLocationRaceInfo.tsx
@@ -23,7 +23,7 @@ import {
 import { DEFAULT_SUPPORTED_COUNTRY_CODE } from '@/utils/shared/supportedCountries'
 import { getIntlUrls } from '@/utils/shared/urls'
 
-type UserLocationRaceInfoProps = {
+interface UserLocationRaceInfoProps {
   groups: ReturnType<typeof organizeStateSpecificPeople>
   stateCode: USStateCode
   stateName: string

--- a/src/components/app/pageResources/resourcesCard.tsx
+++ b/src/components/app/pageResources/resourcesCard.tsx
@@ -1,6 +1,6 @@
 import { NextImage } from '@/components/ui/image'
 
-type Props = {
+interface Props {
   imageUrl: string
   title: string
   subtitle: string

--- a/src/components/app/pageVoterGuide/types.ts
+++ b/src/components/app/pageVoterGuide/types.ts
@@ -2,7 +2,7 @@ import { UserActionType } from '@prisma/client'
 
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-export type VoterGuideStep = {
+export interface VoterGuideStep {
   title: string
   description: string
   WrapperComponent: (args: {

--- a/src/components/app/recentActivityRow/activityAvatar.tsx
+++ b/src/components/app/recentActivityRow/activityAvatar.tsx
@@ -26,7 +26,7 @@ const ACTIVITY_TYPE_TO_ICON_URL: Record<UserActionType, string> = {
   [UserActionType.VIEW_KEY_PAGE]: '/activityFeedIcons/email.svg',
 }
 
-type ActivityAvatarProps = {
+interface ActivityAvatarProps {
   actionType: ClientUserAction['actionType']
   size: number
 }

--- a/src/components/app/userActionFormCallCongressperson/types.ts
+++ b/src/components/app/userActionFormCallCongressperson/types.ts
@@ -1,4 +1,4 @@
-export type FormFields = {
+export interface FormFields {
   address: {
     description: string
     place_id: string

--- a/src/components/app/userActionFormEmailCongressperson/types.ts
+++ b/src/components/app/userActionFormEmailCongressperson/types.ts
@@ -1,4 +1,4 @@
-export type FormFields = {
+export interface FormFields {
   address: {
     description: string
     place_id: string

--- a/src/components/app/userActionFormEmailDebate/types.ts
+++ b/src/components/app/userActionFormEmailDebate/types.ts
@@ -1,4 +1,4 @@
-export type UserActionEmailDebateFormFields = {
+export interface UserActionEmailDebateFormFields {
   address: {
     description: string
     place_id: string

--- a/src/components/app/userActionFormFollowOnLinkedIn/common/types.d.ts
+++ b/src/components/app/userActionFormFollowOnLinkedIn/common/types.d.ts
@@ -1,6 +1,6 @@
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-export type UserActionFormFollowLinkedInProps = {
+export interface UserActionFormFollowLinkedInProps {
   countryCode: SupportedCountryCodes
   onClose: () => void
 }

--- a/src/components/app/userActionFormLiveEvent/index.tsx
+++ b/src/components/app/userActionFormLiveEvent/index.tsx
@@ -12,7 +12,7 @@ import { NFTSlug } from '@/utils/shared/nft'
 import { USUserActionLiveEventCampaignName } from '@/utils/shared/userActionCampaigns/us/usUserActionCampaigns'
 import { NFT_CLIENT_METADATA } from '@/utils/web/nft'
 
-export type UserActionFormLiveEventProps = {
+export interface UserActionFormLiveEventProps {
   slug: USUserActionLiveEventCampaignName
   onClose: () => void
   isLoggedIn: boolean

--- a/src/components/app/userActionFormShareOnTwitter/common/types.d.ts
+++ b/src/components/app/userActionFormShareOnTwitter/common/types.d.ts
@@ -1,6 +1,6 @@
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-export type UserActionFormShareOnTwitterProps = {
+export interface UserActionFormShareOnTwitterProps {
   countryCode: SupportedCountryCodes
   onClose: () => void
 }

--- a/src/components/app/userActionFormVoterAttestation/types.ts
+++ b/src/components/app/userActionFormVoterAttestation/types.ts
@@ -1,4 +1,4 @@
-export type FormFields = {
+export interface FormFields {
   address: {
     description: string
     place_id: string

--- a/src/components/app/userActionGridCTAs/hooks/useOrderedCTAs.ts
+++ b/src/components/app/userActionGridCTAs/hooks/useOrderedCTAs.ts
@@ -6,7 +6,7 @@ import { getUserActionCTAsByCountry } from '@/components/app/userActionGridCTAs/
 import { UserActionGridCTACampaign } from '@/components/app/userActionGridCTAs/types'
 import { useCountryCode } from '@/hooks/useCountryCode'
 
-type CTAType = {
+interface CTAType {
   title: string
   description: string
   mobileCTADescription?: string

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -12,7 +12,7 @@ type CarouselApi = UseEmblaCarouselType[1]
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
 type CarouselOptions = UseCarouselParameters[0]
 
-type CarouselProps = {
+interface CarouselProps {
   opts?: CarouselOptions
   orientation?: 'horizontal' | 'vertical'
   setApi?: (api: CarouselApi) => void

--- a/src/components/ui/experimentsTesting/index.ts
+++ b/src/components/ui/experimentsTesting/index.ts
@@ -23,7 +23,7 @@ export function useExperimentName<K extends Experiments>({
   return variant
 }
 
-type ExperimentsComponentProps<K extends Experiments> = {
+interface ExperimentsComponentProps<K extends Experiments> {
   experimentName: K
   variants: Record<IExperimentContext[K], React.ReactNode>
 }

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -20,10 +20,10 @@ import { GENERIC_FORM_ERROR_KEY } from '@/utils/web/formUtils'
 
 const Form = FormProvider
 
-type FormFieldContextValue<
+interface FormFieldContextValue<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
-> = {
+> {
   name: TName
 }
 
@@ -80,7 +80,7 @@ const useFormField = () => {
   }
 }
 
-type FormItemContextValue = {
+interface FormItemContextValue {
   id: string
 }
 

--- a/src/components/ui/initialsAvatar.tsx
+++ b/src/components/ui/initialsAvatar.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/utils/web/cn'
 
-type InitialsAvatarProps = {
+interface InitialsAvatarProps {
   size: number
   className?: string
   firstInitial: string

--- a/src/components/ui/responsiveTabsOrSelect.tsx
+++ b/src/components/ui/responsiveTabsOrSelect.tsx
@@ -14,7 +14,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { cn } from '@/utils/web/cn'
 
-type TabOption = {
+interface TabOption {
   value: string
   label: string
   content: React.ReactNode

--- a/src/data/aggregations/getSumDonationsByUser.ts
+++ b/src/data/aggregations/getSumDonationsByUser.ts
@@ -8,7 +8,7 @@ import { getClientModel } from '@/clientModels/utils'
 import { getENSDataMapFromCryptoAddressesAndFailGracefully } from '@/data/web3/getENSDataFromCryptoAddress'
 import { prismaClient } from '@/utils/server/prismaClient'
 
-type SumDonationsByUserConfig = {
+interface SumDonationsByUserConfig {
   limit: number
   offset?: number
   pageNum: number

--- a/src/hooks/useScript.ts
+++ b/src/hooks/useScript.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 
 type UseScriptStatus = 'idle' | 'loading' | 'ready' | 'error'
 
-type UseScriptOptions = {
+interface UseScriptOptions {
   shouldPreventLoad?: boolean
   removeOnUnmount?: boolean
   id?: string

--- a/src/hooks/useSendMintNFTTransaction.ts
+++ b/src/hooks/useSendMintNFTTransaction.ts
@@ -10,7 +10,7 @@ import { logger } from '@/utils/shared/logger'
 import { thirdwebClient } from '@/utils/shared/thirdwebClient'
 import { safeStringify } from '@/utils/web/safeStringify'
 
-type UseSendMintNFTTransactionOptions = {
+interface UseSendMintNFTTransactionOptions {
   contractAddress: string
   quantity: number
 }

--- a/src/inngest/functions/backfillIntlUsers/index.ts
+++ b/src/inngest/functions/backfillIntlUsers/index.ts
@@ -95,7 +95,7 @@ const eventPayloadSchema = z.object({
   persist: z.boolean().optional().default(false),
 })
 
-export type BackfillIntlUsersSchema = {
+export interface BackfillIntlUsersSchema {
   name: typeof BACKFILL_INTL_USERS_INNGEST_EVENT_NAME
   data: z.infer<typeof eventPayloadSchema>
 }

--- a/src/inngest/functions/backfillIntlUsers/logic.ts
+++ b/src/inngest/functions/backfillIntlUsers/logic.ts
@@ -27,7 +27,7 @@ export const PROCESS_BATCH_EVENT_NAME = 'script/backfill-intl-users.process-batc
 export const PROCESS_BATCH_FUNCTION_ID = 'script.backfill-intl-users.process-batch'
 const TRANSACTION_CONNECTION_LIMIT = 50
 
-export type ProcessBatchSchema = {
+export interface ProcessBatchSchema {
   name: typeof PROCESS_BATCH_EVENT_NAME
   data: {
     countryCode: SupportedCountryCodes
@@ -38,7 +38,7 @@ export type ProcessBatchSchema = {
   }
 }
 
-type UserProcessingResult = {
+interface UserProcessingResult {
   action: 'created' | 'updated' | 'skipped' | 'error'
   email: string
   userId?: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-export type PageProps<Params = object> = {
+export interface PageProps<Params = object> {
   params: Promise<
     Params & {
       countryCode: SupportedCountryCodes

--- a/src/types/twitter.ts
+++ b/src/types/twitter.ts
@@ -32,7 +32,7 @@ type TweetMedia =
       duration_ms: 105405
     }
 
-type TweetEntryTextEntity = {
+interface TweetEntryTextEntity {
   start: number
   end: number
 }

--- a/src/utils/server/capitolCanary/fetchAdvocates.ts
+++ b/src/utils/server/capitolCanary/fetchAdvocates.ts
@@ -6,7 +6,7 @@ import { sendCapitolCanaryRequest } from '@/utils/server/capitolCanary/sendCapit
 
 const CAPITOL_CANARY_CREATE_ADVOCATE_API_URL = 'https://api.phone2action.com/2.0/advocates'
 
-export type FetchAdvocatesFromCapitolCanaryRequest = {
+export interface FetchAdvocatesFromCapitolCanaryRequest {
   updatedSince?: number
   page?: number
   campaignid?: number
@@ -15,12 +15,12 @@ export type FetchAdvocatesFromCapitolCanaryRequest = {
   phone?: string
 }
 
-type FetchAdvocatesFromCapitolCanaryResponse = {
+interface FetchAdvocatesFromCapitolCanaryResponse {
   data: FetchAdvocatesFromCapitolCanaryData[]
   pagination: FetchAdvocatesFromCapitolCanaryPageInfo
 }
 
-type FetchAdvocatesFromCapitolCanaryData = {
+interface FetchAdvocatesFromCapitolCanaryData {
   id: number
   firstname: string
   middlename: string
@@ -35,7 +35,7 @@ type FetchAdvocatesFromCapitolCanaryData = {
   tags: string[]
 }
 
-type FetchAdvocatesFromCapitolCanaryAddress = {
+interface FetchAdvocatesFromCapitolCanaryAddress {
   street1: string
   street2: string
   city: string
@@ -49,7 +49,7 @@ type FetchAdvocatesFromCapitolCanaryAddress = {
   longitude: string
 }
 
-type FetchAdvocatesFromCapitolCanaryMembership = {
+interface FetchAdvocatesFromCapitolCanaryMembership {
   id: number
   campaignid: number
   campaigntype: string
@@ -58,14 +58,14 @@ type FetchAdvocatesFromCapitolCanaryMembership = {
   source: string
 }
 
-type FetchAdvocatesFromCapitolCanaryContact = {
+interface FetchAdvocatesFromCapitolCanaryContact {
   id: number
   address: string
   subscribed: boolean
   valid: boolean
 }
 
-type FetchAdvocatesFromCapitolCanaryPageInfo = {
+interface FetchAdvocatesFromCapitolCanaryPageInfo {
   count: number
   current_page: number
   next_url: string

--- a/src/utils/server/districtRankings/getRankingData.ts
+++ b/src/utils/server/districtRankings/getRankingData.ts
@@ -5,19 +5,19 @@ import { logger } from '@/utils/shared/logger'
 import { USStateCode } from '@/utils/shared/stateMappings/usStateUtils'
 import { zodStateDistrict } from '@/validation/fields/zodAddress'
 
-type Result = {
+interface Result {
   state: USStateCode
   district: string
   count: number
 }
 
-type AdvocatesCountByDistrictQueryResult = {
+interface AdvocatesCountByDistrictQueryResult {
   state: string
   district: string
   count: number
 }
 
-type ReferralsCountByDistrictQueryResult = {
+interface ReferralsCountByDistrictQueryResult {
   state: string
   district: string
   refer_actions_count: number

--- a/src/utils/server/districtRankings/upsertRankings.ts
+++ b/src/utils/server/districtRankings/upsertRankings.ts
@@ -9,7 +9,7 @@ import { USStateCode } from '@/utils/shared/stateMappings/usStateUtils'
 
 import { CURRENT_DISTRICT_RANKING, REDIS_KEYS } from './constants'
 
-export type DistrictRankingEntry = {
+export interface DistrictRankingEntry {
   state: USStateCode
   district: string
   count: number
@@ -170,7 +170,7 @@ export async function createDistrictRankingIncrementer(
 type RedisInterlacedResult = Array<[MemberKey, number]>
 export type DistrictRankingEntryWithRank = DistrictRankingEntry & { rank: number }
 
-export type LeaderboardPaginationData = {
+export interface LeaderboardPaginationData {
   items: DistrictRankingEntryWithRank[]
   total: number
 }

--- a/src/utils/server/externalOptIn/types.ts
+++ b/src/utils/server/externalOptIn/types.ts
@@ -20,7 +20,7 @@ export type Input = z.infer<ReturnType<typeof getZodExternalUserActionOptInSchem
   partner?: VerifiedSWCPartner
 }
 
-export type ExternalUserActionOptInResponse<ResultOptions extends string> = {
+export interface ExternalUserActionOptInResponse<ResultOptions extends string> {
   result: ResultOptions
   resultOptions: ResultOptions[]
   sessionId: string

--- a/src/utils/server/generateOpenGraphImageUrl.ts
+++ b/src/utils/server/generateOpenGraphImageUrl.ts
@@ -1,7 +1,10 @@
 import { encodeObjectForUrl } from '@/utils/shared/encodeObjectForUrl'
 import { fullUrl } from '@/utils/shared/urls'
 
-export type OpenGraphImageOptions = { title: string; description?: string }
+export interface OpenGraphImageOptions {
+  title: string
+  description?: string
+}
 export const OPEN_GRAPH_IMAGE_DIMENSIONS = {
   width: 1200,
   height: 630,

--- a/src/utils/server/serverAnalytics/serverAnalytics.ts
+++ b/src/utils/server/serverAnalytics/serverAnalytics.ts
@@ -18,7 +18,10 @@ import { ANALYTICS_FLUSH_TIMEOUT_MS, mixpanel } from './shared'
 
 const logger = getLogger('serverAnalytics')
 
-type ServerAnalyticsConfig = { localUser: LocalUser | null; userId: string }
+interface ServerAnalyticsConfig {
+  localUser: LocalUser | null
+  userId: string
+}
 
 const promisifiedMixpanelTrack = promisify<string, PropertyDict, void>(mixpanel.track)
 

--- a/src/utils/server/serverAnalytics/serverPeopleAnalytics.ts
+++ b/src/utils/server/serverAnalytics/serverPeopleAnalytics.ts
@@ -9,7 +9,10 @@ import { ANALYTICS_FLUSH_TIMEOUT_MS, mixpanel } from './shared'
 
 const logger = getLogger('serverPeopleAnalytics')
 
-type ServerAnalyticsConfig = { localUser: LocalUser | null; userId: string }
+interface ServerAnalyticsConfig {
+  localUser: LocalUser | null
+  userId: string
+}
 
 export type ServerPeopleAnalytics = ReturnType<typeof getServerPeopleAnalytics>
 

--- a/src/utils/server/serverLocalUser.ts
+++ b/src/utils/server/serverLocalUser.ts
@@ -12,7 +12,7 @@ import {
   PersistedLocalUser,
 } from '@/utils/shared/localUser'
 
-export type ServerLocalUser = {
+export interface ServerLocalUser {
   persisted: PersistedLocalUser
   currentSession: CurrentSessionLocalUser
 }

--- a/src/utils/server/thirdweb/fetchBaseETHBalances.ts
+++ b/src/utils/server/thirdweb/fetchBaseETHBalances.ts
@@ -2,7 +2,7 @@ import { formatEther } from 'viem'
 
 import { thirdwebBaseRPCClient } from '@/utils/server/thirdweb/thirdwebRPCClients'
 
-type BaseETHBalance = {
+interface BaseETHBalance {
   walletAddress: string
   ethValue: number
 }

--- a/src/utils/server/thirdweb/onLogin.ts
+++ b/src/utils/server/thirdweb/onLogin.ts
@@ -173,7 +173,7 @@ export async function login(
   currentCookies.set(THIRDWEB_AUTH_TOKEN_COOKIE_PREFIX, jwt)
 }
 
-type ExistingUserLoginParams = {
+interface ExistingUserLoginParams {
   existingVerifiedUser: User
   cryptoAddress: string
   localUser: ServerLocalUser | null
@@ -574,7 +574,9 @@ async function queryMatchingUsers({
   return { embeddedWalletUserDetails, existingUsersWithSource }
 }
 
-type FindUsersToMergeOptions = { userToKeepId?: string }
+interface FindUsersToMergeOptions {
+  userToKeepId?: string
+}
 
 function findUsersToMerge(
   existingUsersWithSource: Awaited<
@@ -926,7 +928,7 @@ async function triggerPostLoginUserActionSteps({
   return { pastActionsMinted, hadOptInUserAction, optInUserAction }
 }
 
-type GetExistingUserArgs = {
+interface GetExistingUserArgs {
   cryptoAddress: string
   userSessionId: string | null
   embeddedWalletUserDetails: ThirdwebEmbeddedWalletMetadata | null

--- a/src/utils/server/verifiedSWCPartner/constants.ts
+++ b/src/utils/server/verifiedSWCPartner/constants.ts
@@ -4,7 +4,7 @@ export enum VerifiedSWCPartner {
   COINBASE = 'coinbase',
 }
 
-export type VerifiedSWCPartnerApiResponse<ResultOptions extends string> = {
+export interface VerifiedSWCPartnerApiResponse<ResultOptions extends string> {
   result: ResultOptions | null
   resultOptions: ResultOptions[] | []
   sessionId: string

--- a/src/utils/shared/encodeObjectForUrl.ts
+++ b/src/utils/shared/encodeObjectForUrl.ts
@@ -2,7 +2,9 @@
 import stringify from 'fast-json-stable-stringify'
 import { isString } from 'lodash-es'
 
-type EncodedObject = { [key: string]: string | number | boolean | null | undefined }
+interface EncodedObject {
+  [key: string]: string | number | boolean | null | undefined
+}
 
 /*
 base64 encoding does not accept non-standard unicode characters and seo we encode all strings on the object before serializing/de-serializing

--- a/src/utils/shared/getCongressionalDistrictFromAddress.ts
+++ b/src/utils/shared/getCongressionalDistrictFromAddress.ts
@@ -72,7 +72,7 @@ export type CongressionalDistrictFromAddress = Awaited<
   ReturnType<typeof getCongressionalDistrictFromAddress>
 >
 
-export type GetCongressionalDistrictFromAddressParams = {
+export interface GetCongressionalDistrictFromAddressParams {
   stateCode?: USStateCode
 }
 

--- a/src/utils/shared/getCryptoToFiatConversion.ts
+++ b/src/utils/shared/getCryptoToFiatConversion.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/nextjs'
 
 import { fetchReq } from '@/utils/shared/fetchReq'
 
-type CryptoToFiatConversionResult = {
+interface CryptoToFiatConversionResult {
   data: {
     amount: Decimal
     currency: string

--- a/src/utils/shared/isValidCountryCode.ts
+++ b/src/utils/shared/isValidCountryCode.ts
@@ -1,6 +1,6 @@
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-type IsValidCountryCodeArgs = {
+interface IsValidCountryCodeArgs {
   countryCode: string
   userAccessLocation?: string
   bypassCountryCheck?: boolean

--- a/src/utils/shared/sharedAnalytics.ts
+++ b/src/utils/shared/sharedAnalytics.ts
@@ -32,13 +32,13 @@ export enum AnalyticActionType {
   keyPress = 'Key Press',
 }
 
-export type AnalyticProperties = {
+export interface AnalyticProperties {
   action?: AnalyticActionType
   component?: AnalyticComponentType
   [key: string]: string | number | boolean | undefined | null | Date | string[] | number[]
 }
 
-export type AnalyticsPeopleProperties = {
+export interface AnalyticsPeopleProperties {
   // https://docs.mixpanel.com/docs/data-structure/user-profiles#reserved-user-properties
   // if we end up using other tools, we might need to map these reserved names to other values
   $email?: string

--- a/src/utils/shared/urlsDeeplinkUserActions.ts
+++ b/src/utils/shared/urlsDeeplinkUserActions.ts
@@ -20,7 +20,7 @@ const parseQueryString = (queryString?: string) => {
   return `?${queryString}`
 }
 
-type DeeplinkConfig = {
+interface DeeplinkConfig {
   countryCode: SupportedCountryCodes
   queryString?: string
 }
@@ -136,7 +136,7 @@ const USER_ACTION_WITH_CAMPAIGN_DEEPLINK_MAP: {
   },
 }
 
-type GetUserActionDeeplinkArgs<ActionType extends UserActionTypesWithDeeplink> = {
+interface GetUserActionDeeplinkArgs<ActionType extends UserActionTypesWithDeeplink> {
   actionType: ActionType
   config: DeeplinkConfig
   campaign?: UserActionCampaignNames

--- a/src/utils/shared/userActionCampaigns/au/auUserActionCampaigns.ts
+++ b/src/utils/shared/userActionCampaigns/au/auUserActionCampaigns.ts
@@ -63,7 +63,7 @@ export type AUUserActionCampaignName =
   | AUUserActionViewKeyPageCampaignName
   | AUUserActionPollCampaignName
 
-export type AUUserActionCampaigns = {
+export interface AUUserActionCampaigns {
   [UserActionType.OPT_IN]: UserActionOptInCampaignName
   [UserActionType.TWEET]: AUUserActionTweetCampaignName
   [UserActionType.LINKEDIN]: AUUserActionLinkedInCampaignName

--- a/src/utils/shared/userActionCampaigns/ca/caUserActionCampaigns.ts
+++ b/src/utils/shared/userActionCampaigns/ca/caUserActionCampaigns.ts
@@ -63,7 +63,7 @@ export type CAUserActionCampaignName =
   | CAUserActionViewKeyPageCampaignName
   | CAUserActionPollCampaignName
 
-export type CAUserActionCampaigns = {
+export interface CAUserActionCampaigns {
   [UserActionType.OPT_IN]: UserActionOptInCampaignName
   [UserActionType.TWEET]: CAUserActionTweetCampaignName
   [UserActionType.LINKEDIN]: CAUserActionLinkedInCampaignName

--- a/src/utils/shared/userActionCampaigns/gb/gbUserActionCampaigns.ts
+++ b/src/utils/shared/userActionCampaigns/gb/gbUserActionCampaigns.ts
@@ -62,7 +62,7 @@ export type GBUserActionCampaignName =
   | GBUserActionViewKeyPageCampaignName
   | GBUserActionPollCampaignName
 
-export type GBUserActionCampaigns = {
+export interface GBUserActionCampaigns {
   [UserActionType.OPT_IN]: UserActionOptInCampaignName
   [UserActionType.TWEET]: GBUserActionTweetCampaignName
   [UserActionType.LINKEDIN]: GBUserActionLinkedInCampaignName

--- a/src/utils/shared/userActionCampaigns/index.ts
+++ b/src/utils/shared/userActionCampaigns/index.ts
@@ -27,7 +27,7 @@ import {
 } from '@/utils/shared/userActionCampaigns/us/usUserActionCampaigns'
 
 // Define which action types are available for each country
-export type CountryActiveClientUserActionWithCampaignType = {
+export interface CountryActiveClientUserActionWithCampaignType {
   [SupportedCountryCodes.US]: USActiveClientUserActionWithCampaignType
   [SupportedCountryCodes.GB]: GBActiveClientUserActionWithCampaignType
   [SupportedCountryCodes.CA]: CAActiveClientUserActionWithCampaignType
@@ -46,7 +46,7 @@ export const COUNTRY_ACTIVE_CLIENT_USER_ACTION_WITH_CAMPAIGN: {
   [SupportedCountryCodes.AU]: AU_ACTIVE_CLIENT_USER_ACTION_WITH_CAMPAIGN,
 }
 
-export type CountryUserActionCampaigns = {
+export interface CountryUserActionCampaigns {
   [SupportedCountryCodes.US]: USUserActionCampaigns
   [SupportedCountryCodes.GB]: GBUserActionCampaigns
   [SupportedCountryCodes.CA]: CAUserActionCampaigns

--- a/src/utils/shared/userActionCampaigns/us/usUserActionCampaigns.ts
+++ b/src/utils/shared/userActionCampaigns/us/usUserActionCampaigns.ts
@@ -118,7 +118,7 @@ export type USUserActionCampaignName =
   | USUserActionReferCampaignName
   | USUserActionPollCampaignName
   | USUserActionLinkedinCampaignName
-export type USUserActionCampaigns = {
+export interface USUserActionCampaigns {
   [UserActionType.EMAIL]: USUserActionEmailCampaignName
   [UserActionType.CALL]: USUserActionCallCampaignName
   [UserActionType.DONATION]: USUserActionDonationCampaignName

--- a/src/utils/web/formUtils.ts
+++ b/src/utils/web/formUtils.ts
@@ -15,7 +15,7 @@ import {
 import { formatErrorStatus } from '@/utils/web/errorUtils'
 
 export const GENERIC_FORM_ERROR_KEY = 'FORM_ERROR' as const
-export type GenericErrorFormValues = {
+export interface GenericErrorFormValues {
   FORM_ERROR?: string
 }
 

--- a/src/utils/web/primitiveComponentAnalytics.ts
+++ b/src/utils/web/primitiveComponentAnalytics.ts
@@ -7,7 +7,7 @@ type AnalyticsFnCall<A> = (params: {
   properties: { Category: string } & AnalyticProperties
 }) => void
 
-export type PrimitiveComponentAnalytics<A> = {
+export interface PrimitiveComponentAnalytics<A> {
   analytics: string | ({ Category: string } & AnalyticProperties) | ((args: A) => void)
 }
 


### PR DESCRIPTION
closes #359 

## What changed? Why?

A new ESLint rule was added to enforce TS 'interface' usage convention.
This is relevant to follow our Coding Conventions accordingly.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test

**Evidence:**

![image](https://github.com/user-attachments/assets/314f07ff-a478-4050-b205-291158473f3d)
