### PR TITLE
feat: add Terms of Service links to footer for AU, CA, and GB

### DIFF
--- a/src/app/au/config.tsx
+++ b/src/app/au/config.tsx
@@ -49,6 +49,7 @@ export const footerConfig: FooterProps = {
     </div>
   ),
   links: [
+    { href: urls.termsOfService(), text: 'Terms of service' },
     {
       href: urls.privacyPolicy(),
       text: 'Privacy',

--- a/src/app/ca/config.tsx
+++ b/src/app/ca/config.tsx
@@ -67,6 +67,7 @@ export const footerConfig: FooterProps = {
     </div>
   ),
   links: [
+    { href: urls.termsOfService(), text: 'Terms of service' },
     {
       href: urls.privacyPolicy(),
       text: 'Privacy',

--- a/src/app/gb/config.tsx
+++ b/src/app/gb/config.tsx
@@ -73,6 +73,7 @@ export const footerConfig: FooterProps = {
     </div>
   ),
   links: [
+    { href: urls.termsOfService(), text: 'Terms of service' },
     {
       href: urls.privacyPolicy(),
       text: 'Privacy',


### PR DESCRIPTION
## Summary
Added Terms of Service links to the footer configuration for Australia, Canada, and Great Britain country-specific pages.

## Changes
- Added `{ href: urls.termsOfService(), text: 'Terms of service' }` to the footer links in:
  - `src/app/au/config.tsx`
  - `src/app/ca/config.tsx`
  - `src/app/gb/config.tsx`

## Testing
- [ ] Verify Terms of Service links appear in footer for AU pages
- [ ] Verify Terms of Service links appear in footer for CA pages  
- [ ] Verify Terms of Service links appear in footer for GB pages
- [ ] Ensure links navigate to correct Terms of Service page