### PR TITLE
fix: update UserActionGridCTAsSkeleton layout and styling

### DIFF
--- a/src/components/app/userActionGridCTAs/skeleton.tsx
+++ b/src/components/app/userActionGridCTAs/skeleton.tsx
@@ -20,8 +20,8 @@ export function UserActionGridCTAsSkeleton({
       className={cn(
         ctas.length < 3
           ? 'flex flex-col lg:flex-row lg:flex-wrap lg:justify-center'
-          : 'grid grid-cols-1 lg:grid-cols-[repeat(auto-fit,minmax(250px,1fr))] lg:justify-items-center',
-        'gap-[18px]',
+          : 'grid grid-cols-1 lg:grid-cols-3 lg:justify-items-center',
+        'gap-6',
       )}
     >
       {ctas.map(cta => {


### PR DESCRIPTION

fixes #2559 

## What changed? Why?

**Description**
When the profile page was loading, the grid had 4 columns. With the card/layout update, it's expected to have 3.

**Solution**
Instead of showing 4 cols on the skeleton, it shows 3.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
