### PR TITLE
Fix isMarketingEmail check failing when event originates from a test marketing email

### DIFF
--- a/src/utils/server/email/utils/parseEventsWebhookRequest.ts
+++ b/src/utils/server/email/utils/parseEventsWebhookRequest.ts
@@ -6,10 +6,15 @@ import { EmailEvent, MarketingEmailEvent } from '@/utils/server/email/constants'
  * @returns an object where the key is the message_id and the value is an array of events that message received
  */
 export function parseEventsWebhookRequest(requestBody: EmailEvent[]) {
-  const transactionalEvents = requestBody.filter(event => !isMarketingEmailEvent(event))
+  const transactionalEvents = requestBody.filter(
+    event => !isMarketingEmailEvent(event) && Boolean(event.sg_message_id),
+  )
   return groupBy(transactionalEvents, 'sg_message_id')
 }
 
 function isMarketingEmailEvent(event: EmailEvent): event is MarketingEmailEvent {
-  return 'singlesend_id' in event && 'singlesend_name' in event
+  return (
+    ('singlesend_id' in event && 'singlesend_name' in event) ||
+    ('mc_stats' in event && 'mc_pod_id' in event)
+  )
 }


### PR DESCRIPTION
closes #2311

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
