### PR TITLE
feat: script to backfill address missing fields

### DIFF
--- a/src/app/api/inngest/route.ts
+++ b/src/app/api/inngest/route.ts
@@ -3,6 +3,8 @@ import { serve } from 'inngest/next'
 import { airdropNFTWithInngest } from '@/inngest/functions/airdropNFT/airdropNFT'
 import { backfillAddressElectoralZoneCoordinator } from '@/inngest/functions/backfillAddressElectoralZone'
 import { backfillAddressElectoralZoneProcessor } from '@/inngest/functions/backfillAddressElectoralZone/logic'
+import { backfillAddressFieldsWithGooglePlacesCoordinator } from '@/inngest/functions/backfillAddressFieldsWithGooglePlaces'
+import { backfillAddressFieldsWithGooglePlacesProcessor } from '@/inngest/functions/backfillAddressFieldsWithGooglePlaces/logic'
 import { backfillCongressionalDistrictCronJob } from '@/inngest/functions/backfillCongressionalDistrictCronJob'
 import { backfillCountryCodesInngest } from '@/inngest/functions/backfillCountryCodes'
 import { backfillFailedNFT } from '@/inngest/functions/backfillFailedNFTCronJob'
@@ -99,5 +101,7 @@ export const { GET, POST, PUT } = serve({
     backfillAddressElectoralZoneProcessor,
     backfillUserActionElectoralZoneCoordinator,
     backfillUserActionElectoralZoneProcessor,
+    backfillAddressFieldsWithGooglePlacesCoordinator,
+    backfillAddressFieldsWithGooglePlacesProcessor,
   ],
 })

--- a/src/inngest/functions/backfillAddressFieldsWithGooglePlaces/config.ts
+++ b/src/inngest/functions/backfillAddressFieldsWithGooglePlaces/config.ts
@@ -1,0 +1,9 @@
+export const BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_BATCH_SIZE = 5000
+export const BATCH_BUFFER = 1.05
+export const BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_RETRY_LIMIT = 5
+export const MINI_BATCH_SIZE = 2500
+/**
+ * This is the maximum number of concurrent "Processor" jobs that can be running at once.
+ * This is to prevent the script from overwhelming the database and hitting connection pool limits.
+ */
+export const CONCURRENCY_LIMIT = 10

--- a/src/inngest/functions/backfillAddressFieldsWithGooglePlaces/index.ts
+++ b/src/inngest/functions/backfillAddressFieldsWithGooglePlaces/index.ts
@@ -1,0 +1,120 @@
+import { inngest } from '@/inngest/inngest'
+import { onScriptFailure } from '@/inngest/onScriptFailure'
+import { prismaClient } from '@/utils/server/prismaClient'
+import {
+  ORDERED_SUPPORTED_COUNTRIES,
+  SupportedCountryCodes,
+} from '@/utils/shared/supportedCountries'
+
+import {
+  BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_BATCH_SIZE,
+  BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_RETRY_LIMIT,
+  BATCH_BUFFER,
+} from './config'
+import { backfillAddressFieldsWithGooglePlacesProcessor } from './logic'
+
+const BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_COORDINATOR_FUNCTION_ID =
+  'script.backfill-address-fields-with-google-places-coordinator'
+export const BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_COORDINATOR_EVENT_NAME =
+  'script/backfill-address-fields-with-google-places-coordinator'
+
+export interface BackfillAddressFieldsWithGooglePlacesCoordinatorEventSchema {
+  name: typeof BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_COORDINATOR_EVENT_NAME
+  data: {
+    persist?: boolean
+    countryCode?: string
+  }
+}
+
+export const backfillAddressFieldsWithGooglePlacesCoordinator = inngest.createFunction(
+  {
+    id: BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_COORDINATOR_FUNCTION_ID,
+    retries: BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_RETRY_LIMIT,
+    onFailure: onScriptFailure,
+  },
+  {
+    event: BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_COORDINATOR_EVENT_NAME,
+  },
+  async ({ step, logger, event }) => {
+    const { countryCode: countryCodeParam, persist = false } = event.data
+
+    if (countryCodeParam && !ORDERED_SUPPORTED_COUNTRIES.includes(countryCodeParam.toLowerCase())) {
+      logger.info('Country code is not supported.')
+      return {
+        message: 'Country code is not supported.',
+      }
+    }
+
+    const countryCode = countryCodeParam?.toLowerCase() as SupportedCountryCodes
+
+    if (!persist) {
+      logger.info('DRY RUN MODE: No changes will be written to the database.')
+    }
+
+    const addressCount = await step.run('get-address-count', () =>
+      prismaClient.address.count({
+        where: {
+          countryCode,
+          formattedDescription: {
+            not: {
+              contains: 'test',
+            },
+          },
+          OR: [
+            {
+              electoralZone: null,
+            },
+            {
+              administrativeAreaLevel1: '',
+            },
+          ],
+        },
+      }),
+    )
+
+    if (addressCount === 0) {
+      logger.info('No addresses to backfill.')
+      return {
+        message: 'No addresses to backfill.',
+      }
+    }
+
+    const totalBatches = Math.ceil(
+      addressCount / BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_BATCH_SIZE,
+    )
+    logger.info(
+      `Found ${addressCount} addresses to backfill, splitting into ${totalBatches} batches.`,
+    )
+
+    const invokeEvents = []
+    for (let i = 0; i < totalBatches * BATCH_BUFFER; i++) {
+      invokeEvents.push(
+        step.invoke(`invoke-processor-batch-${i}`, {
+          function: backfillAddressFieldsWithGooglePlacesProcessor,
+          data: {
+            skip: i * BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_BATCH_SIZE,
+            take: BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_BATCH_SIZE,
+            persist,
+            countryCode,
+          },
+        }),
+      )
+    }
+
+    const results = await Promise.allSettled(invokeEvents)
+
+    const failedInvocations = results.filter(r => r.status === 'rejected')
+    if (failedInvocations.length > 0) {
+      logger.error(`Failed to invoke ${failedInvocations.length} processor jobs.`, {
+        errors: failedInvocations.map(f => f.reason),
+      })
+    }
+
+    return {
+      dryRun: !persist,
+      message: `Finished processing ${totalBatches} batches.`,
+      successfulBatches: totalBatches - failedInvocations.length,
+      failedBatches: failedInvocations.length,
+    }
+  },
+)

--- a/src/inngest/functions/backfillAddressFieldsWithGooglePlaces/logic.ts
+++ b/src/inngest/functions/backfillAddressFieldsWithGooglePlaces/logic.ts
@@ -111,10 +111,6 @@ export const backfillAddressFieldsWithGooglePlacesProcessor = inngest.createFunc
               data: {
                 ...result.value.completeAddress,
                 electoralZone: result.value.electoralZone,
-                usCongressionalDistrict:
-                  countryCode === SupportedCountryCodes.US
-                    ? result.value.completeAddress.electoralZone
-                    : undefined,
               },
             })
           }
@@ -201,7 +197,10 @@ async function getAddressFromGooglePlaces(
   }
   return {
     addressId: address.id,
-    completeAddress,
+    // Remove null and empty strings
+    completeAddress: Object.fromEntries(
+      Object.entries(completeAddress).filter(([_, value]) => Boolean(value)),
+    ),
     electoralZone: electoralZone?.zoneName,
   }
 }

--- a/src/inngest/functions/backfillAddressFieldsWithGooglePlaces/logic.ts
+++ b/src/inngest/functions/backfillAddressFieldsWithGooglePlaces/logic.ts
@@ -1,0 +1,200 @@
+import { Prisma } from '@prisma/client'
+import { chunk, isNull } from 'lodash-es'
+import pRetry from 'p-retry'
+
+import { inngest } from '@/inngest/inngest'
+import { onScriptFailure } from '@/inngest/onScriptFailure'
+import { getAddressSchemaFromGooglePlacePrediction } from '@/utils/server/getPlaceDataFromAddress'
+import { prismaClient } from '@/utils/server/prismaClient'
+import { querySWCCivicElectoralZoneFromLatLong } from '@/utils/server/swcCivic/queries/queryElectoralZoneFromLatLong'
+import { ElectoralZone } from '@/utils/server/swcCivic/types'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+
+import { CONCURRENCY_LIMIT, MINI_BATCH_SIZE } from './config'
+
+const PROCESS_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_PROCESSOR_FUNCTION_ID =
+  'script.backfill-address-fields-with-google-places-processor'
+const PROCESS_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_PROCESSOR_EVENT_NAME =
+  'script/backfill-address-fields-with-google-places-processor'
+
+export interface ProcessAddressFieldsWithGooglePlacesProcessorEventSchema {
+  name: typeof PROCESS_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_PROCESSOR_EVENT_NAME
+  data: {
+    skip: number
+    take: number
+    persist?: boolean
+    countryCode: SupportedCountryCodes
+  }
+}
+
+export const backfillAddressFieldsWithGooglePlacesProcessor = inngest.createFunction(
+  {
+    id: PROCESS_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_PROCESSOR_FUNCTION_ID,
+    onFailure: onScriptFailure,
+    concurrency: CONCURRENCY_LIMIT,
+  },
+  { event: PROCESS_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_PROCESSOR_EVENT_NAME },
+  async ({ event, step, logger }) => {
+    const { skip, take, persist, countryCode } = event.data
+
+    if (!persist) {
+      logger.info(
+        `DRY RUN MODE for batch with skip: ${skip}, take: ${take}. No changes will be written to the database.`,
+      )
+    }
+
+    const addresses = await step.run('get-addresses', () =>
+      prismaClient.address.findMany({
+        where: {
+          countryCode,
+          formattedDescription: {
+            not: {
+              contains: 'test',
+            },
+          },
+          OR: [
+            {
+              electoralZone: null,
+            },
+            {
+              administrativeAreaLevel1: '',
+            },
+          ],
+        },
+        skip,
+        take,
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          googlePlaceId: true,
+          formattedDescription: true,
+        },
+      }),
+    )
+
+    if (addresses.length === 0) {
+      logger.info('No Addresses to process')
+      return {
+        totalProcessed: 0,
+        totalFailed: 0,
+      }
+    }
+
+    const addressChunks = chunk(addresses, MINI_BATCH_SIZE)
+    let chunkIndex = 0
+    let totalSuccess = 0
+    let totalFailed = 0
+    for (const addressChunk of addressChunks) {
+      const completeAddressesResults = await step.run(`get-address-for-batch-${chunkIndex}`, () =>
+        Promise.allSettled(
+          addressChunk.map(address =>
+            pRetry(async () => await getAddressFromGooglePlaces(address), {
+              retries: 2,
+              shouldRetry(error) {
+                return (
+                  !error.message.includes('No place ID found for address') &&
+                  !error.message.includes('404') &&
+                  !error.message.includes('The provided Place ID is no longer valid') &&
+                  !error.message.includes('No place found for address')
+                )
+              },
+            }),
+          ),
+        ),
+      )
+
+      const updatesToPerform = completeAddressesResults
+        .map((result, index) => {
+          if (result.status === 'fulfilled' && !isNull(result.value)) {
+            return prismaClient.address.update({
+              where: { id: result.value.addressId },
+              data: { ...result.value.completeAddress, electoralZone: result.value.electoralZone },
+            })
+          }
+          logger.error('Results not found for address', addressChunk[index])
+          totalFailed++
+          return null
+        })
+        .filter(Boolean)
+
+      if (!updatesToPerform.length) {
+        logger.info(`No updates to perform for batch ${chunkIndex}`)
+        continue
+      }
+
+      const chunkUpdateResults = await step.run(`update-db-for-batch-${chunkIndex}`, async () => {
+        if (!persist) {
+          logger.info(
+            `[DRY RUN] Would update ${updatesToPerform.length} addresses in batch ${chunkIndex}.`,
+          )
+          return { affectedRows: updatesToPerform.length }
+        }
+
+        if (updatesToPerform.length === 0) {
+          return { affectedRows: 0 }
+        }
+
+        try {
+          const affectedRows = await prismaClient.$transaction(updatesToPerform)
+          logger.info(`UPDATED Updated ${affectedRows.length} addresses in batch ${chunkIndex}`, {
+            affectedRows,
+          })
+          return { affectedRows: affectedRows.length }
+        } catch (error) {
+          logger.error(`Raw SQL update failed for batch ${chunkIndex}`, { error })
+          return { affectedRows: 0 }
+        }
+      })
+
+      const successfulUpdatesInChunk = chunkUpdateResults.affectedRows
+      const failedUpdatesInChunk = updatesToPerform.length - successfulUpdatesInChunk
+      totalSuccess += successfulUpdatesInChunk
+      totalFailed += failedUpdatesInChunk
+
+      logger.info(
+        `${!persist ? '[DRY RUN] ' : ''}Processed ${
+          successfulUpdatesInChunk
+        }/${updatesToPerform.length} addresses in batch ${chunkIndex}.`,
+      )
+      chunkIndex++
+    }
+
+    logger.info(
+      `${!persist ? '[DRY RUN] ' : ''}Finished processing batch with skip: ${skip}.
+			Total addresses successfully updated: ${totalSuccess}.
+			Total addresses failed to update: ${totalFailed}.
+			Total addresses processed: ${addresses.length}.`,
+    )
+    return {
+      totalSuccess,
+      totalFailed,
+    }
+  },
+)
+
+async function getAddressFromGooglePlaces(
+  address: Prisma.AddressGetPayload<{
+    select: {
+      id: true
+      googlePlaceId: true
+      formattedDescription: true
+    }
+  }>,
+) {
+  const completeAddress = await getAddressSchemaFromGooglePlacePrediction({
+    description: address.formattedDescription,
+    place_id: address.googlePlaceId ?? undefined,
+  })
+  let electoralZone: ElectoralZone | undefined
+  if (completeAddress.latitude && completeAddress.longitude) {
+    electoralZone = await querySWCCivicElectoralZoneFromLatLong(
+      completeAddress.latitude,
+      completeAddress.longitude,
+    )
+  }
+  return {
+    addressId: address.id,
+    completeAddress,
+    electoralZone: electoralZone?.zoneName,
+  }
+}

--- a/src/inngest/types.ts
+++ b/src/inngest/types.ts
@@ -3,6 +3,8 @@ import { EventSchemas } from 'inngest'
 import type { AirdropNftInngestSchema } from '@/inngest/functions/airdropNFT/airdropNFT'
 import type { BackfillAddressElectoralZoneCoordinatorEventSchema } from '@/inngest/functions/backfillAddressElectoralZone'
 import type { ProcessAddressElectoralZoneProcessorEventSchema } from '@/inngest/functions/backfillAddressElectoralZone/logic'
+import { BackfillAddressFieldsWithGooglePlacesCoordinatorEventSchema } from '@/inngest/functions/backfillAddressFieldsWithGooglePlaces'
+import { ProcessAddressFieldsWithGooglePlacesProcessorEventSchema } from '@/inngest/functions/backfillAddressFieldsWithGooglePlaces/logic'
 import type { BackfillUsCongressionalDistrictsInngestCronJobSchema } from '@/inngest/functions/backfillCongressionalDistrictCronJob'
 import type { BackfillCountryCodesEventSchema } from '@/inngest/functions/backfillCountryCodes'
 import type { BackfillFailedNftInngestSchema } from '@/inngest/functions/backfillFailedNFTCronJob'
@@ -84,5 +86,7 @@ type EventTypes =
   | ProcessAddressElectoralZoneProcessorEventSchema
   | BackfillUserActionElectoralZoneCoordinatorEventSchema
   | ProcessUserActionElectoralZoneProcessorEventSchema
+  | BackfillAddressFieldsWithGooglePlacesCoordinatorEventSchema
+  | ProcessAddressFieldsWithGooglePlacesProcessorEventSchema
 
 export const INNGEST_SCHEMAS = new EventSchemas().fromUnion<EventTypes>()

--- a/src/utils/server/getAddressFromGooglePlacePrediction.ts
+++ b/src/utils/server/getAddressFromGooglePlacePrediction.ts
@@ -5,6 +5,7 @@ import _isEmpty from 'lodash-es/isEmpty'
 
 import { fetchReq } from '@/utils/shared/fetchReq'
 import { formatGooglePlacesResultToAddress } from '@/utils/shared/formatGooglePlacesResultToAddress'
+import { getLogger } from '@/utils/shared/logger'
 import { requiredEnv } from '@/utils/shared/requiredEnv'
 
 const GOOGLE_PLACES_TEXT_SEARCH_API_URL = 'https://places.googleapis.com/v1/places:searchText'
@@ -20,6 +21,7 @@ interface AddressComponent {
   types: string[]
   languageCode: string
 }
+const logger = getLogger('getAddressFromGooglePlacePrediction')
 
 interface PlaceData {
   placeId: string
@@ -52,9 +54,11 @@ async function getPlaceDataFromAddress({ address, placeId }: Args): Promise<Plac
   let data: GooglePlacesDetailsResponse | undefined
   let response: Response
   if (placeId) {
+    logger.info('fetching by placeId', placeId)
     response = await fetchDataByPlaceId(placeId)
     data = (await response.json()) as GooglePlacesDetailsResponse
   } else if (address) {
+    logger.info('fetching by address', address)
     response = await fetchDataByAddress(address)
     data = ((await response.json()) as GooglePlacesTextSearchResponse).places?.[0]
   } else {

--- a/src/utils/server/getAddressFromGooglePlacePrediction.ts
+++ b/src/utils/server/getAddressFromGooglePlacePrediction.ts
@@ -69,7 +69,7 @@ async function getPlaceDataFromAddress({ address, placeId }: Args): Promise<Plac
         extra: { address },
       },
     )
-    throw new Error(`Failed to search for place: ${response.status}`)
+    throw new Error(`Failed to search for place: ${response.status} ${errorText}`)
   }
 
   if (_isEmpty(data) || !data) {


### PR DESCRIPTION
## What changed? Why?

This script will backfill addresses that are missing the `electoralZone` and `administrativeAreaLevel1` fields

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
