### PR TITLE
fix: fix trigger toast error

### DIFF
--- a/src/utils/web/googlePlaceUtils.ts
+++ b/src/utils/web/googlePlaceUtils.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
+import { isError } from 'lodash-es'
 import { getDetails } from 'use-places-autocomplete'
 import { z } from 'zod'
 
@@ -91,7 +92,7 @@ async function getAddressWithRetry(prediction: GooglePlaceAutocompletePrediction
     if (error === 'NOT_FOUND' || error === 'INVALID_REQUEST') {
       return await handleExpiredPlaceId(prediction)
     }
-    throw error
+    throw isError(error) ? error : new Error(String(error))
   }
 }
 


### PR DESCRIPTION
closes #1489 

fixes PROD-SWC-WEB-SE

## What changed? Why?

The issue "Unexpected error type passed to catchUnexpectedServerErrorAndTriggerToast" was fixed.

Previously, the `getAddressWithRetry` function was rethrowing error strings directly from `use-places-autocomplete` without converting them to `Error` instances. This caused an issue because `catchUnexpectedServerErrorAndTriggerToast` expects an `Error`, not a string.

The `getAddressWithRetry` function now converts any error strings to `Error` instances before rethrowing. This ensures `catchUnexpectedServerErrorAndTriggerToast` receives errors in the expected format.

![image](https://github.com/user-attachments/assets/db164124-f604-4e42-a309-947e11fb80d9)

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
