### PR TITLE
fix: press description alignment & wrong founders country on Canada homepage

### DIFF
--- a/src/components/app/pageHome/ca/index.tsx
+++ b/src/components/app/pageHome/ca/index.tsx
@@ -87,7 +87,7 @@ export function CaPageHome({
         <HomePageSection container={false}>
           <HomePageSection.Title>Founders</HomePageSection.Title>
           <HomePageSection.Subtitle>
-            Members from our community that have founded crypto-related businesses in the UK.
+            Members from our community that have founded crypto-related businesses in Canada.
           </HomePageSection.Subtitle>
 
           <FoundersCarousel founders={founders} />

--- a/src/components/app/pagePress/NewsList.tsx
+++ b/src/components/app/pagePress/NewsList.tsx
@@ -108,7 +108,7 @@ function NewsListItem({
             />
           </div>
         )}
-        <div className="text-center">
+        <div className="flex flex-col items-center text-center">
           <strong className="text-primary group-hover:underline group-focus:underline">
             {source}: {title}
           </strong>


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
