### PR TITLE
fix: split district rank api

### DIFF
--- a/src/app/api/public/referrals/[stateCode]/[districtNumber]/by-state/route.ts
+++ b/src/app/api/public/referrals/[stateCode]/[districtNumber]/by-state/route.ts
@@ -2,8 +2,7 @@ import 'server-only'
 
 import { NextRequest, NextResponse } from 'next/server'
 
-import { CURRENT_DISTRICT_RANKING } from '@/utils/server/districtRankings/constants'
-import { getDistrictRank } from '@/utils/server/districtRankings/upsertRankings'
+import { getDistrictRankByState } from '@/utils/server/districtRankings/upsertRankings'
 import { zodStateDistrict } from '@/validation/fields/zodAddress'
 
 export const revalidate = 60 // 1 minute
@@ -26,9 +25,9 @@ export async function GET(
     district: parseResult.data.district,
   }
 
-  const data = await getDistrictRank(CURRENT_DISTRICT_RANKING, member)
+  const data = await getDistrictRankByState(member)
 
   return NextResponse.json(data)
 }
 
-export type GetDistrictRankResponse = Awaited<ReturnType<typeof getDistrictRank>>
+export type GetDistrictRankResponse = Awaited<ReturnType<typeof getDistrictRankByState>>

--- a/src/utils/shared/urls/index.ts
+++ b/src/utils/shared/urls/index.ts
@@ -253,8 +253,7 @@ export const apiUrls = {
     stateCode: string
     districtNumber: string
     filteredByState?: boolean
-  }) =>
-    `/api/public/referrals/${stateCode}/${districtNumber}${filteredByState ? '?filteredByState=true' : ''}`,
+  }) => `/api/public/referrals/${stateCode}/${districtNumber}${filteredByState ? '/by-state' : ''}`,
   dtsiRacesByCongressionalDistrict: ({
     stateCode,
     district,


### PR DESCRIPTION
## What changed? Why?

Overview: This PR introduces a separation of the district rank API into two distinct endpoints to improve functionality and clarity.

Changes Made:

General District Rank:
`/api/public/referrals/[stateCode]/[districtNumber]`
Returns the general district rank without any filters applied.

Filtered District Rank by State:
`/api/public/referrals/[stateCode]/[districtNumber]/by-state`
Returns the district rank filtered specifically by state.

Benefits:

This separation allows for more targeted data retrieval, enhancing the efficiency of API calls.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
