### PR TITLE
chore: makes google places error ignore regex more generic

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -106,7 +106,7 @@ Sentry.init({
     // `Can't find variable: bytecode`,
     'ResizeObserver loop limit exceeded',
     'ResizeObserver loop completed with undelivered notifications',
-    /As of March 1st, 2025, google\.maps\.places.*/,
+    /As of March 1st, 2025, google\.maps\.places.*/i,
   ],
   beforeSend: (event, hint) => {
     // prevent local errors from triggering sentry

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -106,7 +106,7 @@ Sentry.init({
     // `Can't find variable: bytecode`,
     'ResizeObserver loop limit exceeded',
     'ResizeObserver loop completed with undelivered notifications',
-    /As of March 1st, 2025, google\.maps\.places\.AutocompleteService.*/,
+    /As of March 1st, 2025, google\.maps\.places.*/,
   ],
   beforeSend: (event, hint) => {
     // prevent local errors from triggering sentry

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -106,7 +106,7 @@ Sentry.init({
     // `Can't find variable: bytecode`,
     'ResizeObserver loop limit exceeded',
     'ResizeObserver loop completed with undelivered notifications',
-    'As of March 1st, 2025, google.maps.places.AutocompleteService is not available to new customers. Please use google.maps.places.AutocompleteSuggestion instead. At this time, google.maps.places.AutocompleteService is not scheduled to be discontinued',
+    /As of March 1st, 2025, google\.maps\.places\.AutocompleteService.*/,
   ],
   beforeSend: (event, hint) => {
     // prevent local errors from triggering sentry


### PR DESCRIPTION
## What changed? Why?

This PR makes the ignore regex more generic to catch autocomplete and place errors

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
