### PR TITLE
feat: load bills from builder.io + merge logic

### DIFF
--- a/src/app/[countryCode]/bills/page.tsx
+++ b/src/app/[countryCode]/bills/page.tsx
@@ -1,9 +1,10 @@
 import { Metadata } from 'next'
 
 import { PageBills } from '@/components/app/pageBills'
-import { queryDTSIAllBills } from '@/data/dtsi/queries/queryDTSIAllBills'
+import { getAllBills } from '@/data/bills/getAllBills'
 import { PageProps } from '@/types'
 import { generateMetadataDetails } from '@/utils/server/metadataUtils'
+import { DEFAULT_SUPPORTED_COUNTRY_CODE } from '@/utils/shared/supportedCountries'
 
 export const revalidate = 60 // 1 minute
 export const dynamic = 'error'
@@ -19,7 +20,7 @@ export const metadata: Metadata = {
 }
 
 export default async function BillsPage(props: PageProps) {
-  const results = await queryDTSIAllBills()
+  const results = await getAllBills(DEFAULT_SUPPORTED_COUNTRY_CODE)
 
   return (
     <PageBills

--- a/src/components/app/dtsiBillCard/index.tsx
+++ b/src/components/app/dtsiBillCard/index.tsx
@@ -6,12 +6,13 @@ import { LinkBox, linkBoxLinkClassName } from '@/components/ui/linkBox'
 import { DTSI_BillCardFragment } from '@/data/dtsi/generated'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { getIntlUrls } from '@/utils/shared/urls'
+import { SWCBill } from '@/utils/shared/zod/getSWCBills'
 import { cn } from '@/utils/web/cn'
 
 export type DTSIBill = DTSI_BillCardFragment
 
 interface DTSIBillCardProps {
-  bill: DTSIBill
+  bill: SWCBill
   description?: string
   countryCode: SupportedCountryCodes
   children?: ReactElement<typeof CryptoSupportHighlight>
@@ -33,9 +34,9 @@ export function DTSIBillCard(props: DTSIBillCardProps) {
         <InternalLink
           className={cn(linkBoxLinkClassName, 'line-clamp-3 text-lg font-semibold')}
           data-link-box-subject
-          href={getIntlUrls(countryCode).billDetails(bill.id)}
+          href={getIntlUrls(countryCode).billDetails(bill.dtsiSlug!)}
         >
-          {bill.shortTitle || bill.title}
+          {bill.title}
         </InternalLink>
         <p className="mt-2 text-fontcolor-muted">{description}</p>
       </div>

--- a/src/components/app/pageBills/index.tsx
+++ b/src/components/app/pageBills/index.tsx
@@ -1,15 +1,16 @@
 import { partition, sortBy } from 'lodash-es'
 
 import { CryptoSupportHighlight } from '@/components/app/cryptoSupportHighlight'
-import { DTSIBill, DTSIBillCard } from '@/components/app/dtsiBillCard'
+import { DTSIBillCard } from '@/components/app/dtsiBillCard'
 import { PageSubTitle } from '@/components/ui/pageSubTitle'
 import { PageTitle } from '@/components/ui/pageTitleText'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { SWCBill } from '@/utils/shared/zod/getSWCBills'
 
 interface PageBillsProps {
   title: string
   description: string
-  bills: DTSIBill[]
+  bills: SWCBill[]
   countryCode: SupportedCountryCodes
 }
 
@@ -18,8 +19,8 @@ const KEY_BILLS = ['HR3633', 'S1582', 'hr4763', 'hjres109', 'SJRES3', 'HJRES25',
 export function PageBills(props: PageBillsProps) {
   const { title, description, bills, countryCode } = props
 
-  const [keyBills, otherBills] = partition(bills, bill => KEY_BILLS.includes(bill.slug))
-  const sortedKeyBills = sortBy(keyBills, bill => KEY_BILLS.indexOf(bill.slug))
+  const [keyBills, otherBills] = partition(bills, bill => KEY_BILLS.includes(bill.dtsiSlug!))
+  const sortedKeyBills = sortBy(keyBills, bill => KEY_BILLS.indexOf(bill.dtsiSlug!))
 
   return (
     <div className="standard-spacing-from-navbar container space-y-16">
@@ -38,7 +39,7 @@ export function PageBills(props: PageBillsProps) {
           </PageTitle>
           <div className="flex flex-col gap-4 lg:gap-8">
             {results.map(bill => (
-              <DTSIBillCard bill={bill} countryCode={countryCode} key={bill.id}>
+              <DTSIBillCard bill={bill} countryCode={countryCode} key={bill.dtsiSlug}>
                 <CryptoSupportHighlight
                   className="flex-shrink-0 rounded-full text-base"
                   stanceScore={bill.computedStanceScore}

--- a/src/data/bills/getAllBills.ts
+++ b/src/data/bills/getAllBills.ts
@@ -1,0 +1,22 @@
+import 'server-only'
+
+import { DTSI_BillDetails, mergeBillsFromBuilderIOAndDTSI } from '@/data/bills/utils/merge'
+import { queryDTSIAllBills } from '@/data/dtsi/queries/queryDTSIAllBills'
+import { getBillsFromBuilderIO } from '@/utils/server/builder/models/data/bills'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+
+export async function getAllBills(countryCode: SupportedCountryCodes) {
+  const [billsFromBuilderIO, billsFromDTSI] = await Promise.allSettled([
+    getBillsFromBuilderIO({ countryCode }),
+    queryDTSIAllBills(),
+  ])
+
+  const mergedBills = mergeBillsFromBuilderIOAndDTSI(
+    billsFromBuilderIO.status === 'fulfilled' ? billsFromBuilderIO.value : [],
+    billsFromDTSI.status === 'fulfilled'
+      ? (billsFromDTSI.value as unknown as DTSI_BillDetails[])
+      : null,
+  )
+
+  return mergedBills
+}

--- a/src/data/bills/getBill.ts
+++ b/src/data/bills/getBill.ts
@@ -1,0 +1,23 @@
+import 'server-only'
+
+import { DTSI_BillDetails, mergeBillFromBuilderIOAndDTSI } from '@/data/bills/utils/merge'
+import { queryDTSIBillDetails } from '@/data/dtsi/queries/queryDTSIBillDetails'
+import { getBillFromBuilderIO } from '@/utils/server/builder/models/data/bills'
+import { SWCBill } from '@/utils/shared/zod/getSWCBills'
+
+export async function getBill(billNumber: string): Promise<SWCBill | null> {
+  const billFromBuilderIO = await getBillFromBuilderIO(billNumber)
+
+  if (!billFromBuilderIO) {
+    return null
+  }
+
+  let billFromDTSI: DTSI_BillDetails | null | undefined = null
+  if (billFromBuilderIO.dtsiSlug) {
+    billFromDTSI = (await queryDTSIBillDetails(billFromBuilderIO.dtsiSlug)) as DTSI_BillDetails
+  }
+
+  const mergedBill = mergeBillFromBuilderIOAndDTSI(billFromBuilderIO, billFromDTSI)
+
+  return mergedBill
+}

--- a/src/data/bills/utils/merge.ts
+++ b/src/data/bills/utils/merge.ts
@@ -1,0 +1,59 @@
+import { DTSI_Bill } from '@/data/dtsi/generated'
+import { SWCBill } from '@/utils/shared/zod/getSWCBills'
+
+export type DTSI_BillDetails = Pick<
+  DTSI_Bill,
+  | 'computedStanceScore'
+  | 'congressDotGovUrl'
+  | 'dateIntroduced'
+  | 'shortTitle'
+  | 'slug'
+  | 'status'
+  | 'summary'
+  | 'title'
+> & { analysis: { richTextCommentary: string }[] }
+
+export function mergeBillFromBuilderIOAndDTSI(
+  billFromBuilderIO: SWCBill,
+  billFromDTSI: DTSI_BillDetails | null | undefined,
+): SWCBill {
+  if (!billFromDTSI) {
+    return billFromBuilderIO
+  }
+
+  return {
+    ...billFromBuilderIO,
+    analysis:
+      billFromBuilderIO.analysis ||
+      billFromDTSI.analysis?.reduce(
+        (analysis, { richTextCommentary }) => analysis + richTextCommentary,
+        '',
+      ) ||
+      '',
+    computedStanceScore: billFromDTSI.computedStanceScore,
+    dateIntroduced: billFromBuilderIO.dateIntroduced || billFromDTSI.dateIntroduced,
+    dtsiSlug: billFromBuilderIO.dtsiSlug || billFromDTSI.slug,
+    officialBillUrl: billFromBuilderIO.officialBillUrl || billFromDTSI.congressDotGovUrl,
+    summary: billFromBuilderIO.summary || billFromDTSI.summary,
+    title: billFromBuilderIO.title || billFromDTSI.shortTitle || billFromDTSI.title,
+  }
+}
+
+export function mergeBillsFromBuilderIOAndDTSI(
+  billsFromBuilderIO: SWCBill[],
+  billsFromDTSI: DTSI_BillDetails[] | null | undefined,
+): SWCBill[] {
+  if (!billsFromDTSI || billsFromDTSI.length === 0) {
+    return billsFromBuilderIO
+  }
+
+  const mergedBills: SWCBill[] = []
+
+  for (const billFromBuilderIO of billsFromBuilderIO) {
+    const billFromDTSI = billsFromDTSI.find(bill => bill.slug === billFromBuilderIO.dtsiSlug)
+
+    mergedBills.push(mergeBillFromBuilderIOAndDTSI(billFromBuilderIO, billFromDTSI))
+  }
+
+  return mergedBills
+}

--- a/src/data/dtsi/queries/queryDTSIBillDetails/dtsiBillDetailsQueryString.ts
+++ b/src/data/dtsi/queries/queryDTSIBillDetails/dtsiBillDetailsQueryString.ts
@@ -51,7 +51,6 @@ export const dtsiBillDetailsQueryString = /* GraphQL */ `
       congressDotGovUrl
       dateIntroduced
       datetimeCreated
-
       analysis {
         ...BillAnalysis
       }

--- a/src/utils/server/builder/models/data/bills.ts
+++ b/src/utils/server/builder/models/data/bills.ts
@@ -1,0 +1,155 @@
+import * as Sentry from '@sentry/nextjs'
+import pRetry from 'p-retry'
+
+import { builderSDKClient } from '@/utils/server/builder'
+import { BuilderDataModelIdentifiers } from '@/utils/server/builder/models/data/constants'
+import { getLogger } from '@/utils/shared/logger'
+import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import {
+  BILL_CHAMBER_ORIGIN_OPTIONS,
+  BILL_KEY_DATE_CATEGORY_OPTIONS,
+  SWCBill,
+  SWCBillFromBuilderIO,
+  SWCBillsFromBuilderIO,
+  zodBillSchemaValidation,
+} from '@/utils/shared/zod/getSWCBills'
+
+const logger = getLogger(`builderIOEvents`)
+
+const isProduction = NEXT_PUBLIC_ENVIRONMENT === 'production'
+
+export async function getBillFromBuilderIO(dtsiSlug: string): Promise<SWCBill | null> {
+  try {
+    const entry = await pRetry(
+      () =>
+        builderSDKClient.get(BuilderDataModelIdentifiers.BILLS, {
+          query: {
+            data: {
+              dtsiSlug,
+            },
+            ...(isProduction && { published: 'published' }),
+          },
+          includeUnpublished: !isProduction,
+          cacheSeconds: 60,
+        }),
+      {
+        retries: 3,
+        minTimeout: 5000,
+      },
+    )
+
+    const parsedEntry = zodBillSchemaValidation.safeParse(entry)
+
+    if (!parsedEntry.success) {
+      return null
+    }
+
+    return parseBillEntryFromBuilderIO(parsedEntry.data.data)
+  } catch (error) {
+    logger.error('error getting single bill:' + error)
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { domain: 'getBill' },
+    })
+    return null
+  }
+}
+
+const LIMIT = 100
+
+async function getAllBillsWithOffset({
+  offset,
+  countryCode,
+}: {
+  offset: number
+  countryCode: SupportedCountryCodes
+}): Promise<SWCBillsFromBuilderIO> {
+  return (await pRetry(
+    () =>
+      builderSDKClient.getAll(BuilderDataModelIdentifiers.BILLS, {
+        query: {
+          ...(isProduction && { published: 'published' }),
+          data: {
+            countryCode: countryCode.toUpperCase(),
+          },
+        },
+        includeUnpublished: !isProduction,
+        cacheSeconds: 60,
+        limit: LIMIT,
+        offset,
+      }),
+    {
+      retries: 3,
+      minTimeout: 10000,
+    },
+  )) as SWCBillsFromBuilderIO
+}
+
+export async function getBillsFromBuilderIO({
+  countryCode,
+}: {
+  countryCode: SupportedCountryCodes
+}): Promise<SWCBill[]> {
+  try {
+    let offset = 0
+
+    const entries = await getAllBillsWithOffset({ offset, countryCode })
+
+    while (entries.length === LIMIT + offset) {
+      offset += entries.length
+      entries.push(...(await getAllBillsWithOffset({ offset, countryCode })))
+    }
+
+    const filteredIncompleteBills = entries
+      .map(entry => {
+        const validEntry = zodBillSchemaValidation.safeParse(entry)
+        console.log({ validEntry })
+        return validEntry.success ? validEntry.data : null
+      })
+      .filter(Boolean) as SWCBillsFromBuilderIO
+
+    if (filteredIncompleteBills.length === 0) {
+      return []
+    }
+
+    return filteredIncompleteBills.map(bill => parseBillEntryFromBuilderIO(bill.data))
+  } catch (error) {
+    logger.error('error getting all bills:' + error)
+    Sentry.captureException(error, {
+      level: 'error',
+      tags: { domain: 'builder.io', model: 'bills' },
+    })
+    return []
+  }
+}
+
+function parseBillEntryFromBuilderIO(bill: SWCBillFromBuilderIO): SWCBill {
+  return {
+    ...bill,
+    administrativeAreaLevel1:
+      bill.auAdministrativeAreaLevel1 ||
+      bill.caAdministrativeAreaLevel1 ||
+      bill.gbAdministrativeAreaLevel1 ||
+      bill.usAdministrativeAreaLevel1,
+    isKeyBill: bill.isKeyBill ?? false,
+    keyDates: [
+      {
+        category:
+          bill.chamberOrigin === BILL_CHAMBER_ORIGIN_OPTIONS.LOWER_CHAMBER
+            ? BILL_KEY_DATE_CATEGORY_OPTIONS.BILL_INTRODUCED_LOWER_CHAMBER
+            : BILL_KEY_DATE_CATEGORY_OPTIONS.BILL_INTRODUCED_UPPER_CHAMBER,
+        date: bill.dateIntroduced,
+        description:
+          'The bill was introduced to the assembly, setting the stage for further discussion and consideration.',
+        isMajorMilestone: true,
+        title: 'Bill Introduced',
+      },
+      ...(bill.keyDates || []).map(keyDate => ({
+        ...keyDate,
+        isMajorMilestone: keyDate.isMajorMilestone ?? false,
+      })),
+    ],
+    relatedUrls: bill.relatedUrls || [],
+  }
+}

--- a/src/utils/server/builder/models/data/constants.ts
+++ b/src/utils/server/builder/models/data/constants.ts
@@ -1,8 +1,9 @@
 export enum BuilderDataModelIdentifiers {
+  BILLS = 'bills',
   EVENTS = 'events',
-  QUESTIONNAIRE = 'questionnaire-2',
+  FOUNDERS = 'founders',
+  NEWS = 'news',
   PARTNERS = 'partners',
   POLLS = 'polls',
-  NEWS = 'news',
-  FOUNDERS = 'founders',
+  QUESTIONNAIRE = 'questionnaire-2',
 }

--- a/src/utils/shared/zod/getSWCBills.ts
+++ b/src/utils/shared/zod/getSWCBills.ts
@@ -1,0 +1,70 @@
+import { array, boolean, nativeEnum, object, string, z } from 'zod'
+
+import { DTSIBill } from '@/components/app/dtsiBillCard'
+
+export enum BILL_CHAMBER_ORIGIN_OPTIONS {
+  LOWER_CHAMBER = 'Lower Chamber',
+  UPPER_CHAMBER = 'Upper Chamber',
+}
+
+export enum BILL_KEY_DATE_CATEGORY_OPTIONS {
+  BILL_INTRODUCED_LOWER_CHAMBER = 'BILL_INTRODUCED_LOWER_CHAMBER',
+  BILL_PASSED_LOWER_CHAMBER_COMMITTEE = 'BILL_PASSED_LOWER_CHAMBER_COMMITTEE',
+  BILL_FAILED_LOWER_CHAMBER_COMMITTEE = 'BILL_FAILED_LOWER_CHAMBER_COMMITTEE',
+  BILL_PASSED_LOWER_CHAMBER = 'BILL_PASSED_LOWER_CHAMBER',
+  BILL_FAILED_LOWER_CHAMBER = 'BILL_FAILED_LOWER_CHAMBER',
+  BILL_INTRODUCED_UPPER_CHAMBER = 'BILL_INTRODUCED_UPPER_CHAMBER',
+  BILL_PASSED_UPPER_CHAMBER_COMMITTEE = 'BILL_PASSED_UPPER_CHAMBER_COMMITTEE',
+  BILL_FAILED_UPPER_CHAMBER_COMMITTEE = 'BILL_FAILED_UPPER_CHAMBER_COMMITTEE',
+  BILL_PASSED_UPPER_CHAMBER = 'BILL_PASSED_UPPER_CHAMBER',
+  BILL_FAILED_UPPER_CHAMBER = 'BILL_FAILED_UPPER_CHAMBER',
+  PRESIDENT_SIGNED = 'PRESIDENT_SIGNED',
+  PRESIDENT_VETOED = 'PRESIDENT_VETOED',
+}
+
+export const zodBillSchemaValidation = object({
+  data: object({
+    title: string(),
+    summary: string(),
+    billNumber: string(),
+    dtsiSlug: string().optional(),
+    dateIntroduced: string(),
+    chamberOrigin: nativeEnum(BILL_CHAMBER_ORIGIN_OPTIONS),
+    officialBillUrl: string().url(),
+    analysis: string(),
+    relatedUrls: array(
+      object({
+        title: string(),
+        url: string().url(),
+      }),
+    ),
+    keyDates: array(
+      object({
+        date: string(),
+        title: string(),
+        description: string(),
+        isMajorMilestone: boolean().optional(),
+        category: nativeEnum(BILL_KEY_DATE_CATEGORY_OPTIONS),
+      }),
+    ).optional(),
+    ctaButton: object({
+      label: string(),
+      url: string().url(),
+    }),
+    isKeyBill: boolean(),
+    countryCode: string().length(2),
+    auAdministrativeAreaLevel1: string().min(2).max(3).optional(),
+    caAdministrativeAreaLevel1: string().min(2).max(3).optional(),
+    gbAdministrativeAreaLevel1: string().min(2).max(3).optional(),
+    usAdministrativeAreaLevel1: string().min(2).max(3).optional(),
+  }),
+})
+
+export type SWCBillsFromBuilderIO = z.infer<typeof zodBillSchemaValidation>[]
+
+export type SWCBillFromBuilderIO = SWCBillsFromBuilderIO[number]['data']
+
+export type SWCBill = Omit<SWCBillsFromBuilderIO[number]['data'], 'keyDates'> & {
+  administrativeAreaLevel1?: string
+  keyDates: Required<SWCBillsFromBuilderIO[number]['data']['keyDates']>
+} & Partial<Pick<DTSIBill, 'computedStanceScore'>>


### PR DESCRIPTION
closes #2502 

## What changed? Why?

- Zod Schema Creation:
  - Created a new Zod Schema to represent and validate bill entries from Builder.io.
- Developed two new functions:
  - to load all bills: Function to load all bills from Builder.io.
  - to load a single bill: Function to load a specific bill from Builder.io.
- Data Merging Function:
  - Implemented a function to merge data from Builder.io, with a fallback to DTSI if necessary.
- Resilience Assurance:
  - Ensured that the merging function operates correctly even if DTSI is down, establishing Builder.io as the only dependency and source of truth.