### PR TITLE
feat(au-email): add and activate two new AU email campaigns

### DIFF
--- a/.cursor/rules/create-new-email-action-campaign.mdc
+++ b/.cursor/rules/create-new-email-action-campaign.mdc
@@ -1,6 +1,7 @@
 ---
 description: Create a new email action campaign
 globs: 
+alwaysApply: false
 ---
 # Creating new email action campaigns
 
@@ -42,10 +43,6 @@ globs:
     const CAMPAIGN_NAME = USUserActionEmailCampaignName.DEFAULT
 
     export const EMAIL_FLOW_POLITICIANS_CATEGORY: YourPoliticianCategory = 'house'
-
-    export const DIALOG_TITLE = 'Email Your Member of Congress'
-
-    export const DIALOG_SUBTITLE = 'Support Crucial Crypto Legislation'
 
     function getEmailBodyText(props?: GetTextProps & { address?: string }) {
     const fullNameSignOff = getFullNameSignOff({

--- a/src/components/app/userActionFormEmailCongressperson/au/campaigns/1-default.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/au/campaigns/1-default.tsx
@@ -16,10 +16,6 @@ const CAMPAIGN_NAME = AUUserActionEmailCampaignName.DEFAULT
 
 export const EMAIL_FLOW_POLITICIANS_CATEGORY: YourPoliticianCategory = 'senate'
 
-export const DIALOG_TITLE = 'Email Your Senator'
-
-export const DIALOG_SUBTITLE = 'Support Crucial Crypto Legislation'
-
 function getEmailBodyText(props?: GetTextProps & { address?: string }) {
   const fullNameSignOff = getFullNameSignOff({
     firstName: props?.firstName,

--- a/src/components/app/userActionFormEmailCongressperson/au/campaigns/20240611-newmode-debanking.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/au/campaigns/20240611-newmode-debanking.tsx
@@ -1,0 +1,40 @@
+import {
+  getConstituentIntroduction,
+  getFullNameSignOff,
+  getRepIntro,
+  GetTextProps,
+} from '@/components/app/userActionFormEmailCongressperson/common/emailBodyUtils'
+import { AUUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/au/auUserActionCampaigns'
+import {
+  getYourPoliticianCategoryShortDisplayName,
+  YourPoliticianCategory,
+} from '@/utils/shared/yourPoliticianCategory/au'
+
+import type { CampaignMetadata } from './types'
+
+const CAMPAIGN_NAME = AUUserActionEmailCampaignName.AU_NEWMODE_DEBANKING
+
+export const EMAIL_FLOW_POLITICIANS_CATEGORY: YourPoliticianCategory = 'house-of-reps'
+
+export const DIALOG_TITLE = 'Email your MP to stop unfair debanking'
+
+export const DIALOG_SUBTITLE = 'Urge them to stand up for financial access and innovation.'
+
+function getEmailBodyText(props?: GetTextProps & { address?: string }) {
+  const fullNameSignOff = getFullNameSignOff({
+    firstName: props?.firstName,
+    lastName: props?.lastName,
+  })
+  const maybeDistrictIntro = getConstituentIntroduction(props?.location)
+
+  return `${getRepIntro({ dtsiLastName: props?.dtsiLastName })}\n\n${maybeDistrictIntro}, and I wanted to write to you about the issue of unfair debanking in Australia.\n\nAccess to financial services is essential for innovation and economic growth. Unfair debanking practices threaten the future of crypto and financial access for all Australians.\n\nI urge you to stand up for financial access and innovation, and to support policies that ensure fair treatment for everyone.\n\nThank you for your attention to this important issue.${fullNameSignOff}`
+}
+
+export const campaignMetadata: CampaignMetadata = {
+  campaignName: CAMPAIGN_NAME,
+  dialogTitle: `Email your ${getYourPoliticianCategoryShortDisplayName('house-of-reps')}`,
+  dialogSubtitle: 'You emailed your MP to stop unfair debanking.',
+  politicianCategory: 'house-of-reps',
+  subject: 'Stop Unfair Debanking in Australia',
+  getEmailBodyText,
+}

--- a/src/components/app/userActionFormEmailCongressperson/au/campaigns/20240611-newmode-debanking.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/au/campaigns/20240611-newmode-debanking.tsx
@@ -1,5 +1,4 @@
 import {
-  getConstituentIntroduction,
   getFullNameSignOff,
   getRepIntro,
   GetTextProps,
@@ -16,18 +15,22 @@ const CAMPAIGN_NAME = AUUserActionEmailCampaignName.AU_NEWMODE_DEBANKING
 
 export const EMAIL_FLOW_POLITICIANS_CATEGORY: YourPoliticianCategory = 'house-of-reps'
 
-export const DIALOG_TITLE = 'Email your MP to stop unfair debanking'
-
-export const DIALOG_SUBTITLE = 'Urge them to stand up for financial access and innovation.'
-
 function getEmailBodyText(props?: GetTextProps & { address?: string }) {
   const fullNameSignOff = getFullNameSignOff({
     firstName: props?.firstName,
     lastName: props?.lastName,
   })
-  const maybeDistrictIntro = getConstituentIntroduction(props?.location)
 
-  return `${getRepIntro({ dtsiLastName: props?.dtsiLastName })}\n\n${maybeDistrictIntro}, and I wanted to write to you about the issue of unfair debanking in Australia.\n\nAccess to financial services is essential for innovation and economic growth. Unfair debanking practices threaten the future of crypto and financial access for all Australians.\n\nI urge you to stand up for financial access and innovation, and to support policies that ensure fair treatment for everyone.\n\nThank you for your attention to this important issue.${fullNameSignOff}`
+  return `${getRepIntro({ dtsiLastName: props?.dtsiLastName })}
+
+I am writing to you as a concerned constituent regarding the growing issue of de-banking in Australia. Increasingly, individuals and businesses are having their bank accounts closed, or their transactions blocked and frozen without clear justification, often with little to no recourse. This troubling trend threatens financial inclusion, trust in the banking system, and fundamental democratic principles.
+
+Access to banking services is not just a convenience—it is a necessity in modern society. Losing access to banking services can be devastating for startups and small businesses who are crucial to driving economic growth. Australia has a history of home-grown tech giants but the next great success story could be just one bank's decision away from never launching at all.
+
+This practice disproportionately affects crypto users, businesses, and entrepreneurs. There are Australian crypto entrepreneurs building impact-driven businesses that support our nations athletes, facilitate carbon credit trading via blockchain, secure billions of dollars of on-chain assets, and provide access to critical data for our local farmers. Without access to traditional banking or with restrictive transaction limits, crypto firms are unable to reach their full innovative potential.
+
+Will you commit to addressing de-banking in Australia? Your leadership on this issue is critical.
+I look forward to hearing what concrete steps your office will take to ensure financial fairness for all Australians.${fullNameSignOff}`
 }
 
 export const campaignMetadata: CampaignMetadata = {

--- a/src/components/app/userActionFormEmailCongressperson/au/campaigns/20240611-q2-2025-election.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/au/campaigns/20240611-q2-2025-election.tsx
@@ -1,0 +1,41 @@
+import {
+  getConstituentIntroduction,
+  getFullNameSignOff,
+  getRepIntro,
+  GetTextProps,
+} from '@/components/app/userActionFormEmailCongressperson/common/emailBodyUtils'
+import { AUUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/au/auUserActionCampaigns'
+import {
+  getYourPoliticianCategoryShortDisplayName,
+  YourPoliticianCategory,
+} from '@/utils/shared/yourPoliticianCategory/au'
+
+import type { CampaignMetadata } from './types'
+
+const CAMPAIGN_NAME = AUUserActionEmailCampaignName.AU_Q2_2025_ELECTION
+
+export const EMAIL_FLOW_POLITICIANS_CATEGORY: YourPoliticianCategory = 'house-of-reps'
+
+export const DIALOG_TITLE = 'Email your Member of Parliament'
+
+export const DIALOG_SUBTITLE =
+  'Tell your MP to support responsible crypto policy — send an email now!'
+
+function getEmailBodyText(props?: GetTextProps & { address?: string }) {
+  const fullNameSignOff = getFullNameSignOff({
+    firstName: props?.firstName,
+    lastName: props?.lastName,
+  })
+  const maybeDistrictIntro = getConstituentIntroduction(props?.location)
+
+  return `${getRepIntro({ dtsiLastName: props?.dtsiLastName })}\n\n${maybeDistrictIntro}, and I wanted to write to you and let you know that I care about crypto and blockchain technology.\n\nCrypto needs clear rules, regulations, and guidelines to thrive in Australia, and we need members of Parliament like you to champion this powerful technology so that it can reach its full potential. If crypto doesn't succeed in Australia, then jobs, innovation, and new technologies will be driven overseas and our country will miss out on the massive benefits.\n\nI hope that you will keep the views of pro-crypto constituents like myself in mind as you carry on your work in Parliament.${fullNameSignOff}`
+}
+
+export const campaignMetadata: CampaignMetadata = {
+  campaignName: CAMPAIGN_NAME,
+  dialogTitle: `Email your ${getYourPoliticianCategoryShortDisplayName('house-of-reps')}`,
+  dialogSubtitle: 'You emailed your MP about supporting responsible crypto policy.',
+  politicianCategory: 'house-of-reps',
+  subject: 'Support Responsible Crypto Policy',
+  getEmailBodyText,
+}

--- a/src/components/app/userActionFormEmailCongressperson/au/campaigns/20240611-q2-2025-election.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/au/campaigns/20240611-q2-2025-election.tsx
@@ -1,5 +1,4 @@
 import {
-  getConstituentIntroduction,
   getFullNameSignOff,
   getRepIntro,
   GetTextProps,
@@ -16,19 +15,13 @@ const CAMPAIGN_NAME = AUUserActionEmailCampaignName.AU_Q2_2025_ELECTION
 
 export const EMAIL_FLOW_POLITICIANS_CATEGORY: YourPoliticianCategory = 'house-of-reps'
 
-export const DIALOG_TITLE = 'Email your Member of Parliament'
-
-export const DIALOG_SUBTITLE =
-  'Tell your MP to support responsible crypto policy — send an email now!'
-
 function getEmailBodyText(props?: GetTextProps & { address?: string }) {
   const fullNameSignOff = getFullNameSignOff({
     firstName: props?.firstName,
     lastName: props?.lastName,
   })
-  const maybeDistrictIntro = getConstituentIntroduction(props?.location)
 
-  return `${getRepIntro({ dtsiLastName: props?.dtsiLastName })}\n\n${maybeDistrictIntro}, and I wanted to write to you and let you know that I care about crypto and blockchain technology.\n\nCrypto needs clear rules, regulations, and guidelines to thrive in Australia, and we need members of Parliament like you to champion this powerful technology so that it can reach its full potential. If crypto doesn't succeed in Australia, then jobs, innovation, and new technologies will be driven overseas and our country will miss out on the massive benefits.\n\nI hope that you will keep the views of pro-crypto constituents like myself in mind as you carry on your work in Parliament.${fullNameSignOff}`
+  return `${getRepIntro({ dtsiLastName: props?.dtsiLastName })}\n\nAs a voter in your electorate, I’m writing to express my strong support for crypto and blockchain innovation in Australia. This industry represents a major opportunity for economic growth, job creation, and financial inclusion.\n\nOther countries are moving forward with smart, balanced regulations that foster innovation while protecting consumers. Australia must do the same—or risk losing talent and investment to more forward-thinking jurisdictions.\n\nI’m supporting candidates who understand the importance of crypto and will champion policies that allow the industry to thrive responsibly here. I urge you to take a clear stance on this issue.${fullNameSignOff}`
 }
 
 export const campaignMetadata: CampaignMetadata = {

--- a/src/components/app/userActionFormEmailCongressperson/au/campaigns/index.ts
+++ b/src/components/app/userActionFormEmailCongressperson/au/campaigns/index.ts
@@ -2,6 +2,8 @@ import { CampaignMetadata } from '@/components/app/userActionFormEmailCongresspe
 import { AUUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/au/auUserActionCampaigns'
 
 import * as DEFAULT from './1-default'
+import * as NEWMODE_DEBANKING from './20240611-newmode-debanking'
+import * as Q2_2025_ELECTION from './20240611-q2-2025-election'
 
 export const DEFAULT_DEEPLINK_URL_CAMPAIGN_NAME = AUUserActionEmailCampaignName.DEFAULT
 
@@ -10,6 +12,8 @@ const EMAIL_ACTION_CAMPAIGN_NAME_TO_METADATA: Record<
   CampaignMetadata
 > = {
   [AUUserActionEmailCampaignName.DEFAULT]: DEFAULT.campaignMetadata,
+  [AUUserActionEmailCampaignName.AU_Q2_2025_ELECTION]: Q2_2025_ELECTION.campaignMetadata,
+  [AUUserActionEmailCampaignName.AU_NEWMODE_DEBANKING]: NEWMODE_DEBANKING.campaignMetadata,
 }
 
 export function getAUEmailActionCampaignMetadata(campaignName: AUUserActionEmailCampaignName) {

--- a/src/components/app/userActionFormEmailCongressperson/au/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/au/index.tsx
@@ -7,7 +7,6 @@ import * as Sentry from '@sentry/nextjs'
 import { useRouter } from 'next/navigation'
 
 import { actionCreateUserActionEmailCongresspersonIntl } from '@/actions/actionCreateUserActionEmailCongresspersonIntl'
-import { getAUEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/au/campaigns'
 import {
   ANALYTICS_NAME_USER_ACTION_FORM_EMAIL_CONGRESSPERSON,
   SectionNames,
@@ -28,7 +27,6 @@ import { AUUserActionEmailCampaignName } from '@/utils/shared/userActionCampaign
 import {
   filterDTSIPeopleByAUPoliticalCategory,
   getAUPoliticianCategoryDisplayName,
-  YourPoliticianCategory,
 } from '@/utils/shared/yourPoliticianCategory/au'
 import { cn } from '@/utils/web/cn'
 import { triggerServerActionForForm } from '@/utils/web/formUtils'
@@ -42,19 +40,13 @@ import { zodUserActionFormEmailCongresspersonFields } from '@/validation/forms/z
 
 const countryCode = SupportedCountryCodes.AU
 
-const DEFAULT_POLITICIAN_CATEGORY = getAUEmailActionCampaignMetadata(
-  AUUserActionEmailCampaignName.DEFAULT,
-).politicianCategory
-
 interface AUUserActionFormEmailCongresspersonProps
   extends UserActionFormEmailCongresspersonPropsBase {
   campaignName: AUUserActionEmailCampaignName
-  politicianCategory?: YourPoliticianCategory
 }
 export function AUUserActionFormEmailCongressperson({
   user,
   initialValues,
-  politicianCategory = DEFAULT_POLITICIAN_CATEGORY,
   onCancel,
   campaignName,
 }: AUUserActionFormEmailCongresspersonProps) {
@@ -144,7 +136,7 @@ export function AUUserActionFormEmailCongressperson({
   const addressField = form.watch('address')
   const dtsiPeopleFromAddressResponse = useGetDTSIPeopleFromAddress({
     address: addressField?.description,
-    filterFn: filterDTSIPeopleByAUPoliticalCategory(politicianCategory),
+    filterFn: filterDTSIPeopleByAUPoliticalCategory(campaignMetadata.politicianCategory),
   })
 
   switch (sectionProps.currentSection) {
@@ -158,7 +150,9 @@ export function AUUserActionFormEmailCongressperson({
             />
             <EmailCongressperson.PersonalInformationFields />
             <EmailCongressperson.Representatives
-              categoryDisplayName={getAUPoliticianCategoryDisplayName(politicianCategory)}
+              categoryDisplayName={getAUPoliticianCategoryDisplayName(
+                campaignMetadata.politicianCategory,
+              )}
               countryCode={countryCode}
               dtsiPeopleFromAddressResponse={dtsiPeopleFromAddressResponse}
             />

--- a/src/components/app/userActionFormEmailCongressperson/ca/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/ca/index.tsx
@@ -9,7 +9,6 @@ import { useRouter } from 'next/navigation'
 import { z } from 'zod'
 
 import { actionCreateUserActionEmailCongresspersonIntl } from '@/actions/actionCreateUserActionEmailCongresspersonIntl'
-import { getCAEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/ca/campaigns'
 import {
   ANALYTICS_NAME_USER_ACTION_FORM_EMAIL_CONGRESSPERSON,
   SectionNames,
@@ -32,7 +31,6 @@ import { CAUserActionEmailCampaignName } from '@/utils/shared/userActionCampaign
 import {
   filterDTSIPeopleByCAPoliticalCategory,
   getCAPoliticianCategoryDisplayName,
-  YourPoliticianCategory,
 } from '@/utils/shared/yourPoliticianCategory/ca'
 import { cn } from '@/utils/web/cn'
 import { triggerServerActionForForm } from '@/utils/web/formUtils'
@@ -50,20 +48,14 @@ import { zodUserActionFormEmailCongresspersonFields } from '@/validation/forms/z
 
 const countryCode = SupportedCountryCodes.CA
 
-const DEFAULT_POLITICIAN_CATEGORY = getCAEmailActionCampaignMetadata(
-  CAUserActionEmailCampaignName.DEFAULT,
-).politicianCategory
-
 interface CAUserActionFormEmailCongresspersonProps
   extends UserActionFormEmailCongresspersonPropsBase {
   campaignName: CAUserActionEmailCampaignName
-  politicianCategory?: YourPoliticianCategory
 }
 export function CAUserActionFormEmailCongressperson({
   user,
   initialValues,
   campaignName,
-  politicianCategory = DEFAULT_POLITICIAN_CATEGORY,
   onCancel,
 }: CAUserActionFormEmailCongresspersonProps) {
   const router = useRouter()
@@ -156,7 +148,7 @@ export function CAUserActionFormEmailCongressperson({
   const addressField = form.watch('address')
   const dtsiPeopleFromAddressResponse = useGetDTSIPeopleFromAddress({
     address: addressField?.description,
-    filterFn: filterDTSIPeopleByCAPoliticalCategory(politicianCategory),
+    filterFn: filterDTSIPeopleByCAPoliticalCategory(campaignMetadata.politicianCategory),
   })
 
   const scriptStatus = useGoogleMapsScript()
@@ -199,7 +191,9 @@ export function CAUserActionFormEmailCongressperson({
             />
             <EmailCongressperson.PersonalInformationFields />
             <EmailCongressperson.Representatives
-              categoryDisplayName={getCAPoliticianCategoryDisplayName(politicianCategory)}
+              categoryDisplayName={getCAPoliticianCategoryDisplayName(
+                campaignMetadata.politicianCategory,
+              )}
               countryCode={countryCode}
               dtsiPeopleFromAddressResponse={dtsiPeopleFromAddressResponse}
             />

--- a/src/components/app/userActionFormEmailCongressperson/common/useEmailActionCampaignMetadata.ts
+++ b/src/components/app/userActionFormEmailCongressperson/common/useEmailActionCampaignMetadata.ts
@@ -1,10 +1,14 @@
 import { useMemo } from 'react'
 
 import { getAUEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/au/campaigns'
+import { CampaignMetadata as AUCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/au/campaigns/types'
 import { getCAEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/ca/campaigns'
+import { CampaignMetadata as CACampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/ca/campaigns/types'
 import { EmailActionCampaignNames } from '@/components/app/userActionFormEmailCongressperson/common/types'
 import { getGBEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/gb/campaigns'
+import { CampaignMetadata as GBCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/gb/campaigns/types'
 import { getUSEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/us/campaigns'
+import { CampaignMetadata as USCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/us/campaigns/types'
 import { gracefullyError } from '@/utils/shared/gracefullyError'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { AUUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/au/auUserActionCampaigns'
@@ -12,12 +16,26 @@ import { CAUserActionEmailCampaignName } from '@/utils/shared/userActionCampaign
 import { GBUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/gb/gbUserActionCampaigns'
 import { USUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/us/usUserActionCampaigns'
 
-interface UseEmailActionCampaignMetadataProps {
-  countryCode: SupportedCountryCodes
+interface UseEmailActionCampaignMetadataProps<TCountryCode extends SupportedCountryCodes> {
+  countryCode: TCountryCode
   campaignName: EmailActionCampaignNames
 }
 
-export function useEmailActionCampaignMetadata(props: UseEmailActionCampaignMetadataProps) {
+// This is ugly, but it's the only way to get the type of the campaign metadata for the country
+// And we need to do this because of the politicianCategory field which is different for each country
+// TODO: Refactor to keep type safety and not have to do this
+type CampaignMetadata<TCountryCode extends SupportedCountryCodes> =
+  TCountryCode extends SupportedCountryCodes.US
+    ? USCampaignMetadata
+    : TCountryCode extends SupportedCountryCodes.AU
+      ? AUCampaignMetadata
+      : TCountryCode extends SupportedCountryCodes.CA
+        ? CACampaignMetadata
+        : GBCampaignMetadata
+
+export function useEmailActionCampaignMetadata<TCountryCode extends SupportedCountryCodes>(
+  props: UseEmailActionCampaignMetadataProps<TCountryCode>,
+): CampaignMetadata<TCountryCode> {
   const { campaignName, countryCode } = props
   return useMemo(() => {
     switch (countryCode) {
@@ -44,5 +62,5 @@ export function useEmailActionCampaignMetadata(props: UseEmailActionCampaignMeta
           },
         })
     }
-  }, [campaignName, countryCode])
+  }, [campaignName, countryCode]) as CampaignMetadata<TCountryCode>
 }

--- a/src/components/app/userActionFormEmailCongressperson/common/useEmailActionCampaignMetadata.ts
+++ b/src/components/app/userActionFormEmailCongressperson/common/useEmailActionCampaignMetadata.ts
@@ -21,17 +21,14 @@ interface UseEmailActionCampaignMetadataProps<TCountryCode extends SupportedCoun
   campaignName: EmailActionCampaignNames
 }
 
-// This is ugly, but it's the only way to get the type of the campaign metadata for the country
-// And we need to do this because of the politicianCategory field which is different for each country
-// TODO: Refactor to keep type safety and not have to do this
+interface CampaignMetadataMap {
+  [SupportedCountryCodes.US]: USCampaignMetadata
+  [SupportedCountryCodes.AU]: AUCampaignMetadata
+  [SupportedCountryCodes.CA]: CACampaignMetadata
+  [SupportedCountryCodes.GB]: GBCampaignMetadata
+}
 type CampaignMetadata<TCountryCode extends SupportedCountryCodes> =
-  TCountryCode extends SupportedCountryCodes.US
-    ? USCampaignMetadata
-    : TCountryCode extends SupportedCountryCodes.AU
-      ? AUCampaignMetadata
-      : TCountryCode extends SupportedCountryCodes.CA
-        ? CACampaignMetadata
-        : GBCampaignMetadata
+  CampaignMetadataMap[TCountryCode]
 
 export function useEmailActionCampaignMetadata<TCountryCode extends SupportedCountryCodes>(
   props: UseEmailActionCampaignMetadataProps<TCountryCode>,

--- a/src/components/app/userActionFormEmailCongressperson/gb/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/gb/index.tsx
@@ -19,7 +19,6 @@ import {
   UserActionFormEmailCongresspersonPropsBase,
 } from '@/components/app/userActionFormEmailCongressperson/common/types'
 import { useEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/common/useEmailActionCampaignMetadata'
-import { getGBEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/gb/campaigns'
 import { dialogContentPaddingStyles } from '@/components/ui/dialog/styles'
 import { useGetDTSIPeopleFromAddress } from '@/hooks/useGetDTSIPeopleFromAddress'
 import { useSections } from '@/hooks/useSections'
@@ -29,7 +28,6 @@ import { GBUserActionEmailCampaignName } from '@/utils/shared/userActionCampaign
 import {
   filterDTSIPeopleByGBPoliticalCategory,
   getGBPoliticianCategoryDisplayName,
-  YourPoliticianCategory,
 } from '@/utils/shared/yourPoliticianCategory/gb'
 import { cn } from '@/utils/web/cn'
 import { triggerServerActionForForm } from '@/utils/web/formUtils'
@@ -43,20 +41,14 @@ import { zodUserActionFormEmailCongresspersonFields } from '@/validation/forms/z
 
 const countryCode = SupportedCountryCodes.GB
 
-const DEFAULT_POLITICIAN_CATEGORY = getGBEmailActionCampaignMetadata(
-  GBUserActionEmailCampaignName.DEFAULT,
-).politicianCategory
-
 interface GBUserActionFormEmailCongresspersonProps
   extends UserActionFormEmailCongresspersonPropsBase {
   campaignName: GBUserActionEmailCampaignName
-  politicianCategory?: YourPoliticianCategory
 }
 export function GBUserActionFormEmailCongressperson({
   user,
   initialValues,
   campaignName,
-  politicianCategory = DEFAULT_POLITICIAN_CATEGORY,
   onCancel,
 }: GBUserActionFormEmailCongresspersonProps) {
   const router = useRouter()
@@ -149,7 +141,7 @@ export function GBUserActionFormEmailCongressperson({
   const addressField = form.watch('address')
   const dtsiPeopleFromAddressResponse = useGetDTSIPeopleFromAddress({
     address: addressField?.description,
-    filterFn: filterDTSIPeopleByGBPoliticalCategory(politicianCategory),
+    filterFn: filterDTSIPeopleByGBPoliticalCategory(campaignMetadata.politicianCategory),
   })
 
   switch (sectionProps.currentSection) {
@@ -163,7 +155,9 @@ export function GBUserActionFormEmailCongressperson({
             />
             <EmailCongressperson.PersonalInformationFields />
             <EmailCongressperson.Representatives
-              categoryDisplayName={getGBPoliticianCategoryDisplayName(politicianCategory)}
+              categoryDisplayName={getGBPoliticianCategoryDisplayName(
+                campaignMetadata.politicianCategory,
+              )}
               countryCode={countryCode}
               dtsiPeopleFromAddressResponse={dtsiPeopleFromAddressResponse}
             />

--- a/src/components/app/userActionFormEmailCongressperson/us/index.tsx
+++ b/src/components/app/userActionFormEmailCongressperson/us/index.tsx
@@ -18,7 +18,6 @@ import {
   UserActionFormEmailCongresspersonPropsBase,
 } from '@/components/app/userActionFormEmailCongressperson/common/types'
 import { useEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/common/useEmailActionCampaignMetadata'
-import { getUSEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/us/campaigns'
 import { dialogContentPaddingStyles } from '@/components/ui/dialog/styles'
 import { useGetDTSIPeopleFromAddress } from '@/hooks/useGetDTSIPeopleFromAddress'
 import { useSections } from '@/hooks/useSections'
@@ -28,7 +27,6 @@ import { USUserActionEmailCampaignName } from '@/utils/shared/userActionCampaign
 import {
   filterDTSIPeopleByUSPoliticalCategory,
   getUSPoliticianCategoryDisplayName,
-  YourPoliticianCategory,
 } from '@/utils/shared/yourPoliticianCategory/us'
 import { cn } from '@/utils/web/cn'
 import { triggerServerActionForForm } from '@/utils/web/formUtils'
@@ -42,20 +40,14 @@ import { zodUserActionFormEmailCongresspersonFields } from '@/validation/forms/z
 
 const countryCode = SupportedCountryCodes.US
 
-const DEFAULT_POLITICIAN_CATEGORY = getUSEmailActionCampaignMetadata(
-  USUserActionEmailCampaignName.DEFAULT,
-).politicianCategory
-
 interface USUserActionFormEmailCongresspersonProps
   extends UserActionFormEmailCongresspersonPropsBase {
   campaignName: USUserActionEmailCampaignName
-  politicianCategory?: YourPoliticianCategory
 }
 
 export function USUserActionFormEmailCongressperson({
   user,
   initialValues,
-  politicianCategory = DEFAULT_POLITICIAN_CATEGORY,
   onCancel,
   campaignName,
 }: USUserActionFormEmailCongresspersonProps) {
@@ -145,7 +137,7 @@ export function USUserActionFormEmailCongressperson({
   const addressField = form.watch('address')
   const dtsiPeopleFromAddressResponse = useGetDTSIPeopleFromAddress({
     address: addressField?.description,
-    filterFn: filterDTSIPeopleByUSPoliticalCategory(politicianCategory),
+    filterFn: filterDTSIPeopleByUSPoliticalCategory(campaignMetadata.politicianCategory),
   })
 
   switch (sectionProps.currentSection) {
@@ -159,7 +151,9 @@ export function USUserActionFormEmailCongressperson({
             />
             <EmailCongressperson.PersonalInformationFields />
             <EmailCongressperson.Representatives
-              categoryDisplayName={getUSPoliticianCategoryDisplayName(politicianCategory)}
+              categoryDisplayName={getUSPoliticianCategoryDisplayName(
+                campaignMetadata.politicianCategory,
+              )}
               countryCode={countryCode}
               dtsiPeopleFromAddressResponse={dtsiPeopleFromAddressResponse}
             />

--- a/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
@@ -68,18 +68,6 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
       },
       {
         actionType: UserActionType.EMAIL,
-        campaignName: AUUserActionEmailCampaignName.AU_Q2_2025_ELECTION,
-        isCampaignActive: true,
-        title: `Email your Member of Parliament`,
-        description: 'Tell your MP to support responsible crypto policy — send an email now!',
-        canBeTriggeredMultipleTimes: true,
-        WrapperComponent: getEmailActionWrapperComponentByCampaignName({
-          countryCode,
-          campaignName: AUUserActionEmailCampaignName.AU_Q2_2025_ELECTION,
-        }),
-      },
-      {
-        actionType: UserActionType.EMAIL,
         campaignName: AUUserActionEmailCampaignName.AU_NEWMODE_DEBANKING,
         isCampaignActive: false,
         title: 'Email your MP to stop unfair debanking',
@@ -88,6 +76,18 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
         WrapperComponent: getEmailActionWrapperComponentByCampaignName({
           countryCode,
           campaignName: AUUserActionEmailCampaignName.AU_NEWMODE_DEBANKING,
+        }),
+      },
+      {
+        actionType: UserActionType.EMAIL,
+        campaignName: AUUserActionEmailCampaignName.AU_Q2_2025_ELECTION,
+        isCampaignActive: true,
+        title: `Email your Member of Parliament`,
+        description: 'Tell your MP to support responsible crypto policy — send an email now!',
+        canBeTriggeredMultipleTimes: true,
+        WrapperComponent: getEmailActionWrapperComponentByCampaignName({
+          countryCode,
+          campaignName: AUUserActionEmailCampaignName.AU_Q2_2025_ELECTION,
         }),
       },
     ],

--- a/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
@@ -81,7 +81,7 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
       {
         actionType: UserActionType.EMAIL,
         campaignName: AUUserActionEmailCampaignName.AU_NEWMODE_DEBANKING,
-        isCampaignActive: true,
+        isCampaignActive: false,
         title: 'Email your MP to stop unfair debanking',
         description: 'Urge them to stand up for financial access and innovation.',
         canBeTriggeredMultipleTimes: true,

--- a/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
@@ -2,6 +2,7 @@ import { UserActionType } from '@prisma/client'
 import Link from 'next/link'
 
 import { LoginDialogWrapper } from '@/components/app/authentication/loginDialogWrapper'
+import { getEmailActionWrapperComponentByCampaignName } from '@/components/app/userActionFormEmailCongressperson/getWrapperComponentByCampaignName'
 import { UserActionFormFollowLinkedInDialog } from '@/components/app/userActionFormFollowOnLinkedIn/common/dialog'
 import { UserActionFormReferDialog } from '@/components/app/userActionFormRefer/dialog'
 import { UserActionFormShareOnTwitterDialog } from '@/components/app/userActionFormShareOnTwitter/common/dialog'
@@ -10,6 +11,7 @@ import { UserActionGridCTA } from '@/components/app/userActionGridCTAs/types'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { getIntlUrls } from '@/utils/shared/urls'
 import {
+  AUUserActionEmailCampaignName,
   AUUserActionLinkedInCampaignName,
   AUUserActionPollCampaignName,
   AUUserActionReferCampaignName,
@@ -44,6 +46,52 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
       },
     ],
   },
+  [UserActionType.EMAIL]: {
+    title: 'Email your Member of Parliament',
+    description:
+      'Make your voice heard on important crypto policy issues by emailing your representatives',
+    campaignsModalDescription:
+      'Make your voice heard on important crypto policy issues by emailing your representatives',
+    image: '/au/actionTypeIcons/email.png',
+    campaigns: [
+      {
+        actionType: UserActionType.EMAIL,
+        campaignName: AUUserActionEmailCampaignName.DEFAULT,
+        isCampaignActive: false,
+        title: `Email your Member of Parliament`,
+        description: 'Tell your MP to support responsible crypto policy — send an email now!',
+        canBeTriggeredMultipleTimes: true,
+        WrapperComponent: getEmailActionWrapperComponentByCampaignName({
+          countryCode,
+          campaignName: AUUserActionEmailCampaignName.DEFAULT,
+        }),
+      },
+      {
+        actionType: UserActionType.EMAIL,
+        campaignName: AUUserActionEmailCampaignName.AU_Q2_2025_ELECTION,
+        isCampaignActive: true,
+        title: `Email your Member of Parliament`,
+        description: 'Tell your MP to support responsible crypto policy — send an email now!',
+        canBeTriggeredMultipleTimes: true,
+        WrapperComponent: getEmailActionWrapperComponentByCampaignName({
+          countryCode,
+          campaignName: AUUserActionEmailCampaignName.AU_Q2_2025_ELECTION,
+        }),
+      },
+      {
+        actionType: UserActionType.EMAIL,
+        campaignName: AUUserActionEmailCampaignName.AU_NEWMODE_DEBANKING,
+        isCampaignActive: true,
+        title: 'Email your MP to stop unfair debanking',
+        description: 'Urge them to stand up for financial access and innovation.',
+        canBeTriggeredMultipleTimes: true,
+        WrapperComponent: getEmailActionWrapperComponentByCampaignName({
+          countryCode,
+          campaignName: AUUserActionEmailCampaignName.AU_NEWMODE_DEBANKING,
+        }),
+      },
+    ],
+  },
   [UserActionType.VIEW_KEY_PAGE]: {
     title: 'Email your Member of Parliament',
     description:
@@ -55,7 +103,7 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
       {
         actionType: UserActionType.VIEW_KEY_PAGE,
         campaignName: AUUserActionViewKeyPageCampaignName.AU_Q2_2025_ELECTION,
-        isCampaignActive: true,
+        isCampaignActive: false,
         title: `Email your Member of Parliament`,
         description: 'Tell your MP to support responsible crypto policy — send an email now!',
         canBeTriggeredMultipleTimes: true,
@@ -68,7 +116,7 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
       {
         actionType: UserActionType.VIEW_KEY_PAGE,
         campaignName: AUUserActionViewKeyPageCampaignName.AU_NEWMODE_DEBANKING,
-        isCampaignActive: true,
+        isCampaignActive: false,
         title: 'Email your MP to stop unfair debanking',
         description: 'Urge them to stand up for financial access and innovation.',
         canBeTriggeredMultipleTimes: true,

--- a/src/utils/shared/userActionCampaigns/au/auUserActionCampaigns.ts
+++ b/src/utils/shared/userActionCampaigns/au/auUserActionCampaigns.ts
@@ -55,6 +55,8 @@ export enum AUUserActionPollCampaignName {
 
 export enum AUUserActionEmailCampaignName {
   DEFAULT = 'DEFAULT',
+  AU_Q2_2025_ELECTION = 'AU_Q2_2025_ELECTION',
+  AU_NEWMODE_DEBANKING = 'AU_NEWMODE_DEBANKING',
 }
 
 export type AUUserActionCampaignName =


### PR DESCRIPTION
## Description
This PR implements changes to address [swc-internal#409](https://github.com/Stand-With-Crypto/swc-internal/issues/409).

## Checklist
- [x] All changes are committed and pushed
- [x] Linting and tests pass (`npm run audit`)
- [ ] No Prisma schema changes
- [x] "AI Generated" marked in Notes to Reviewers

## Linked Issues
closes swc-internal#409

## Notes to Reviewers
- AI Generated

## Testing
- [x] All relevant tests pass
- [ ] Screenshots provided for UI changes (please add if applicable)

