### PR TITLE
Fix addressComponents type

### DIFF
--- a/src/utils/server/externalOptIn/handleExternalUserActionOptIn.ts
+++ b/src/utils/server/externalOptIn/handleExternalUserActionOptIn.ts
@@ -268,9 +268,12 @@ async function maybeUpsertUser({
       const googleAddressData = await getAddressFromGooglePlacePrediction({
         description: formattedDescription,
       })
+      const filteredGoogleAddressData = Object.fromEntries(
+        Object.entries(googleAddressData).filter(([_, value]) => Boolean(value)),
+      )
       dbAddress = {
         ...dbAddress,
-        ...googleAddressData,
+        ...filteredGoogleAddressData,
       }
     } catch (e) {
       logger.error('error getting `googlePlaceId`:' + e)

--- a/src/utils/server/externalOptIn/handleExternalUserActionOptIn.ts
+++ b/src/utils/server/externalOptIn/handleExternalUserActionOptIn.ts
@@ -268,6 +268,7 @@ async function maybeUpsertUser({
       const googleAddressData = await getAddressFromGooglePlacePrediction({
         description: formattedDescription,
       })
+      // Filter out fields without data to avoid overwriting existing data from the external source
       const filteredGoogleAddressData = Object.fromEntries(
         Object.entries(googleAddressData).filter(([_, value]) => Boolean(value)),
       )

--- a/src/utils/server/getAddressFromGooglePlacePrediction.ts
+++ b/src/utils/server/getAddressFromGooglePlacePrediction.ts
@@ -48,7 +48,7 @@ type Args =
  * @returns Place data with ID, formatted address, address components, and location
  * @throws Error if no place is found or if the API request fails
  */
-export async function getPlaceDataFromAddress({ address, placeId }: Args): Promise<PlaceData> {
+async function getPlaceDataFromAddress({ address, placeId }: Args): Promise<PlaceData> {
   let data: GooglePlacesDetailsResponse | undefined
   let response: Response
   if (placeId) {

--- a/src/utils/server/getAddressFromGooglePlacePrediction.ts
+++ b/src/utils/server/getAddressFromGooglePlacePrediction.ts
@@ -14,12 +14,17 @@ const GOOGLE_PLACES_BACKEND_API_KEY = requiredEnv(
   'GOOGLE_PLACES_BACKEND_API_KEY',
 )
 
-type AddressComponents = google.maps.GeocoderAddressComponent[]
+interface AddressComponent {
+  longText: string
+  shortText: string
+  types: string[]
+  languageCode: string
+}
 
 interface PlaceData {
   placeId: string
   formattedAddress: string
-  addressComponents: AddressComponents
+  addressComponents: AddressComponent[]
   location: {
     latitude: number
     longitude: number
@@ -43,7 +48,7 @@ type Args =
  * @returns Place data with ID, formatted address, address components, and location
  * @throws Error if no place is found or if the API request fails
  */
-async function getPlaceDataFromAddress({ address, placeId }: Args): Promise<PlaceData> {
+export async function getPlaceDataFromAddress({ address, placeId }: Args): Promise<PlaceData> {
   let data: GooglePlacesDetailsResponse | undefined
   let response: Response
   if (placeId) {
@@ -95,7 +100,7 @@ interface GooglePlacesTextSearchResponse {
   places?: Array<{
     id: string
     formattedAddress: string
-    addressComponents: AddressComponents
+    addressComponents: AddressComponent[]
     location: {
       latitude: number
       longitude: number
@@ -127,7 +132,7 @@ async function fetchDataByAddress(address: string) {
 interface GooglePlacesDetailsResponse {
   id: string
   formattedAddress: string
-  addressComponents: AddressComponents
+  addressComponents: AddressComponent[]
   location: {
     latitude: number
     longitude: number
@@ -153,7 +158,11 @@ export async function getAddressFromGooglePlacePrediction(
     placeId: prediction.place_id,
   })
   return formatGooglePlacesResultToAddress({
-    address_components: result.addressComponents,
+    address_components: result.addressComponents.map(component => ({
+      ...component,
+      long_name: component.longText,
+      short_name: component.shortText,
+    })),
     geometry: {
       location: {
         lat: () => result.location.latitude,


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

The `addressComponents` returned from the Google Places API is different from the one returned from the client Google Maps API.

- Updated the `AddressComponent` type for the server.
- `handleExternalUserActionOptIn` now only overwrites an address field with google places data if it exists.

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

- [ ] AI Generated

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
