### PR TITLE
Feat: show datetime in CA and AU community feed

### DIFF
--- a/src/components/app/recentActivityRow/recentActivityRow.tsx
+++ b/src/components/app/recentActivityRow/recentActivityRow.tsx
@@ -74,7 +74,7 @@ function ActionAdditionalInfo({ action, countryCode }: ActionAdditionalInfoProps
   }
 
   // TODO: Change this to a prop instead of hardcoded based on the countryCode
-  if (countryCode !== SupportedCountryCodes.US) {
+  if (countryCode === SupportedCountryCodes.GB) {
     const { administrativeAreaLevel1, countryCode: userLocationCountryCode } =
       action.user.userLocationDetails ?? {}
     const hasUserChangedLocationSinceActionCompleted =


### PR DESCRIPTION
## What changed? Why?

Restores datetime in community feed for AU and CA

## Screenshot

<img width="1273" alt="image" src="https://github.com/user-attachments/assets/e8145225-aa13-4115-976f-6a778ab1eab8" />


## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
