### PR TITLE
chore: adds network error to ignore array

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -117,6 +117,9 @@ Sentry.init({
     'ResizeObserver loop limit exceeded',
     'ResizeObserver loop completed with undelivered notifications',
     /As of March 1st, 2025, google\.maps\.places.*/i,
+    // Network errors are being ignored here because of this investigation: https://github.com/Stand-With-Crypto/swc-web/issues/2408
+    'network error',
+    /^TypeError: network error$/,
   ],
   beforeSend: (event, hint) => {
     // prevent local errors from triggering sentry


### PR DESCRIPTION
closes #2408

## What changed? Why?

This PR adds a new ignore entry on Sentry for network errors. Investigation and decision is detailed in this [issue](https://github.com/Stand-With-Crypto/swc-web/issues/2408)

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
