### PR TITLE
feat: enhance action tiles styling

### DIFF
--- a/src/components/app/userActionGridCTAs/components/campaignsCheckmarks.tsx
+++ b/src/components/app/userActionGridCTAs/components/campaignsCheckmarks.tsx
@@ -32,13 +32,15 @@ export function CampaignsCheckmarks({
           completed={isCompleted}
           key={index}
           svgClassname={cn(
-            'border-2 border-muted bg-muted',
+            'h-6 w-6 border-background box-content bg-muted lg:h-8 lg:w-8',
             index % ICONS_PER_ROW !== 0 && '-ml-4',
+            { 'border-none': isCompleted && campaignsLength === 1 },
+            { 'border-2 -mt-1': campaignsLength > 1 },
           )}
         />
       )
     })
-  }, [iconsToDisplay, completedCampaigns, hasMoreThanMaxChecks, hasPendingChecks])
+  }, [iconsToDisplay, completedCampaigns, hasMoreThanMaxChecks, hasPendingChecks, campaignsLength])
 
   return (
     <div className="flex items-end">

--- a/src/components/app/userActionGridCTAs/components/campaignsCheckmarks.tsx
+++ b/src/components/app/userActionGridCTAs/components/campaignsCheckmarks.tsx
@@ -34,7 +34,8 @@ export function CampaignsCheckmarks({
           svgClassname={cn(
             'h-6 w-6 border-background box-content bg-muted lg:h-8 lg:w-8',
             index % ICONS_PER_ROW !== 0 && '-ml-4',
-            { 'border-none': isCompleted && campaignsLength === 1 },
+            //once the border is added and box-sizing: content-box is set, the content expands to out of the box, making the section bigger
+            //the -mt-1 (margin-top: -4px) fixes this, while border-2 adds the border of 2 pixels on top and bottom
             { 'border-2 -mt-1': campaignsLength > 1 },
           )}
         />

--- a/src/components/app/userActionGridCTAs/components/userActionCard.tsx
+++ b/src/components/app/userActionGridCTAs/components/userActionCard.tsx
@@ -37,7 +37,7 @@ export const UserActionCard = forwardRef<
         return completedCampaigns === 1 ? 'Complete' : 'Not complete'
       }
 
-      return `${completedCampaigns}/${campaignsLength} complete`
+      return `${completedCampaigns}/${campaignsLength} Complete`
     }
 
     const isPrepareToVoteAction = campaigns.some(

--- a/src/components/app/userActionGridCTAs/components/userActionCard.tsx
+++ b/src/components/app/userActionGridCTAs/components/userActionCard.tsx
@@ -69,7 +69,7 @@ export const UserActionCard = forwardRef<
             width={80}
           />
         </div>
-        <div className="flex h-auto w-full flex-col items-start justify-between rounded-bl-3xl rounded-tl-3xl lg:h-full lg:rounded-br-3xl lg:rounded-tl-none">
+        <div className="flex h-auto w-full flex-col items-start justify-between rounded-bl-3xl rounded-tl-3xl border-t border-muted lg:h-full lg:rounded-br-3xl lg:rounded-tl-none lg:border-none">
           <div className="flex flex-col gap-1 p-4 lg:gap-4 lg:p-6">
             <strong className="text-left font-sans text-sm font-bold lg:text-2xl lg:leading-none lg:-tracking-[0.24px]">
               {title}

--- a/src/components/app/userActionGridCTAs/components/userActionCard.tsx
+++ b/src/components/app/userActionGridCTAs/components/userActionCard.tsx
@@ -47,7 +47,7 @@ export const UserActionCard = forwardRef<
     return (
       <button
         className={cn(
-          'grid h-full w-full cursor-pointer rounded-3xl transition-shadow hover:shadow-lg max-lg:grid-cols-[1fr_128px] lg:max-w-96 lg:grid-rows-[200px_1fr]',
+          'grid h-full w-full cursor-pointer rounded-3xl shadow-md transition-shadow hover:shadow-xl max-lg:grid-cols-[1fr_128px] lg:max-w-96 lg:grid-rows-[200px_1fr]',
           isReadOnly && 'pointer-events-none cursor-default',
         )}
         ref={ref}
@@ -69,17 +69,20 @@ export const UserActionCard = forwardRef<
             width={80}
           />
         </div>
+        <div className="flex h-auto w-full flex-col items-start justify-between rounded-bl-3xl rounded-tl-3xl lg:h-full lg:rounded-br-3xl lg:rounded-tl-none">
+          <div className="flex flex-col gap-1 p-4 lg:gap-4 lg:p-6">
+            <strong className="text-left font-sans text-sm font-bold lg:text-2xl lg:leading-none lg:-tracking-[0.24px]">
+              {title}
+            </strong>
+            <p className="hidden text-left text-sm text-muted-foreground lg:block lg:text-base">
+              {description}
+            </p>
+            <p className="text-left text-sm text-muted-foreground lg:hidden lg:text-base">
+              {mobileCTADescription ?? description}
+            </p>
+          </div>
 
-        <div className="flex h-auto w-full flex-col items-start justify-between gap-3 rounded-bl-3xl rounded-tl-3xl bg-muted px-4 py-4 lg:h-full lg:rounded-br-3xl lg:rounded-tl-none lg:p-6">
-          <strong className="text-left font-sans text-sm font-bold lg:text-xl">{title}</strong>
-          <p className="hidden text-left text-sm text-muted-foreground lg:block lg:text-base">
-            {description}
-          </p>
-          <p className="text-left text-sm text-muted-foreground lg:hidden lg:text-base">
-            {mobileCTADescription ?? description}
-          </p>
-
-          <div className="mt-auto flex w-full items-center gap-2 pt-5">
+          <div className="mt-auto flex w-full items-center gap-2 border-t-0 p-4 lg:gap-4 lg:border-t-[1px] lg:border-t-muted lg:p-6">
             <CampaignsCheckmarks
               campaignsLength={campaignsLength}
               completedCampaigns={completedCampaigns}

--- a/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
@@ -47,7 +47,7 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     ],
   },
   [UserActionType.EMAIL]: {
-    title: 'Email your Member of Parliament',
+    title: 'Email your member of Parliament',
     description:
       'Tell your MP to support Blockchain as a priority for Australia’s Productivity Agenda',
     campaignsModalDescription:
@@ -58,7 +58,7 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
         actionType: UserActionType.EMAIL,
         campaignName: AUUserActionEmailCampaignName.DEFAULT,
         isCampaignActive: false,
-        title: `Email your Member of Parliament`,
+        title: `Email your member of Parliament`,
         description: 'Tell your MP to support responsible crypto policy — send an email now!',
         canBeTriggeredMultipleTimes: true,
         WrapperComponent: getEmailActionWrapperComponentByCampaignName({
@@ -82,7 +82,7 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
         actionType: UserActionType.EMAIL,
         campaignName: AUUserActionEmailCampaignName.AU_Q2_2025_ELECTION,
         isCampaignActive: false,
-        title: `Email your Member of Parliament`,
+        title: `Email your member of Parliament`,
         description: 'Tell your MP to support responsible crypto policy — send an email now!',
         canBeTriggeredMultipleTimes: true,
         WrapperComponent: getEmailActionWrapperComponentByCampaignName({
@@ -105,7 +105,7 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     ],
   },
   [UserActionType.VIEW_KEY_PAGE]: {
-    title: 'Email your Member of Parliament',
+    title: 'Email your member of Parliament',
     description:
       'Make your voice heard on important crypto policy issues by emailing your representatives',
     campaignsModalDescription:
@@ -116,7 +116,7 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
         actionType: UserActionType.VIEW_KEY_PAGE,
         campaignName: AUUserActionViewKeyPageCampaignName.AU_Q2_2025_ELECTION,
         isCampaignActive: false,
-        title: `Email your Member of Parliament`,
+        title: `Email your member of Parliament`,
         description: 'Tell your MP to support responsible crypto policy — send an email now!',
         canBeTriggeredMultipleTimes: true,
         WrapperComponent: ({ children }) => (
@@ -187,7 +187,7 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     ],
   },
   [UserActionType.REFER]: {
-    title: 'Refer a Friend',
+    title: 'Refer a friend',
     description: 'Get your friend to signup for Stand With Crypto and verify their account.',
     mobileCTADescription:
       'Get your friend to signup for Stand With Crypto and verify their account.',
@@ -198,7 +198,7 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
         actionType: UserActionType.REFER,
         campaignName: AUUserActionReferCampaignName.DEFAULT,
         isCampaignActive: true,
-        title: 'Refer a Friend',
+        title: 'Refer a friend',
         description: 'You have referred friends to join Stand With Crypto.',
         canBeTriggeredMultipleTimes: true,
         WrapperComponent: ({ children }) => (

--- a/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/au/auCtas.tsx
@@ -221,7 +221,11 @@ export const AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     mobileCTADescription: 'Take the poll and see the results.',
     campaignsModalDescription: 'Take the poll and see the results.',
     image: '/actionTypeIcons/voterAttestation.png',
-    link: ({ children }) => <Link href={urls.polls()}>{children}</Link>,
+    link: ({ children }) => (
+      <Link className="w-full" href={urls.polls()}>
+        {children}
+      </Link>
+    ),
     campaigns: [
       {
         actionType: UserActionType.POLL,

--- a/src/components/app/userActionGridCTAs/constants/ca/caCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/ca/caCtas.tsx
@@ -71,7 +71,7 @@ export const CA_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     ],
   },
   [UserActionType.VIEW_KEY_PAGE]: {
-    title: 'Email your Member of Parliament',
+    title: 'Email your member of Parliament',
     description:
       'Make your voice heard on important crypto policy issues by emailing your representatives.',
     campaignsModalDescription:
@@ -85,7 +85,7 @@ export const CA_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
         actionType: UserActionType.VIEW_KEY_PAGE,
         campaignName: CAUserActionViewKeyPageCampaignName.CA_Q2_2025_ELECTION,
         isCampaignActive: false,
-        title: 'Email your Member of Parliament',
+        title: 'Email your member of Parliament',
         description: 'Tell your MP to support responsible crypto policy — send an email now!',
         canBeTriggeredMultipleTimes: true,
         WrapperComponent: null,
@@ -111,7 +111,7 @@ export const CA_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     ],
   },
   [UserActionType.VIEW_KEY_RACES]: {
-    title: 'View Key Races in Canada',
+    title: 'View key races in Canada',
     description:
       'View the key races occurring across Canada that will impact the future of crypto.',
     campaignsModalDescription:
@@ -122,7 +122,7 @@ export const CA_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
         actionType: UserActionType.VIEW_KEY_RACES,
         campaignName: CAUserActionViewKeyRacesCampaignName.H1_2025,
         isCampaignActive: false,
-        title: 'View Key Races in Canada',
+        title: 'View key races in Canada',
         description:
           'Viewed the key races occurring across Canada that would impact the future of crypto in early 2025.',
         canBeTriggeredMultipleTimes: true,
@@ -154,7 +154,7 @@ export const CA_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     ],
   },
   [UserActionType.REFER]: {
-    title: 'Refer a Friend',
+    title: 'Refer a friend',
     description: 'Get your friend to signup for Stand With Crypto and verify their account.',
     mobileCTADescription:
       'Get your friend to signup for Stand With Crypto and verify their account.',
@@ -165,7 +165,7 @@ export const CA_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
         actionType: UserActionType.REFER,
         campaignName: CAUserActionReferCampaignName.DEFAULT,
         isCampaignActive: true,
-        title: 'Refer a Friend',
+        title: 'Refer a friend',
         description: 'You have referred friends to join Stand With Crypto.',
         canBeTriggeredMultipleTimes: true,
         WrapperComponent: ({ children }) => (

--- a/src/components/app/userActionGridCTAs/constants/ca/caCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/ca/caCtas.tsx
@@ -188,7 +188,11 @@ export const CA_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     mobileCTADescription: 'Take the poll and see the results.',
     campaignsModalDescription: 'Take the poll and see the results.',
     image: '/actionTypeIcons/voterAttestation.png',
-    link: ({ children }) => <Link href={urls.polls()}>{children}</Link>,
+    link: ({ children }) => (
+      <Link className="w-full" href={urls.polls()}>
+        {children}
+      </Link>
+    ),
     campaigns: [
       {
         actionType: UserActionType.POLL,

--- a/src/components/app/userActionGridCTAs/constants/gb/gbCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/gb/gbCtas.tsx
@@ -44,7 +44,7 @@ export const GB_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     ],
   },
   [UserActionType.EMAIL]: {
-    title: 'Email your Member of Parliament',
+    title: 'Email your member of Parliament',
     description: 'Make stablecoin leadership a strategic priority',
     mobileCTADescription: 'Make stablecoin leadership a strategic priority',
     campaignsModalDescription: 'Make stablecoin leadership a strategic priority',
@@ -54,7 +54,7 @@ export const GB_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
         actionType: UserActionType.EMAIL,
         campaignName: GBUserActionEmailCampaignName.STABLECOINS,
         isCampaignActive: false,
-        title: 'Email your Member of Parliament',
+        title: 'Email your member of Parliament',
         description: 'Make stablecoin leadership a strategic priority',
         canBeTriggeredMultipleTimes: true,
         WrapperComponent: null,
@@ -103,7 +103,7 @@ export const GB_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     ],
   },
   [UserActionType.REFER]: {
-    title: 'Refer a Friend',
+    title: 'Refer a friend',
     description: 'Get your friend to signup for Stand With Crypto and verify their account.',
     mobileCTADescription:
       'Get your friend to signup for Stand With Crypto and verify their account.',
@@ -114,7 +114,7 @@ export const GB_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
         actionType: UserActionType.REFER,
         campaignName: GBUserActionReferCampaignName.DEFAULT,
         isCampaignActive: true,
-        title: 'Refer a Friend',
+        title: 'Refer a friend',
         description: 'You have referred friends to join Stand With Crypto.',
         canBeTriggeredMultipleTimes: true,
         WrapperComponent: ({ children }) => (

--- a/src/components/app/userActionGridCTAs/constants/gb/gbCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/gb/gbCtas.tsx
@@ -137,7 +137,11 @@ export const GB_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     mobileCTADescription: 'Take the poll and see the results.',
     campaignsModalDescription: 'Take the poll and see the results.',
     image: '/actionTypeIcons/voterAttestation.png',
-    link: ({ children }) => <Link href={urls.polls()}>{children}</Link>,
+    link: ({ children }) => (
+      <Link className="w-full" href={urls.polls()}>
+        {children}
+      </Link>
+    ),
     campaigns: [
       {
         actionType: UserActionType.POLL,

--- a/src/components/app/userActionGridCTAs/constants/us/usCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/us/usCtas.tsx
@@ -387,7 +387,11 @@ export const US_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     mobileCTADescription: 'Take the poll and see the results.',
     campaignsModalDescription: 'Take the poll and see the results.',
     image: '/actionTypeIcons/voterAttestation.png',
-    link: ({ children }) => <Link href={urls.polls()}>{children}</Link>,
+    link: ({ children }) => (
+      <Link className="w-full" href={urls.polls()}>
+        {children}
+      </Link>
+    ),
     campaigns: [
       {
         actionType: UserActionType.POLL,

--- a/src/components/app/userActionGridCTAs/constants/us/usCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/us/usCtas.tsx
@@ -57,8 +57,8 @@ export const US_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     ],
   },
   [UserActionType.EMAIL]: {
-    title: 'Email Your Senator',
-    description: 'Pass Crucial Crypto Legislation',
+    title: 'Email your senator',
+    description: 'Pass crucial crypto legislation',
     campaignsModalDescription:
       'One of the most effective ways of making your voice heard. We’ve drafted emails to make it easy for you.',
     image: '/actionTypeIcons/email.png',
@@ -432,7 +432,7 @@ export const US_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     ],
   },
   [UserActionType.REFER]: {
-    title: 'Refer a Friend',
+    title: 'Refer a friend',
     description: 'Get your friend to signup for Stand With Crypto and verify their account.',
     mobileCTADescription:
       'Get your friend to signup for Stand With Crypto and verify their account.',
@@ -443,7 +443,7 @@ export const US_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
         actionType: UserActionType.REFER,
         campaignName: USUserActionReferCampaignName.DEFAULT,
         isCampaignActive: true,
-        title: 'Refer a Friend',
+        title: 'Refer a friend',
         description: 'You have referred friends to join Stand With Crypto.',
         canBeTriggeredMultipleTimes: true,
         WrapperComponent: ({ children }) => (
@@ -461,7 +461,7 @@ export const US_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
     ],
   },
   [UserActionType.NFT_MINT]: {
-    title: 'Mint your Supporter NFT',
+    title: 'Mint your supporter NFT',
     description: 'All mint proceeds are donated to the movement.',
     mobileCTADescription: 'All mint proceeds are donated to the movement.',
     campaignsModalDescription: 'All mint proceeds are donated to the movement.',
@@ -471,7 +471,7 @@ export const US_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
         actionType: UserActionType.NFT_MINT,
         campaignName: USUserActionNftMintCampaignName.DEFAULT,
         isCampaignActive: true,
-        title: 'Mint your Supporter NFT',
+        title: 'Mint your supporter NFT',
         description: 'All mint proceeds are donated to the movement.',
         canBeTriggeredMultipleTimes: true,
         WrapperComponent: UserActionFormNFTMintDialog,

--- a/src/components/app/userActionGridCTAs/index.tsx
+++ b/src/components/app/userActionGridCTAs/index.tsx
@@ -25,8 +25,8 @@ export function UserActionGridCTAs({ excludeUserActionTypes }: UserActionGridCTA
       className={cn(
         ctas.length < 3
           ? 'flex flex-col lg:flex-row lg:flex-wrap lg:justify-center'
-          : 'grid grid-cols-1 lg:grid-cols-[repeat(auto-fit,minmax(250px,1fr))] lg:justify-items-center',
-        'gap-[18px]',
+          : 'grid grid-cols-1 lg:grid-cols-3 lg:justify-items-center',
+        'gap-6',
       )}
     >
       {ctas.map(cta => {


### PR DESCRIPTION
## What changed? Why?

This PR adds new styles to call-to-action cards on homepage (a.k.a UserActionCard)

Here are some visual evidencies:

<details>
<summary>
Visual reference (design)
</summary>

**Desktop**
<img width="952" height="411" alt="image" src="https://github.com/user-attachments/assets/84bc8f24-9acb-429f-98ed-fefb6a8e41b8" />

**Mobile**
<img width="308" height="318" alt="image" src="https://github.com/user-attachments/assets/4c057cf2-9042-4677-9085-23f816e80bda" />


</details>

Description | Before | After
--- | --- | ---
Desktop card | <img width="278" height="474" alt="image" src="https://github.com/user-attachments/assets/1ed0d9fc-b4a2-485d-894b-3c5f93ba039f" />  | <img width="374" height="452" alt="image" src="https://github.com/user-attachments/assets/4277da01-e666-4920-b459-79d596e60296" />
Mobile card | <img width="401" height="187" alt="image" src="https://github.com/user-attachments/assets/c2079a62-d35d-4235-a47d-3b1770127844" /> | <img width="404" height="177" alt="image" src="https://github.com/user-attachments/assets/14617a2c-dae7-4e37-aee1-93c4e1df188c" />
List (desktop) | <img width="1684" height="1186" alt="image" src="https://github.com/user-attachments/assets/4583206c-6535-4c51-b08c-3f94900d4638" /> | <img width="1685" height="1116" alt="image" src="https://github.com/user-attachments/assets/c13d1f3e-36bc-429a-beae-0107c75f1dd6" />
List (mobile) | <img width="411" height="786" alt="image" src="https://github.com/user-attachments/assets/77bc74b7-15d9-4b79-83d4-73d555c69f73" /> | <img width="413" height="785" alt="image" src="https://github.com/user-attachments/assets/a0f3ddb5-42f4-41be-ba87-0a45f300fe00" />


PS: the typographies are slightly different but this will be fixed in another moment.

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
