### PR TITLE
feat: update branding from 'Stand With Crypto International Ltd' to 'SWC International Ltd'

### DIFF
--- a/src/components/app/sms/smsOptInConsentText.tsx
+++ b/src/components/app/sms/smsOptInConsentText.tsx
@@ -5,11 +5,11 @@ const SMS_OPT_IN_CONSENT: Record<SupportedCountryCodes, string> = {
   [SupportedCountryCodes.US]:
     'you consent to receive recurring texts from Stand With Crypto. You can reply STOP to stop receiving texts. Message and data rates may apply.',
   [SupportedCountryCodes.GB]:
-    'I authorize Stand With Crypto International Ltd and its service providers to contact me at this number via text (SMS) for cryptocurrency advocacy purposes. Message and data rates may apply. To opt-out at any time reply "STOP".',
+    'I authorize SWC International Ltd and its service providers to contact me at this number via text (SMS) for cryptocurrency advocacy purposes. Message and data rates may apply. To opt-out at any time reply "STOP".',
   [SupportedCountryCodes.CA]:
-    'I authorize Stand With Crypto International Ltd and its service providers to contact me at this number via text (SMS) for cryptocurrency advocacy purposes. Message and data rates may apply. To opt-out at any time reply "STOP".',
+    'I authorize SWC International Ltd and its service providers to contact me at this number via text (SMS) for cryptocurrency advocacy purposes. Message and data rates may apply. To opt-out at any time reply "STOP".',
   [SupportedCountryCodes.AU]:
-    'I authorize Stand With Crypto International Ltd and its service providers to contact me at this number via text (SMS) for cryptocurrency advocacy purposes. Message and data rates may apply. To opt-out at any time reply "STOP".',
+    'I authorize SWC International Ltd and its service providers to contact me at this number via text (SMS) for cryptocurrency advocacy purposes. Message and data rates may apply. To opt-out at any time reply "STOP".',
 }
 
 export function SMSOptInConsentText({


### PR DESCRIPTION
closes <!-- No GitHub issue associated -->

fixes <!-- No Sentry issue associated -->

## What changed? Why?

Updated all references of "Stand With Crypto International Ltd" to "SWC International Ltd" in SMS opt-in consent text for GB, CA, and AU country codes. This aligns with the updated branding guidelines.

The change affects:
- SMS consent text displayed to users in Great Britain, Canada, and Australia when opting into text messages
- Three instances in `src/components/app/sms/smsOptInConsentText.tsx`

## PlanetScale deploy request

<!-- No database schema changes -->

## Notes to reviewers

- [x] AI Generated

This is a simple branding update that changes the legal entity name displayed in user-facing SMS consent text. The functionality remains unchanged.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch  
- [ ] Unit test
- [ ] Functional test