### PR TITLE
feat: add reset filters functionality to global filters component

### DIFF
--- a/src/components/app/dtsiClientPersonDataTable/au/index.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/au/index.tsx
@@ -114,7 +114,15 @@ export function AuDTSIClientPersonDataTable({
   )
 }
 
-function AuGlobalFilters({ columns }: { columns?: Column<Person>[] }) {
+function AuGlobalFilters({
+  columns,
+  onResetFilters,
+  isResetButtonDisabled,
+}: {
+  columns?: Column<Person>[]
+  onResetFilters: () => void
+  isResetButtonDisabled: boolean
+}) {
   const namedColumns = useMemo(() => {
     if (!columns) return {}
 
@@ -150,6 +158,8 @@ function AuGlobalFilters({ columns }: { columns?: Column<Person>[] }) {
         namedColumns={namedColumns}
         partyOptions={PARTY_OPTIONS}
       />
+
+      <GlobalFilters.ResetButton disabled={isResetButtonDisabled} onResetFilters={onResetFilters} />
     </GlobalFilters>
   )
 }

--- a/src/components/app/dtsiClientPersonDataTable/au/index.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/au/index.tsx
@@ -16,7 +16,10 @@ import {
   Person,
 } from '@/components/app/dtsiClientPersonDataTable/common/columns'
 import { GlobalFilters } from '@/components/app/dtsiClientPersonDataTable/common/filters'
-import { DataTable } from '@/components/app/dtsiClientPersonDataTable/common/table'
+import {
+  DataTable,
+  type GlobalFiltersProps,
+} from '@/components/app/dtsiClientPersonDataTable/common/table'
 import { useGetAllPeople } from '@/components/app/dtsiClientPersonDataTable/common/useGetAllPeople'
 import { useSearchFilter } from '@/components/app/dtsiClientPersonDataTable/common/useTableFilters'
 import {
@@ -114,15 +117,7 @@ export function AuDTSIClientPersonDataTable({
   )
 }
 
-function AuGlobalFilters({
-  columns,
-  onResetFilters,
-  isResetButtonDisabled,
-}: {
-  columns?: Column<Person>[]
-  onResetFilters: () => void
-  isResetButtonDisabled: boolean
-}) {
+function AuGlobalFilters({ columns, onResetFilters, isResetButtonDisabled }: GlobalFiltersProps) {
   const namedColumns = useMemo(() => {
     if (!columns) return {}
 

--- a/src/components/app/dtsiClientPersonDataTable/ca/index.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/ca/index.tsx
@@ -115,7 +115,15 @@ export function CaDTSIClientPersonDataTable({
   )
 }
 
-function CaGlobalFilters({ columns }: { columns?: Column<Person>[] }) {
+function CaGlobalFilters({
+  columns,
+  onResetFilters,
+  isResetButtonDisabled,
+}: {
+  columns?: Column<Person>[]
+  onResetFilters: () => void
+  isResetButtonDisabled: boolean
+}) {
   const namedColumns = useMemo(() => {
     if (!columns) return {}
 
@@ -154,6 +162,8 @@ function CaGlobalFilters({ columns }: { columns?: Column<Person>[] }) {
         namedColumns={namedColumns}
         partyOptions={PARTY_OPTIONS}
       />
+
+      <GlobalFilters.ResetButton disabled={isResetButtonDisabled} onResetFilters={onResetFilters} />
     </GlobalFilters>
   )
 }

--- a/src/components/app/dtsiClientPersonDataTable/ca/index.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/ca/index.tsx
@@ -16,7 +16,10 @@ import {
   Person,
 } from '@/components/app/dtsiClientPersonDataTable/common/columns'
 import { GlobalFilters } from '@/components/app/dtsiClientPersonDataTable/common/filters'
-import { DataTable } from '@/components/app/dtsiClientPersonDataTable/common/table'
+import {
+  DataTable,
+  type GlobalFiltersProps,
+} from '@/components/app/dtsiClientPersonDataTable/common/table'
 import { useGetAllPeople } from '@/components/app/dtsiClientPersonDataTable/common/useGetAllPeople'
 import { useSearchFilter } from '@/components/app/dtsiClientPersonDataTable/common/useTableFilters'
 import {
@@ -115,15 +118,7 @@ export function CaDTSIClientPersonDataTable({
   )
 }
 
-function CaGlobalFilters({
-  columns,
-  onResetFilters,
-  isResetButtonDisabled,
-}: {
-  columns?: Column<Person>[]
-  onResetFilters: () => void
-  isResetButtonDisabled: boolean
-}) {
+function CaGlobalFilters({ columns, onResetFilters, isResetButtonDisabled }: GlobalFiltersProps) {
   const namedColumns = useMemo(() => {
     if (!columns) return {}
 

--- a/src/components/app/dtsiClientPersonDataTable/common/filters.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/common/filters.tsx
@@ -1,11 +1,13 @@
 'use client'
 
 import { Column } from '@tanstack/react-table'
+import { X } from 'lucide-react'
 
 import {
   Person,
   PERSON_TABLE_COLUMNS_IDS,
 } from '@/components/app/dtsiClientPersonDataTable/common/columns'
+import { Button } from '@/components/ui/button'
 import {
   Select,
   SelectContent,
@@ -166,3 +168,26 @@ function GlobalFiltersStateSelect({
 }
 
 GlobalFilters.StateSelect = GlobalFiltersStateSelect
+
+function GlobalFiltersResetButton({
+  onResetFilters,
+  disabled,
+}: {
+  onResetFilters: () => void
+  disabled?: boolean
+}) {
+  return (
+    <Button
+      className="flex-shrink-0"
+      onClick={onResetFilters}
+      size="sm"
+      variant="secondary"
+      disabled={disabled}
+    >
+      <X className="mr-2 h-4 w-4" />
+      Reset Filters
+    </Button>
+  )
+}
+
+GlobalFilters.ResetButton = GlobalFiltersResetButton

--- a/src/components/app/dtsiClientPersonDataTable/common/filters.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/common/filters.tsx
@@ -179,10 +179,10 @@ function GlobalFiltersResetButton({
   return (
     <Button
       className="flex-shrink-0"
+      disabled={disabled}
       onClick={onResetFilters}
       size="sm"
       variant="secondary"
-      disabled={disabled}
     >
       <X className="mr-2 h-4 w-4" />
       Reset Filters

--- a/src/components/app/dtsiClientPersonDataTable/common/table.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/common/table.tsx
@@ -40,7 +40,7 @@ import {
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { getIntlUrls } from '@/utils/shared/urls'
 
-interface GlobalFiltersProps<TData extends Person = Person> {
+export interface GlobalFiltersProps<TData extends Person = Person> {
   columns?: Column<TData>[]
   onResetFilters: () => void
   isResetButtonDisabled: boolean
@@ -165,8 +165,13 @@ function DataTableBody<TData extends Person = Person>({
   const tableRowModel = table.getRowModel()
 
   const isResetButtonDisabled = useMemo(() => {
-    return !columnFilters.some(filter => filter.value !== 'All')
-  }, [columnFilters])
+    const defaultFilters = getGlobalFilterDefaults()
+
+    return defaultFilters.every(defaultFilter => {
+      const currentFilter = columnFilters.find(columnFilter => columnFilter.id === defaultFilter.id)
+      return currentFilter?.value === defaultFilter.value
+    })
+  }, [columnFilters, getGlobalFilterDefaults])
 
   const handleResetFilters = useCallback(() => {
     setColumnFilters(getGlobalFilterDefaults())

--- a/src/components/app/dtsiClientPersonDataTable/common/table.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/common/table.tsx
@@ -170,7 +170,7 @@ function DataTableBody<TData extends Person = Person>({
 
   const handleResetFilters = useCallback(() => {
     setColumnFilters(getGlobalFilterDefaults())
-  }, [setColumnFilters, getGlobalFilterDefaults, setGlobalFilter])
+  }, [setColumnFilters, getGlobalFilterDefaults])
 
   return (
     <div className="md:container" id={id}>
@@ -181,8 +181,8 @@ function DataTableBody<TData extends Person = Person>({
           </PageTitle>
           <GlobalFiltersComponent
             columns={table.getAllColumns()}
-            onResetFilters={handleResetFilters}
             isResetButtonDisabled={isResetButtonDisabled}
+            onResetFilters={handleResetFilters}
           />
         </div>
 

--- a/src/components/app/dtsiClientPersonDataTable/common/table.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/common/table.tsx
@@ -42,6 +42,8 @@ import { getIntlUrls } from '@/utils/shared/urls'
 
 interface GlobalFiltersProps<TData extends Person = Person> {
   columns?: Column<TData>[]
+  onResetFilters: () => void
+  isResetButtonDisabled: boolean
 }
 
 interface DataTableProps<TData extends Person = Person> extends Partial<TableOptions<TData>> {
@@ -162,6 +164,14 @@ function DataTableBody<TData extends Person = Person>({
 
   const tableRowModel = table.getRowModel()
 
+  const isResetButtonDisabled = useMemo(() => {
+    return !columnFilters.some(filter => filter.value !== 'All')
+  }, [columnFilters])
+
+  const handleResetFilters = useCallback(() => {
+    setColumnFilters(getGlobalFilterDefaults())
+  }, [setColumnFilters, getGlobalFilterDefaults, setGlobalFilter])
+
   return (
     <div className="md:container" id={id}>
       <div className="md:min-h-[578px] md:rounded-md md:border-b md:border-l md:border-r">
@@ -169,7 +179,11 @@ function DataTableBody<TData extends Person = Person>({
           <PageTitle className="text-left" size="md">
             Politicians
           </PageTitle>
-          <GlobalFiltersComponent columns={table.getAllColumns()} />
+          <GlobalFiltersComponent
+            columns={table.getAllColumns()}
+            onResetFilters={handleResetFilters}
+            isResetButtonDisabled={isResetButtonDisabled}
+          />
         </div>
 
         <div className="relative w-full">

--- a/src/components/app/dtsiClientPersonDataTable/common/useTableFilters.ts
+++ b/src/components/app/dtsiClientPersonDataTable/common/useTableFilters.ts
@@ -72,6 +72,8 @@ const partyKey = PERSON_TABLE_COLUMNS_IDS.PARTY
 const stateKey = PERSON_TABLE_COLUMNS_IDS.STATE
 const stanceKey = PERSON_TABLE_COLUMNS_IDS.STANCE
 
+const defaultFiltersValue = 'All'
+
 export function useColumnFilters(): [
   ColumnFiltersState,
   Dispatch<SetStateAction<ColumnFiltersState>>,
@@ -79,10 +81,10 @@ export function useColumnFilters(): [
   const hasHydrated = useHasHydrated()
 
   const [searchParamValues, setSearchParamValues] = useMultipleSearchParamState({
-    [roleKey]: 'All',
-    [partyKey]: 'All',
-    [stateKey]: 'All',
-    [stanceKey]: 'All',
+    [roleKey]: defaultFiltersValue,
+    [partyKey]: defaultFiltersValue,
+    [stateKey]: defaultFiltersValue,
+    [stanceKey]: defaultFiltersValue,
   })
 
   const roleValue = searchParamValues[roleKey]

--- a/src/components/app/dtsiClientPersonDataTable/common/useTableFilters.ts
+++ b/src/components/app/dtsiClientPersonDataTable/common/useTableFilters.ts
@@ -67,12 +67,12 @@ export function useSortingFilter(
   return [hasHydrated ? sortedValue : [], handleSortingValue]
 }
 
-const roleKey = PERSON_TABLE_COLUMNS_IDS.ROLE
-const partyKey = PERSON_TABLE_COLUMNS_IDS.PARTY
-const stateKey = PERSON_TABLE_COLUMNS_IDS.STATE
-const stanceKey = PERSON_TABLE_COLUMNS_IDS.STANCE
+const ROLE_KEY = PERSON_TABLE_COLUMNS_IDS.ROLE
+const PARTY_KEY = PERSON_TABLE_COLUMNS_IDS.PARTY
+const STATE_KEY = PERSON_TABLE_COLUMNS_IDS.STATE
+const STANCE_KEY = PERSON_TABLE_COLUMNS_IDS.STANCE
 
-const defaultFiltersValue = 'All'
+const DEFAULT_FILTERS_VALUE = 'All'
 
 export function useColumnFilters(): [
   ColumnFiltersState,
@@ -81,23 +81,23 @@ export function useColumnFilters(): [
   const hasHydrated = useHasHydrated()
 
   const [searchParamValues, setSearchParamValues] = useMultipleSearchParamState({
-    [roleKey]: defaultFiltersValue,
-    [partyKey]: defaultFiltersValue,
-    [stateKey]: defaultFiltersValue,
-    [stanceKey]: defaultFiltersValue,
+    [ROLE_KEY]: DEFAULT_FILTERS_VALUE,
+    [PARTY_KEY]: DEFAULT_FILTERS_VALUE,
+    [STATE_KEY]: DEFAULT_FILTERS_VALUE,
+    [STANCE_KEY]: DEFAULT_FILTERS_VALUE,
   })
 
-  const roleValue = searchParamValues[roleKey]
-  const partyValue = searchParamValues[partyKey]
-  const stateValue = searchParamValues[stateKey]
-  const stanceValue = searchParamValues[stanceKey]
+  const roleValue = searchParamValues[ROLE_KEY]
+  const partyValue = searchParamValues[PARTY_KEY]
+  const stateValue = searchParamValues[STATE_KEY]
+  const stanceValue = searchParamValues[STANCE_KEY]
 
   const filters: ColumnFiltersState = useMemo(
     () => [
-      { id: stanceKey, value: stanceValue },
-      { id: roleKey, value: roleValue },
-      { id: partyKey, value: partyValue },
-      { id: stateKey, value: stateValue },
+      { id: STANCE_KEY, value: stanceValue },
+      { id: ROLE_KEY, value: roleValue },
+      { id: PARTY_KEY, value: partyValue },
+      { id: STATE_KEY, value: stateValue },
     ],
     [partyValue, roleValue, stanceValue, stateValue],
   )
@@ -108,24 +108,24 @@ export function useColumnFilters(): [
 
       const newSearchParamValues: MultipleSearchParamConfig = {}
 
-      const newStanceValue = valueToSet.find(filter => filter.id === stanceKey)
+      const newStanceValue = valueToSet.find(filter => filter.id === STANCE_KEY)
       if (newStanceValue?.value) {
-        newSearchParamValues[stanceKey] = newStanceValue.value as string
+        newSearchParamValues[STANCE_KEY] = newStanceValue.value as string
       }
 
-      const newRoleValue = valueToSet.find(filter => filter.id === roleKey)
+      const newRoleValue = valueToSet.find(filter => filter.id === ROLE_KEY)
       if (newRoleValue?.value) {
-        newSearchParamValues[roleKey] = newRoleValue.value as string
+        newSearchParamValues[ROLE_KEY] = newRoleValue.value as string
       }
 
-      const newPartyValue = valueToSet.find(filter => filter.id === partyKey)
+      const newPartyValue = valueToSet.find(filter => filter.id === PARTY_KEY)
       if (newPartyValue?.value) {
-        newSearchParamValues[partyKey] = newPartyValue.value as string
+        newSearchParamValues[PARTY_KEY] = newPartyValue.value as string
       }
 
-      const newStateValue = valueToSet.find(filter => filter.id === stateKey)
+      const newStateValue = valueToSet.find(filter => filter.id === STATE_KEY)
       if (newStateValue?.value) {
-        newSearchParamValues[stateKey] = newStateValue.value as string
+        newSearchParamValues[STATE_KEY] = newStateValue.value as string
       }
 
       setSearchParamValues(newSearchParamValues)

--- a/src/components/app/dtsiClientPersonDataTable/gb/index.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/gb/index.tsx
@@ -8,7 +8,10 @@ import {
   Person,
 } from '@/components/app/dtsiClientPersonDataTable/common/columns'
 import { GlobalFilters } from '@/components/app/dtsiClientPersonDataTable/common/filters'
-import { DataTable } from '@/components/app/dtsiClientPersonDataTable/common/table'
+import {
+  DataTable,
+  type GlobalFiltersProps,
+} from '@/components/app/dtsiClientPersonDataTable/common/table'
 import { useGetAllPeople } from '@/components/app/dtsiClientPersonDataTable/common/useGetAllPeople'
 import { useSearchFilter } from '@/components/app/dtsiClientPersonDataTable/common/useTableFilters'
 import {
@@ -115,15 +118,7 @@ export function GbDTSIClientPersonDataTable({
   )
 }
 
-function GbGlobalFilters({
-  columns,
-  onResetFilters,
-  isResetButtonDisabled,
-}: {
-  columns?: Column<Person>[]
-  onResetFilters: () => void
-  isResetButtonDisabled: boolean
-}) {
+function GbGlobalFilters({ columns, onResetFilters, isResetButtonDisabled }: GlobalFiltersProps) {
   const namedColumns = useMemo(() => {
     if (!columns) return {}
 

--- a/src/components/app/dtsiClientPersonDataTable/gb/index.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/gb/index.tsx
@@ -115,7 +115,15 @@ export function GbDTSIClientPersonDataTable({
   )
 }
 
-function GbGlobalFilters({ columns }: { columns?: Column<Person>[] }) {
+function GbGlobalFilters({
+  columns,
+  onResetFilters,
+  isResetButtonDisabled,
+}: {
+  columns?: Column<Person>[]
+  onResetFilters: () => void
+  isResetButtonDisabled: boolean
+}) {
   const namedColumns = useMemo(() => {
     if (!columns) return {}
 
@@ -151,6 +159,8 @@ function GbGlobalFilters({ columns }: { columns?: Column<Person>[] }) {
         namedColumns={namedColumns}
         partyOptions={PARTY_OPTIONS}
       />
+
+      <GlobalFilters.ResetButton disabled={isResetButtonDisabled} onResetFilters={onResetFilters} />
     </GlobalFilters>
   )
 }

--- a/src/components/app/dtsiClientPersonDataTable/us/index.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/us/index.tsx
@@ -115,7 +115,15 @@ export function UsDTSIClientPersonDataTable({
   )
 }
 
-function UsGlobalFilters({ columns }: { columns?: Column<Person>[] }) {
+function UsGlobalFilters({
+  columns,
+  onResetFilters,
+  isResetButtonDisabled,
+}: {
+  columns?: Column<Person>[]
+  onResetFilters: () => void
+  isResetButtonDisabled: boolean
+}) {
   const namedColumns = useMemo(() => {
     if (!columns) return {}
 
@@ -150,6 +158,8 @@ function UsGlobalFilters({ columns }: { columns?: Column<Person>[] }) {
         namedColumns={namedColumns}
         partyOptions={PARTY_OPTIONS}
       />
+
+      <GlobalFilters.ResetButton disabled={isResetButtonDisabled} onResetFilters={onResetFilters} />
     </GlobalFilters>
   )
 }

--- a/src/components/app/dtsiClientPersonDataTable/us/index.tsx
+++ b/src/components/app/dtsiClientPersonDataTable/us/index.tsx
@@ -8,7 +8,10 @@ import {
   Person,
 } from '@/components/app/dtsiClientPersonDataTable/common/columns'
 import { GlobalFilters } from '@/components/app/dtsiClientPersonDataTable/common/filters'
-import { DataTable } from '@/components/app/dtsiClientPersonDataTable/common/table'
+import {
+  DataTable,
+  type GlobalFiltersProps,
+} from '@/components/app/dtsiClientPersonDataTable/common/table'
 import { useGetAllPeople } from '@/components/app/dtsiClientPersonDataTable/common/useGetAllPeople'
 import { useSearchFilter } from '@/components/app/dtsiClientPersonDataTable/common/useTableFilters'
 import {
@@ -115,15 +118,7 @@ export function UsDTSIClientPersonDataTable({
   )
 }
 
-function UsGlobalFilters({
-  columns,
-  onResetFilters,
-  isResetButtonDisabled,
-}: {
-  columns?: Column<Person>[]
-  onResetFilters: () => void
-  isResetButtonDisabled: boolean
-}) {
+function UsGlobalFilters({ columns, onResetFilters, isResetButtonDisabled }: GlobalFiltersProps) {
   const namedColumns = useMemo(() => {
     if (!columns) return {}
 

--- a/src/hooks/useMultipleSearchParamState.ts
+++ b/src/hooks/useMultipleSearchParamState.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import { useCallback, useMemo } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+
+export interface MultipleSearchParamConfig {
+  [key: string]: string | undefined | null
+}
+
+export function useMultipleSearchParamState(
+  defaultValues: MultipleSearchParamConfig,
+): [MultipleSearchParamConfig, (newValues: MultipleSearchParamConfig) => void] {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname() || ''
+
+  const currentSearchParamValues = useMemo(() => {
+    const paramValues = { ...defaultValues }
+
+    if (!searchParams) return paramValues
+
+    for (const paramKey in paramValues) {
+      const value = searchParams.get(paramKey)
+      if (value) paramValues[paramKey] = value
+    }
+
+    return paramValues
+  }, [defaultValues, searchParams])
+
+  const updateSearchParams = useCallback(
+    (newParamValues: MultipleSearchParamConfig) => {
+      const currentSearchParams = new URLSearchParams(searchParams?.toString() ?? '')
+
+      for (const paramKey in newParamValues) {
+        const newValue = newParamValues[paramKey] as string
+        const defaultValue = defaultValues[paramKey]
+
+        if (!newValue || newValue === defaultValue) {
+          currentSearchParams.delete(paramKey)
+        } else {
+          currentSearchParams.set(paramKey, encodeURIComponent(newValue))
+        }
+      }
+
+      router.replace(`${pathname}?${currentSearchParams.toString()}`, { scroll: false })
+    },
+    [defaultValues, pathname, router, searchParams],
+  )
+
+  return [currentSearchParamValues, updateSearchParams]
+}


### PR DESCRIPTION
closes #581 

## What changed? Why?

- Added a “Reset Filters” button to the Politician page filters section.
- This button allows users to quickly clear all selected filters with a single click, instead of manually resetting each filter one by one.



## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
