### PR TITLE
fix: allow mx to pass user access location validation for border cases

### DIFF
--- a/src/utils/server/getUserAccessLocationCookie.ts
+++ b/src/utils/server/getUserAccessLocationCookie.ts
@@ -40,7 +40,10 @@ export async function getUserAccessLocationCookie<TBypassCountryCodeCheck extend
       : SupportedCountryCodes
   }
 
-  if (!COUNTRY_CODE_REGEX_PATTERN.test(maybeUserAccessLocationCookie)) {
+  if (
+    !COUNTRY_CODE_REGEX_PATTERN.test(maybeUserAccessLocationCookie) &&
+    maybeUserAccessLocationCookie !== 'mx' // there are cases where users in the US are getting blocked if they are close to the US border so we want to be more permissive with Canada/Mexico
+  ) {
     const error = new Error('Invalid User Access Location cookie.')
     Sentry.captureException(error, { tags: { countryCode: maybeUserAccessLocationCookie } })
     throw error


### PR DESCRIPTION
fixes [PROD-SWC-WEB-63V](https://stand-with-crypto.sentry.io/issues/6537023319/events/15879378e8284af185b11b0f9f91de78/)

## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
