### PR TITLE
fix: error state load on locale mismatch

### DIFF
--- a/src/components/app/pageReferrals/referralsCounter.tsx
+++ b/src/components/app/pageReferrals/referralsCounter.tsx
@@ -92,7 +92,7 @@ export function UserDistrictRank({ className }: { className?: string }) {
     }
 
     if (!rank || !districtRankingResponse.data) {
-      return null
+      return <p>N/A</p>
     }
 
     return (

--- a/src/components/app/pageReferrals/yourDistrictRank.tsx
+++ b/src/components/app/pageReferrals/yourDistrictRank.tsx
@@ -73,7 +73,7 @@ function YourDistrictRankContent(props: YourDistrictRankContentProps) {
           value={address === 'loading' ? null : address}
         />
         <p className="pl-4 text-sm text-fontcolor-muted">
-          District rank not found, please try a different address.
+          Looks like your address is outside the U.S., so it's not part of any district here.
         </p>
       </div>
     )


### PR DESCRIPTION
closes #2335 

## What changed? Why?

- Fixed an issue where non-US (e.g., Canadian) addresses were incorrectly showing US district data on US pages.
- Now, for invalid or non-US addresses, the district ranking displays "N/A" and the message is updated to clarify the address is outside the US.

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
