### PR TITLE
fix: use Promise.allSettled to update backfilled addresses

### DIFF
--- a/src/inngest/functions/backfillAddressFieldsWithGooglePlaces/config.ts
+++ b/src/inngest/functions/backfillAddressFieldsWithGooglePlaces/config.ts
@@ -1,7 +1,7 @@
 export const BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_BATCH_SIZE = 5000
 export const BATCH_BUFFER = 1.05
 export const BACKFILL_ADDRESS_FIELDS_WITH_GOOGLE_PLACES_RETRY_LIMIT = 5
-export const DEFAULT_MINI_BATCH_SIZE = 2500
+export const DEFAULT_MINI_BATCH_SIZE = 600
 /**
  * This is the maximum number of concurrent "Processor" jobs that can be running at once.
  * This is to prevent the script from overwhelming the database and hitting connection pool limits.


### PR DESCRIPTION
closes <!-- GITHUB issue: Adding the github issue number here (e.g.: #123) will auto-close the issue when this PR is merged -->

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

- [ ] AI Generated

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
