### PR TITLE
fix: identify messages that start with stop as opt out & handle reactions to prevent false unidentified keyword

### DIFF
--- a/src/utils/server/sms/identifyIncomingKeyword.test.ts
+++ b/src/utils/server/sms/identifyIncomingKeyword.test.ts
@@ -1,17 +1,38 @@
 import { describe, expect, it } from '@jest/globals'
 
 import { identifyIncomingKeyword } from '@/utils/server/sms/identifyIncomingKeyword'
+import { getSMSMessages } from '@/utils/server/sms/messages'
+import { DEFAULT_SUPPORTED_COUNTRY_CODE } from '@/utils/shared/supportedCountries'
+
+const messages = getSMSMessages(DEFAULT_SUPPORTED_COUNTRY_CODE)
 
 describe('identifyIncomingKeyword', () => {
-  it.each(['STOP', 'Stop', 'Stop\n', 'stop ', '\nSTOPALL', '   STop'])(
-    'should identify opt-out keyword: %s',
-    keyword => {
-      expect(identifyIncomingKeyword(keyword)?.isOptOutKeyword).toBe(true)
-      expect(identifyIncomingKeyword(keyword)?.isHelpKeyword).toBe(false)
-      expect(identifyIncomingKeyword(keyword)?.isUnstopKeyword).toBe(false)
-      expect(identifyIncomingKeyword(keyword)?.isUnidentifiedKeyword).toBe(false)
-    },
-  )
+  it.each([
+    'STOP',
+    'Stop',
+    'Stop\n',
+    'stop ',
+    '\nSTOPALL',
+    '   STop',
+    'Stop it!',
+    'STOPALL NOW',
+    'UNSUBSCRIBE PLEASE',
+    'CANCEL THIS',
+    'END IT',
+    'QUIT NOW',
+    'STOP IMMEDIATELY',
+    'stop,',
+    'Stop to opt out',
+    'Unsubscribe me',
+    'Stop!',
+    '	Stop 🛑',
+    'Stop end',
+  ])('should identify opt-out keyword: %s', keyword => {
+    expect(identifyIncomingKeyword(keyword)?.isOptOutKeyword).toBe(true)
+    expect(identifyIncomingKeyword(keyword)?.isHelpKeyword).toBe(false)
+    expect(identifyIncomingKeyword(keyword)?.isUnstopKeyword).toBe(false)
+    expect(identifyIncomingKeyword(keyword)?.isUnidentifiedKeyword).toBe(false)
+  })
 
   it.each(['HELP', 'Help', 'help ', '\nHELP', '   Help'])(
     'should identify help keyword: %s',
@@ -41,21 +62,27 @@ describe('identifyIncomingKeyword', () => {
   })
 
   it.each([
-    'STOPALL NOW',
-    'UNSUBSCRIBE PLEASE',
-    'CANCEL THIS',
-    'END IT',
-    'QUIT NOW',
-    'STOP IMMEDIATELY',
     'HELP ME',
     'YES PLEASE',
     'START NOW',
     'CONTINUE PLEASE',
     'UNSTOP NOW',
+    "Yes, let's make them stop!",
   ])('should not identify any keyword: %s', keyword => {
     expect(identifyIncomingKeyword(keyword)?.isOptOutKeyword).toBe(false)
     expect(identifyIncomingKeyword(keyword)?.isHelpKeyword).toBe(false)
     expect(identifyIncomingKeyword(keyword)?.isUnstopKeyword).toBe(false)
     expect(identifyIncomingKeyword(keyword)?.isUnidentifiedKeyword).toBe(true)
+  })
+
+  it.each([
+    `Questioned “${messages.bulkWelcomeMessage}”`,
+    `Liked “${messages.welcomeMessage}”`,
+    `👍 to “${messages.welcomeMessage}”`,
+  ])('should not identify text on reactions: %s', keyword => {
+    expect(identifyIncomingKeyword(keyword)?.isOptOutKeyword).toBe(false)
+    expect(identifyIncomingKeyword(keyword)?.isHelpKeyword).toBe(false)
+    expect(identifyIncomingKeyword(keyword)?.isUnstopKeyword).toBe(false)
+    expect(identifyIncomingKeyword(keyword)?.isUnidentifiedKeyword).toBe(false)
   })
 })

--- a/src/utils/server/sms/identifyIncomingKeyword.ts
+++ b/src/utils/server/sms/identifyIncomingKeyword.ts
@@ -1,3 +1,5 @@
+import { convertToOnlyEnglishCharacters } from '@/utils/shared/convertToOnlyEnglishCharacters'
+
 const optOutKeywords = ['STOPALL', 'UNSUBSCRIBE', 'CANCEL', 'END', 'QUIT', 'STOP']
 const helpKeywords = ['HELP', 'INFO', 'AIDE']
 const unstopKeywords = ['YES', 'START', 'CONTINUE', 'UNSTOP']
@@ -5,9 +7,15 @@ const unstopKeywords = ['YES', 'START', 'CONTINUE', 'UNSTOP']
 export function identifyIncomingKeyword(keyword: string | undefined) {
   if (!keyword || keyword.length === 0) return
 
-  const normalizedKeyword = keyword?.toUpperCase().trim()
+  const normalizedKeyword = convertToOnlyEnglishCharacters(keyword)
+    ?.toUpperCase()
+    .trim()
+    .replace(/\n/g, ' ')
+    .replace(/".*?"/g, '') // Remove quoted content from message reactions (e.g., 'Liked "Thanks for subscribing..."' becomes 'Liked')
 
-  const isOptOutKeyword = optOutKeywords.includes(normalizedKeyword)
+  const isOptOutKeyword =
+    optOutKeywords.includes(normalizedKeyword) ||
+    optOutKeywords.some(command => normalizedKeyword.startsWith(command))
   const isHelpKeyword = helpKeywords.includes(normalizedKeyword)
   const isUnstopKeyword = unstopKeywords.includes(normalizedKeyword)
 


### PR DESCRIPTION
fixes [PROD-SWC-WEB-5AM](https://stand-with-crypto.sentry.io/issues/6081263126/events/afce24303ef8408cae581322869ed621/)

## What changed? Why?

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
