### PR TITLE
fix: improve Sentry error logging for phone number parsing failures

### DIFF
--- a/src/utils/shared/phoneNumber.ts
+++ b/src/utils/shared/phoneNumber.ts
@@ -79,13 +79,18 @@ function parsePhoneNumber(phoneNumber: string, countryCode = DEFAULT_SUPPORTED_C
     return parsePhoneNumberWithError(phoneNumber, phoneLibCountryCode, phoneNumberMetadata)
   } catch (e) {
     if (e instanceof ParseError) {
-      Sentry.captureException(e, {
-        tags: {
+      const errorName = `Error parsing phone number: ${e.message}`
+
+      Sentry.withScope(scope => {
+        scope.setTransactionName(errorName)
+        scope.setTags({
           domain: 'parsePhoneNumberWithError',
-        },
-        extra: {
+        })
+        scope.setExtras({
           payload: phoneNumber,
-        },
+          countryCode,
+        })
+        Sentry.captureException(e)
       })
     }
     throw e


### PR DESCRIPTION
## What changed? Why?

These changes will improve how we log these errors: https://stand-with-crypto.sentry.io/issues/?project=4506490717470720&query=domain%3AparsePhoneNumberWithError&referrer=issue-list&statsPeriod=30d

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
