### PR TITLE
chore(db): add composite index for backfill NFT cron job performance

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -327,6 +327,7 @@ model UserAction {
   @@index([actionType, userId])
   @@index([actionType, campaignName])
   @@index([actionType, nftMintId, datetimeCreated(sort: Desc)])
+  @@index([actionType, nftMintId, datetimeCreated(sort: Asc)], map: "user_action_action_type_nft_mint_id_datetime_created_asc_idx")
   @@index([userCryptoAddressId])
   @@index([userSessionId])
   @@index([userEmailAddressId])


### PR DESCRIPTION
## Summary

This PR adds a composite index to the `UserAction` table for `(actionType, nftMintId, datetimeCreated ASC)` to optimize the slow query in the NFT backfill cron job.

### Why?
- Addresses Sentry issue: PROD-SWC-WEB-5YK (Slow DB Query on /api/inngest)
- Improves performance for the backfill NFT cron job

## Checklist
- [x] Schema updated
- [ ] PlanetScale deploy request needed after merge
- [x] AI Generated

### Fixes
Fixes Sentry: PROD-SWC-WEB-5YK

---
Please create a PlanetScale deploy request after merging this PR to apply the new index to production.