### PR TITLE
fix: add overflow handling to notable statements section in politician details page

### DIFF
--- a/src/components/app/dtsiStanceDetails/dtsiStanceDetailsTweet.tsx
+++ b/src/components/app/dtsiStanceDetails/dtsiStanceDetailsTweet.tsx
@@ -235,7 +235,10 @@ export const DTSIStanceDetailsTweet: React.FC<
         <NextImage alt="x.com logo" height={24} src={'/misc/xDotComLogo.svg'} width={24} />
       </div>
 
-      <div className={cn('mb-3 whitespace-pre-line ', bodyClassName)} style={{ lineHeight: 1.2 }}>
+      <div
+        className={cn('mb-3 whitespace-pre-line break-words', bodyClassName)}
+        style={{ lineHeight: 1.2 }}
+      >
         <TweetBody tweet={stance.tweet} />
       </div>
       {!hideImages && stance.tweet.tweetMedia.length ? (

--- a/src/components/app/pagePoliticianDetails/common/politiciansDetails.tsx
+++ b/src/components/app/pagePoliticianDetails/common/politiciansDetails.tsx
@@ -162,7 +162,7 @@ function PoliticianStances({
       <PageTitle as="h2" className="mb-4 text-center text-lg md:text-xl lg:text-2xl" size="md">
         Notable statements
       </PageTitle>
-      <div className="space-y-14 md:space-y-16">
+      <div className="space-y-14 overflow-hidden md:space-y-16">
         {!stances.length && (
           <div className="flex items-center justify-center">No recent statements.</div>
         )}

--- a/src/components/app/pagePoliticianDetails/common/politiciansDetails.tsx
+++ b/src/components/app/pagePoliticianDetails/common/politiciansDetails.tsx
@@ -162,7 +162,7 @@ function PoliticianStances({
       <PageTitle as="h2" className="mb-4 text-center text-lg md:text-xl lg:text-2xl" size="md">
         Notable statements
       </PageTitle>
-      <div className="space-y-14 overflow-hidden md:space-y-16">
+      <div className="space-y-14 md:space-y-16">
         {!stances.length && (
           <div className="flex items-center justify-center">No recent statements.</div>
         )}


### PR DESCRIPTION
## What changed? Why?

Added an overflow control class to do not overflow elements in mobile screens.

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
