### PR TITLE
feat: add getNumberFormat utility for phone number formatting

### DIFF
--- a/src/app/api/verified-swc-partner/user-action-opt-in/getNumberFormat.ts
+++ b/src/app/api/verified-swc-partner/user-action-opt-in/getNumberFormat.ts
@@ -1,0 +1,23 @@
+/**
+ * Extracts the format pattern from a phone number by replacing digits with 'D'
+ * while preserving formatting characters like dashes, spaces, parentheses, etc.
+ *
+ * This is useful for logging and analytics to understand what formats users
+ * are submitting phone numbers in.
+ *
+ * @param phoneNumber - The phone number string to extract format from
+ * @returns The format pattern (e.g., "DD-DDD-DDD-DDDD", "(DDD) DDD-DDDD")
+ *
+ * @example
+ * getNumberFormat("123-456-7890") // returns "DDD-DDD-DDDD"
+ * getNumberFormat("(123) 456-7890") // returns "(DDD) DDD-DDDD"
+ * getNumberFormat("+1 (123) 456-7890") // returns "+D (DDD) DDD-DDDD"
+ * getNumberFormat("1234567890") // returns "DDDDDDDDDD"
+ */
+export function getNumberFormat(phoneNumber: string): string {
+  if (!phoneNumber || typeof phoneNumber !== 'string') {
+    return ''
+  }
+
+  return phoneNumber.replace(/\d/g, 'D')
+}

--- a/src/app/api/verified-swc-partner/user-action-opt-in/route.ts
+++ b/src/app/api/verified-swc-partner/user-action-opt-in/route.ts
@@ -44,9 +44,7 @@ export const POST = withRouteMiddleware(async (request: NextRequest) => {
       extra: {
         partner,
         requestBody,
-        phoneNumberFormat: requestBody.phoneNumber
-          ? getNumberFormat(requestBody.phoneNumber)
-          : null,
+        template: requestBody.phoneNumber ? getNumberFormat(requestBody.phoneNumber) : null,
       },
       level: 'warning',
     })

--- a/src/app/api/verified-swc-partner/user-action-opt-in/route.ts
+++ b/src/app/api/verified-swc-partner/user-action-opt-in/route.ts
@@ -9,11 +9,13 @@ import {
 import { withRouteMiddleware } from '@/utils/server/serverWrappers/withRouteMiddleware'
 import { authenticateAndGetVerifiedSWCPartnerFromHeader } from '@/utils/server/verifiedSWCPartner/getVerifiedSWCPartnerFromHeader'
 
+import { getNumberFormat } from './getNumberFormat'
+
 type RequestBody = z.infer<ReturnType<typeof getZodVerifiedSWCPartnersUserActionOptInSchema>>
 
 export const POST = withRouteMiddleware(async (request: NextRequest) => {
   const partner = await authenticateAndGetVerifiedSWCPartnerFromHeader()
-  const requestBody = await request.json()
+  const requestBody = (await request.json()) as RequestBody
 
   const baseValidationResult = getZodVerifiedSWCPartnersUserActionOptInSchema()
     .omit({ phoneNumber: true })
@@ -33,7 +35,7 @@ export const POST = withRouteMiddleware(async (request: NextRequest) => {
 
   const phoneNumberValidationResult = getZodVerifiedSWCPartnersUserActionOptInSchema(
     countryCode,
-  ).shape.phoneNumber.safeParse((requestBody as RequestBody)?.phoneNumber)
+  ).shape.phoneNumber.safeParse(requestBody.phoneNumber)
 
   let validatedFields: RequestBody = baseValidationResult.data as RequestBody
 
@@ -42,6 +44,9 @@ export const POST = withRouteMiddleware(async (request: NextRequest) => {
       extra: {
         partner,
         requestBody,
+        phoneNumberFormat: requestBody.phoneNumber
+          ? getNumberFormat(requestBody.phoneNumber)
+          : null,
       },
       level: 'warning',
     })


### PR DESCRIPTION
closes #2513 

## What changed? Why?

Added getNumberFormat utility for phone number formatting for investigate better the validations failing.

<img width="1211" height="205" alt="image" src="https://github.com/user-attachments/assets/e7259ca5-38f4-4345-a1e5-64bc65cc8e8f" />

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
