### PR TITLE
fix: only send opt-out custom message for countries with shot-code phone number

### DIFF
--- a/src/utils/server/sms/actions.ts
+++ b/src/utils/server/sms/actions.ts
@@ -15,6 +15,13 @@ import { smsProvider, SMSProviders } from '@/utils/shared/sms/smsProvider'
 import { isSmsSupportedInCountry } from '@/utils/shared/sms/smsSupportedCountries'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
+// Countries without short code phone numbers are not allowed to send SMS messages to users
+// that replied STOP. Twilio will send a default message to the user when this happens.
+const COUNTRIES_WITH_SHORT_CODE_PHONE_NUMBERS: SupportedCountryCodes[] = [
+  SupportedCountryCodes.US,
+  SupportedCountryCodes.CA,
+]
+
 export async function optInUser({
   phoneNumber,
   user,
@@ -130,7 +137,11 @@ export async function optOutUser({
     },
   })
 
-  if (smsProvider === SMSProviders.TWILIO) {
+  if (
+    smsProvider === SMSProviders.TWILIO &&
+    COUNTRIES_WITH_SHORT_CODE_PHONE_NUMBERS.includes(countryCode) &&
+    smsMessages.goodbyeMessage
+  ) {
     await inngest.send({
       name: ENQUEUE_SMS_INNGEST_EVENT_NAME,
       data: {
@@ -201,7 +212,11 @@ export async function optUserBackIn({
     },
   })
 
-  if (smsProvider === SMSProviders.TWILIO) {
+  if (
+    smsProvider === SMSProviders.TWILIO &&
+    COUNTRIES_WITH_SHORT_CODE_PHONE_NUMBERS.includes(countryCode) &&
+    smsMessages.unstopConfirmationMessage
+  ) {
     await inngest.send({
       name: ENQUEUE_SMS_INNGEST_EVENT_NAME,
       data: {

--- a/src/utils/server/sms/actions.ts
+++ b/src/utils/server/sms/actions.ts
@@ -15,8 +15,8 @@ import { smsProvider, SMSProviders } from '@/utils/shared/sms/smsProvider'
 import { isSmsSupportedInCountry } from '@/utils/shared/sms/smsSupportedCountries'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-// Countries without short code phone numbers are not allowed to send SMS messages to users
-// that replied STOP. Twilio will send a default message to the user when this happens.
+// Countries without short code phone numbers are not allowed to send SMS messages to users that replied STOP.
+// A default message will be sent to the user when they reply STOP and START.
 const COUNTRIES_WITH_SHORT_CODE_PHONE_NUMBERS: SupportedCountryCodes[] = [
   SupportedCountryCodes.US,
   SupportedCountryCodes.CA,

--- a/src/utils/server/sms/messages.ts
+++ b/src/utils/server/sms/messages.ts
@@ -3,8 +3,8 @@ import { fullUrl } from '@/utils/shared/urls'
 
 interface SMSMessages {
   welcomeMessage: string
-  goodbyeMessage: string
-  unstopConfirmationMessage: string
+  goodbyeMessage?: string
+  unstopConfirmationMessage?: string
   helpMessage: string
   bulkWelcomeMessage: string
 }
@@ -19,8 +19,6 @@ const US_SMS_MESSAGES: SMSMessages = {
 
 const GB_SMS_MESSAGES: SMSMessages = {
   welcomeMessage: `Thanks for subscribing to Stand With Crypto! You can expect news, opportunities to engage, and critical updates on crypto policy. Browse our resources and research where your elected officials stand on crypto at ${fullUrl(`/${SupportedCountryCodes.GB}`)}\n\nMessage & data rates may apply. Message frequency varies. Reply HELP for help or STOP to opt out.`,
-  goodbyeMessage: `You have opted out and will no longer receive texts from Stand With Crypto. Text START to receive texts from SWC.`,
-  unstopConfirmationMessage: `Thanks for subscribing to Stand With Crypto. Message & data rates may apply. Message frequency varies. Reply HELP for help or STOP to opt out.`,
   helpMessage: `Reply STOP to unsubscribe. Contact Stand With Crypto Support at uk@swcinternational.org`,
   bulkWelcomeMessage: `Thank you for being a Stand With Crypto advocate. Message & data rates may apply. Message frequency varies. Reply HELP for help or STOP to opt out.`,
 }
@@ -35,8 +33,6 @@ const CA_SMS_MESSAGES: SMSMessages = {
 
 const AU_SMS_MESSAGES: SMSMessages = {
   welcomeMessage: `Thanks for subscribing to Stand With Crypto! You can expect news, opportunities to engage, and critical updates on crypto policy. Browse our resources and research where your elected officials stand on crypto at ${fullUrl(`/${SupportedCountryCodes.AU}`)}\n\nMessage & data rates may apply. Message frequency varies. Reply HELP for help or STOP to opt out.`,
-  goodbyeMessage: `You have opted out and will no longer receive texts from Stand With Crypto. Text START to receive texts from SWC.`,
-  unstopConfirmationMessage: `Thanks for subscribing to Stand With Crypto. Message & data rates may apply. Message frequency varies. Reply HELP for help or STOP to opt out.`,
   helpMessage: `Reply STOP to unsubscribe. Contact Stand With Crypto Support at au@swcinternational.org`,
   bulkWelcomeMessage: `Thank you for being a Stand With Crypto advocate. Message & data rates may apply. Message frequency varies. Reply HELP for help or STOP to opt out.`,
 }


### PR DESCRIPTION
fixes [PROD-SWC-WEB-4DP](https://stand-with-crypto.sentry.io/issues/5682999612/events/4fb88413b95a47909a9853eaeda954ad/)

## What changed? Why?

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
