### PR TITLE
Add AU privacy collection statement page & update signup copy

### DIFF
--- a/src/app/(builder)/[countryCode]/privacy-collection-statement/page.tsx
+++ b/src/app/(builder)/[countryCode]/privacy-collection-statement/page.tsx
@@ -10,7 +10,7 @@ export const dynamic = 'error'
 export const revalidate = 86400 // 1 day
 
 const PAGE_MODEL = BuilderPageModelIdentifiers.PAGE
-const PATHNAME = '/privacy-collection'
+const PATHNAME = '/privacy-collection-statement'
 
 export default async function PrivacyCollectionPage(props: PageProps) {
   const { countryCode } = await props.params

--- a/src/app/(builder)/[countryCode]/privacy-collection-statement/page.tsx
+++ b/src/app/(builder)/[countryCode]/privacy-collection-statement/page.tsx
@@ -1,0 +1,36 @@
+import { Metadata } from 'next'
+
+import { BuilderPageLayout, RenderBuilderContent } from '@/components/app/builder'
+import { PageProps } from '@/types'
+import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/constants'
+import { getPageContent, getPageDetails } from '@/utils/server/builder/models/page/utils'
+import { generateMetadataDetails } from '@/utils/server/metadataUtils'
+
+export const dynamic = 'error'
+export const revalidate = 86400 // 1 day
+
+const PAGE_MODEL = BuilderPageModelIdentifiers.PAGE
+const PATHNAME = '/privacy-collection'
+
+export default async function PrivacyCollectionPage(props: PageProps) {
+  const { countryCode } = await props.params
+
+  const content = await getPageContent(PAGE_MODEL, PATHNAME, countryCode)
+
+  return (
+    <BuilderPageLayout countryCode={countryCode} modelName={PAGE_MODEL} pathname={PATHNAME}>
+      <RenderBuilderContent content={content} model={PAGE_MODEL} />
+    </BuilderPageLayout>
+  )
+}
+
+export async function generateMetadata(props: PageProps): Promise<Metadata> {
+  const { countryCode } = await props.params
+
+  const metadata = await getPageDetails(PAGE_MODEL, PATHNAME, countryCode)
+
+  return generateMetadataDetails({
+    title: metadata.title,
+    description: metadata.description,
+  })
+}

--- a/src/app/au/config.tsx
+++ b/src/app/au/config.tsx
@@ -54,6 +54,10 @@ export const footerConfig: FooterProps = {
       href: urls.privacyPolicy(),
       text: 'Privacy',
     },
+    {
+      href: urls.privacyCollectionStatement(),
+      text: 'Privacy Collection Statement',
+    },
   ],
   socialLinks: [
     {

--- a/src/components/app/authentication/au/footerContent.tsx
+++ b/src/components/app/authentication/au/footerContent.tsx
@@ -1,0 +1,15 @@
+import { FooterContent } from '@/components/app/authentication/common/footerContent'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+
+const countryCode = SupportedCountryCodes.AU
+
+export function AUFooterContent() {
+  return (
+    <FooterContent>
+      By signing up, you consent to and understand that Stand With Crypto and its vendors may
+      collect and use your Personal Information. To learn more, visit our{' '}
+      <FooterContent.PrivacyCollectionStatementLink countryCode={countryCode} /> and the{' '}
+      <FooterContent.PrivacyPolicyLink countryCode={countryCode} />.
+    </FooterContent>
+  )
+}

--- a/src/components/app/authentication/ca/footerContent.tsx
+++ b/src/components/app/authentication/ca/footerContent.tsx
@@ -1,0 +1,14 @@
+import { FooterContent } from '@/components/app/authentication/common/footerContent'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+
+const countryCode = SupportedCountryCodes.CA
+
+export function CAFooterContent() {
+  return (
+    <FooterContent>
+      By signing up, you consent to and understand that Stand With Crypto and its vendors may
+      collect and use your Personal Information. To learn more, visit the{' '}
+      <FooterContent.PrivacyPolicyLink countryCode={countryCode} />.
+    </FooterContent>
+  )
+}

--- a/src/components/app/authentication/common/footerContent.tsx
+++ b/src/components/app/authentication/common/footerContent.tsx
@@ -1,0 +1,37 @@
+import { InternalLink } from '@/components/ui/link'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { getIntlUrls } from '@/utils/shared/urls'
+
+export function FooterContent({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-xs text-muted-foreground">
+      <span className="text-[10px]">{children}</span>
+    </p>
+  )
+}
+
+FooterContent.PrivacyPolicyLink = function PrivacyPolicyLink({
+  countryCode,
+}: {
+  countryCode: SupportedCountryCodes
+}) {
+  const urls = getIntlUrls(countryCode)
+  return (
+    <InternalLink href={urls.privacyPolicy()} target="_blank">
+      Stand With Crypto Privacy Policy
+    </InternalLink>
+  )
+}
+
+FooterContent.PrivacyCollectionStatementLink = function PrivacyCollectionStatementLink({
+  countryCode,
+}: {
+  countryCode: SupportedCountryCodes
+}) {
+  const urls = getIntlUrls(countryCode)
+  return (
+    <InternalLink href={urls.privacyCollectionStatement()} target="_blank">
+      Privacy Collection Statement
+    </InternalLink>
+  )
+}

--- a/src/components/app/authentication/constants.tsx
+++ b/src/components/app/authentication/constants.tsx
@@ -1,3 +1,7 @@
+import { AUFooterContent } from '@/components/app/authentication/au/footerContent'
+import { CAFooterContent } from '@/components/app/authentication/ca/footerContent'
+import { GBFooterContent } from '@/components/app/authentication/gb/footerContent'
+import { USFooterContent } from '@/components/app/authentication/us/footerContent'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 export const ANALYTICS_NAME_LOGIN = 'Login'
@@ -10,7 +14,7 @@ export const COUNTRY_SPECIFIC_LOGIN_CONTENT: Record<
   {
     title: string
     subtitle: string
-    footerContent: string
+    footerContent: React.ComponentType
     iconSrc: string
   }
 > = {
@@ -18,29 +22,25 @@ export const COUNTRY_SPECIFIC_LOGIN_CONTENT: Record<
     title: DEFAULT_TITLE,
     subtitle:
       'Lawmakers and regulators are threatening the crypto industry. You can fight back and ask for sensible rules. Join the Stand With Crypto movement to make your voice heard in Washington D.C.',
-    footerContent:
-      'By signing up with your phone number, you consent to receive recurring texts from Stand With Crypto. You can reply STOP to stop receiving texts. Message and data rates may apply. You understand that Stand With Crypto and its vendors may collect and use your Personal Information.',
+    footerContent: USFooterContent,
     iconSrc: '/logo/shield.svg',
   },
   [SupportedCountryCodes.GB]: {
     title: DEFAULT_TITLE,
     subtitle: 'Join the Stand With Crypto movement to make your voice heard in the UK',
-    footerContent:
-      'By signing up, you consent to and understand that Stand With Crypto and its vendors may collect and use your Personal Information.',
+    footerContent: GBFooterContent,
     iconSrc: '/gb/logo/shield.svg',
   },
   [SupportedCountryCodes.CA]: {
     title: DEFAULT_TITLE,
     subtitle: 'Join the Stand With Crypto movement to make your voice heard in Canada',
-    footerContent:
-      'By signing up, you consent to and understand that Stand With Crypto and its vendors may collect and use your Personal Information.',
+    footerContent: CAFooterContent,
     iconSrc: '/ca/logo/shield.svg',
   },
   [SupportedCountryCodes.AU]: {
     title: DEFAULT_TITLE,
     subtitle: 'Join the Stand With Crypto movement to make your voice heard in Australia',
-    footerContent:
-      'By signing up, you consent to and understand that Stand With Crypto and its vendors may collect and use your Personal Information.',
+    footerContent: AUFooterContent,
     iconSrc: '/au/logo/shield.svg',
   },
 }

--- a/src/components/app/authentication/gb/footerContent.tsx
+++ b/src/components/app/authentication/gb/footerContent.tsx
@@ -1,0 +1,14 @@
+import { FooterContent } from '@/components/app/authentication/common/footerContent'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+
+const countryCode = SupportedCountryCodes.GB
+
+export function GBFooterContent() {
+  return (
+    <FooterContent>
+      By signing up, you consent to and understand that Stand With Crypto and its vendors may
+      collect and use your Personal Information. To learn more, visit the{' '}
+      <FooterContent.PrivacyPolicyLink countryCode={countryCode} />.
+    </FooterContent>
+  )
+}

--- a/src/components/app/authentication/thirdwebLoginContent.tsx
+++ b/src/components/app/authentication/thirdwebLoginContent.tsx
@@ -15,13 +15,11 @@ import {
 } from '@/components/app/authentication/constants'
 import { DialogBody, DialogFooterCTA } from '@/components/ui/dialog'
 import { NextImage } from '@/components/ui/image'
-import { InternalLink } from '@/components/ui/link'
 import { LoadingOverlay } from '@/components/ui/loadingOverlay'
 import { PageSubTitle } from '@/components/ui/pageSubTitle'
 import { PageTitle } from '@/components/ui/pageTitleText'
 import { useThirdwebAuthUser } from '@/hooks/useAuthUser'
 import { useCountryCode } from '@/hooks/useCountryCode'
-import { useIntlUrls } from '@/hooks/useIntlUrls'
 import { generateThirdwebLoginPayload } from '@/utils/server/thirdweb/getThirdwebLoginPayload'
 import { isLoggedIn } from '@/utils/server/thirdweb/isLoggedIn'
 import { login } from '@/utils/server/thirdweb/onLogin'
@@ -52,13 +50,17 @@ export function ThirdwebLoginContent({
   onLoginCallback,
   ...props
 }: ThirdwebLoginContentProps) {
-  const urls = useIntlUrls()
   const thirdwebEmbeddedAuthContainer = useRef<HTMLDivElement>(null)
   const router = useRouter()
   const swrConfig = useSWRConfig()
   const countryCode = useCountryCode()
 
-  const { title, subtitle, footerContent, iconSrc } = COUNTRY_SPECIFIC_LOGIN_CONTENT[countryCode]
+  const {
+    title,
+    subtitle,
+    footerContent: FooterContent,
+    iconSrc,
+  } = COUNTRY_SPECIFIC_LOGIN_CONTENT[countryCode]
 
   const handleLogin = useCallback(async () => {
     if (onLoginCallback) {
@@ -121,16 +123,8 @@ export function ThirdwebLoginContent({
           </div>
         </div>
 
-        <DialogFooterCTA className="mt-auto px-6 pb-2">
-          <p className="text-center text-xs text-muted-foreground">
-            <span className="text-[10px]">
-              {footerContent} To learn more, visit the{' '}
-              <InternalLink href={urls.privacyPolicy()} target="_blank">
-                Stand With Crypto Privacy Policy
-              </InternalLink>
-              .
-            </span>
-          </p>
+        <DialogFooterCTA className="mt-auto px-6 pb-2 text-center">
+          <FooterContent />
         </DialogFooterCTA>
       </DialogBody>
     </ErrorBoundary>

--- a/src/components/app/authentication/us/footerContent.tsx
+++ b/src/components/app/authentication/us/footerContent.tsx
@@ -1,0 +1,16 @@
+import { FooterContent } from '@/components/app/authentication/common/footerContent'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+
+const countryCode = SupportedCountryCodes.US
+
+export function USFooterContent() {
+  return (
+    <FooterContent>
+      By signing up with your phone number, you consent to receive recurring texts from Stand With
+      Crypto. You can reply STOP to stop receiving texts. Message and data rates may apply. You
+      understand that Stand With Crypto and its vendors may collect and use your Personal
+      Information. To learn more, visit the{' '}
+      <FooterContent.PrivacyPolicyLink countryCode={countryCode} />.
+    </FooterContent>
+  )
+}

--- a/src/utils/shared/urls/index.ts
+++ b/src/utils/shared/urls/index.ts
@@ -111,6 +111,7 @@ export const getIntlUrls = (
     termsOfService: () => `${countryPrefix}/terms-of-service`,
     privacyPolicy: () => `${countryPrefix}/privacy`,
     about: () => `${countryPrefix}/about`,
+    privacyCollectionStatement: () => `${countryPrefix}/privacy-collection-statement`,
     // Uses Next.js rewrite function to render the same page as /about
     manifesto: () => `${countryPrefix}/manifesto`,
     resources: () => `${countryPrefix}/resources`,


### PR DESCRIPTION
closes [#420](https://github.com/Stand-With-Crypto/swc-internal/issues/420)

fixes <!-- SENTRY issue: Adding the sentry issue number here (e.g.: PROD-SWC-WEB-1JE) will auto-close the issue when this PR is merged. Please ensure sentry issues are marked resolved after we ship related bug fixes -->

## What changed? Why?

- Added /privacy-collection-statement page in builder.io
- Updated signup copy for AU

<!--
Here you can add any additional context not already captured in related github/sentry issue.
If there are UX changes please do one or both of the following:
    - include paths/steps to reproduce the UI related changes in your vercel preview branch (if you are a core contributor)
    - attach mobile/web screenshots to the PR
-->

## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

- Contentful entries, currently in draft, to be published once deploy is finished:
  - https://app.contentful.com/spaces/c5bd0wqjc7v0/entries/BiI7XO61Tg2XJSOCKaotk?focusedField=subscriberDisclaimer
  - https://app.contentful.com/spaces/c5bd0wqjc7v0/entries/2sGhp2fAnkmAfBftKoKefm?focusedField=disclaimer

- [ ] AI Generated

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
