### PR TITLE
Fix backfillNFT slow db query

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -324,6 +324,7 @@ model UserAction {
   @@index([userId, actionType, campaignName])
   @@index([actionType, userId])
   @@index([actionType, campaignName])
+  @@index([actionType, nftMintId, datetimeCreated(sort: Desc)])
   @@index([userCryptoAddressId])
   @@index([userSessionId])
   @@index([userEmailAddressId])


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes [PROD-SWC-WEB-5YK](https://stand-with-crypto.sentry.io/issues/6354564012/events/4605e9c0a4604eb689d216f32567bc4b/)

## What changed? Why?

The query used a large IN clause to fetch user actions, which was inefficient without a proper database index. The fix was to add a new composite index to the user_action table on `(action_type, nft_mint_id, datetime_created)`. This allows the database to efficiently find the required records without performing a full table scan. 

Query profiling results:


Before
<img width="845" alt="image" src="https://github.com/user-attachments/assets/402ede0f-7981-42f6-93ca-acd4a554f655" />

After
<img width="833" alt="image" src="https://github.com/user-attachments/assets/1842813a-3567-40e7-afa6-0f8c026bedd4" />


<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

https://app.planetscale.com/stand-with-crypto/swc-web/deploy-requests/125

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
