### PR TITLE
fix(sentry): group Magic Eden provider assignment errors

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -28,6 +28,7 @@ const COMMON_ERROR_MESSAGES_TO_GROUP = [
   'ResizeObserver loop', // ResizeObserver loop completed with undelivered notifications.
   'Load failed',
   'Failed to fetch',
+  'Could not assign Magic Eden provider',
   "Failed to read the 'localStorage'",
   'Converting circular structure to JSON',
   "Cannot read properties of undefined (reading 'call')",


### PR DESCRIPTION
## What changed? Why?

Added 'Could not assign Magic Eden provider' to the COMMON_ERROR_MESSAGES_TO_GROUP array in sentry.client.config.ts to group these similar errors together in Sentry reporting. This will help reduce noise and make it easier to track this specific error pattern.

This change follows the existing pattern of grouping common error messages that occur frequently and should be consolidated for better error monitoring.

## Notes to reviewers

- [x] AI Generated

This is a simple addition to the error grouping list - no functional changes or testing required beyond the existing Sentry configuration.

## How has it been tested?

- [x] Locally

The change only affects error grouping in Sentry and doesn't require additional testing beyond verification that the configuration is syntactically correct.