### PR TITLE
fix: error state load on locale mismatch

### DIFF
--- a/src/components/app/pageReferrals/referralsCounter.tsx
+++ b/src/components/app/pageReferrals/referralsCounter.tsx
@@ -25,10 +25,6 @@ export function ReferralsCounter(props: ReferralsCounterProps) {
   const { isLoggedIn, isLoading } = useSession()
   const hasHydrated = useHasHydrated()
 
-  if (!isLoggedIn || isLoading || !hasHydrated) {
-    return null
-  }
-
   return <div className={cn('flex w-full gap-4', className)}>{children}</div>
 }
 
@@ -88,11 +84,11 @@ export function UserDistrictRank({ className }: { className?: string }) {
     }
 
     if (!address) {
-      return <p>Finish your profile to see your district ranking</p>
+      return <p>N/A</p>
     }
 
     if (!rank || !districtRankingResponse.data) {
-      return null
+      return <p>N/A</p>
     }
 
     return (

--- a/src/components/app/pageReferrals/yourDistrictRank.tsx
+++ b/src/components/app/pageReferrals/yourDistrictRank.tsx
@@ -73,7 +73,7 @@ function YourDistrictRankContent(props: YourDistrictRankContentProps) {
           value={address === 'loading' ? null : address}
         />
         <p className="pl-4 text-sm text-fontcolor-muted">
-          District rank not found, please try a different address.
+          Looks like your address is outside the U.S., so it's not part of any district here.
         </p>
       </div>
     )


### PR DESCRIPTION
closes #2424

## What changed? Why?

- Fixed an issue where non-US (e.g., Canadian) addresses were incorrectly showing US district data on US pages.
- Now, for invalid or non-US addresses, the district ranking displays "N/A" and the message is updated to clarify the address is outside the US.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
