### PR TITLE
fix: add early return for notFoundReason in getDTSIPeopleFromAddress

### DIFF
--- a/src/hooks/useGetDTSIPeopleFromAddress.ts
+++ b/src/hooks/useGetDTSIPeopleFromAddress.ts
@@ -52,6 +52,11 @@ export async function getDTSIPeopleFromAddress({
       catchUnexpectedServerErrorAndTriggerToast(e)
       return { notFoundReason: 'UNEXPECTED_ERROR' as const }
     })
+
+  if ('notFoundReason' in data) {
+    return data
+  }
+
   const dtsiPeople = data as DTSIPeopleByElectoralZoneQueryResult
 
   const filteredData = filterFn(dtsiPeople)


### PR DESCRIPTION
## Summary

This PR adds proper error handling to the `getDTSIPeopleFromAddress` function by adding an early return when `notFoundReason` is present in the response data.

## Changes

- Added a check for `notFoundReason` in the response data
- Return early if `notFoundReason` is present to prevent processing invalid data as `DTSIPeopleByElectoralZoneQueryResult`

## Why this change is needed

Without this check, the function would attempt to process error responses as valid DTSI people data, which could lead to runtime errors or unexpected behavior.

## Testing

- [x] Verified the change handles error cases properly
- [x] Confirmed normal flow continues to work when data is valid