### PR TITLE
feat: add recent activity by date range endpoint

### DIFF
--- a/docs/api/swagger-recent-activity-by-date.yaml
+++ b/docs/api/swagger-recent-activity-by-date.yaml
@@ -1,0 +1,188 @@
+openapi: 3.0.3
+info:
+  title: Stand With Crypto - Recent Activity by Date Range API
+  description: Public API endpoint to retrieve recent user activity within a specified date range
+  version: 1.0.0
+  contact:
+    name: Stand With Crypto
+    url: https://standwithcrypto.org
+
+servers:
+  - url: https://standwithcrypto.org
+    description: Production server
+
+paths:
+  /api/public/recent-activity/by-date/{startDate}/{endDate}:
+    get:
+      summary: Get recent activity by date range (default offset)
+      description: |
+        Retrieves public recent activity data within a specified date range with default offset of 0.
+        Returns user actions including emails, calls, donations, NFT mints, and other activities.
+        Data is cached for 60 seconds and limited to US users with visible status.
+      operationId: getRecentActivityByDateRangeDefault
+      parameters:
+        - name: startDate
+          in: path
+          required: true
+          description: Start date in ISO format (YYYY-MM-DD)
+          schema:
+            type: string
+            pattern: '^\d{4}-\d{2}-\d{2}$'
+            example: '2024-01-01'
+        - name: endDate
+          in: path
+          required: true
+          description: End date in ISO format (YYYY-MM-DD)
+          schema:
+            type: string
+            pattern: '^\d{4}-\d{2}-\d{2}$'
+            example: '2024-01-31'
+      responses:
+        '200':
+          $ref: '#/components/responses/RecentActivityResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/public/recent-activity/by-date/{startDate}/{endDate}/{offset}:
+    get:
+      summary: Get recent activity by date range (with offset)
+      description: |
+        Retrieves public recent activity data within a specified date range with custom offset for pagination.
+        Returns user actions including emails, calls, donations, NFT mints, and other activities.
+        Data is cached for 60 seconds and limited to US users with visible status.
+      operationId: getRecentActivityByDateRangeWithOffset
+      parameters:
+        - name: startDate
+          in: path
+          required: true
+          description: Start date in ISO format (YYYY-MM-DD)
+          schema:
+            type: string
+            pattern: '^\d{4}-\d{2}-\d{2}$'
+            example: '2024-01-01'
+        - name: endDate
+          in: path
+          required: true
+          description: End date in ISO format (YYYY-MM-DD)
+          schema:
+            type: string
+            pattern: '^\d{4}-\d{2}-\d{2}$'
+            example: '2024-01-31'
+        - name: offset
+          in: path
+          required: true
+          description: Number of records to skip for pagination (0-1000)
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 1000
+            example: 0
+      responses:
+        '200':
+          $ref: '#/components/responses/RecentActivityResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+components:
+  responses:
+    RecentActivityResponse:
+      description: Successfully retrieved recent activity data
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              count:
+                type: integer
+                description: Total number of activities matching the criteria
+                example: 150
+              data:
+                type: array
+                description: Array of user actions with user information
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: Unique identifier for the user action
+                    actionType:
+                      type: string
+                      description: Type of action performed
+                      enum:
+                        [
+                          EMAIL,
+                          CALL,
+                          DONATION,
+                          NFT_MINT,
+                          TWEET,
+                          POLL,
+                          VOTER_REGISTRATION,
+                          OPT_IN,
+                          RSVP_EVENT,
+                          VIEW_KEY_RACES,
+                          VOTING_INFORMATION_RESEARCHED,
+                          VOTING_DAY,
+                          REFER,
+                          VIEW_KEY_PAGE,
+                        ]
+                    datetimeCreated:
+                      type: string
+                      format: date-time
+                      description: When the action was created
+                    user:
+                      type: object
+                      description: Information about the user who performed the action
+                      properties:
+                        id:
+                          type: string
+                          description: User identifier
+                        firstName:
+                          type: string
+                          description: User's first name
+                        lastName:
+                          type: string
+                          description: User's last name
+                        ensName:
+                          type: string
+                          nullable: true
+                          description: ENS name if available
+                        ensAvatarUrl:
+                          type: string
+                          nullable: true
+                          description: ENS avatar URL if available
+                    # Additional action-specific fields would be included based on action type
+                    # Examples: userActionEmail, nftMint, userActionCall, userActionDonation, etc.
+
+    BadRequest:
+      description: Invalid parameters provided
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error message describing the validation failure
+                example: 'Invalid date format. Expected YYYY-MM-DD'
+
+    InternalServerError:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error message
+                example: 'Internal server error'
+
+  schemas: {}
+
+tags:
+  - name: public
+    description: Public endpoints that don't require authentication

--- a/src/app/api/public/recent-activity/by-date/[...config]/route.ts
+++ b/src/app/api/public/recent-activity/by-date/[...config]/route.ts
@@ -1,0 +1,41 @@
+import 'server-only'
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { getPublicRecentActivityByDateRange } from '@/data/recentActivity/getPublicRecentActivityByDateRange'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+
+export const revalidate = 60
+export const dynamic = 'error'
+
+// ISO date without time information: YYYY-MM-DD
+const zodDateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/)
+
+const zodParams = z.object({
+  startDate: zodDateString,
+  endDate: zodDateString,
+  offset: z.string().pipe(z.coerce.number().int().gte(0).lte(1000)).optional().default('0'),
+})
+
+export async function GET(
+  _request: NextRequest,
+  props: { params: Promise<{ config: [string, string, string?] }> },
+) {
+  const params = await props.params
+  const [rawStartDate, rawEndDate, rawOffset] = params.config
+
+  const { startDate, endDate, offset } = zodParams.parse({
+    startDate: rawStartDate,
+    endDate: rawEndDate,
+    offset: rawOffset || '0',
+  })
+
+  const data = await getPublicRecentActivityByDateRange({
+    startDate,
+    endDate,
+    offset,
+    countryCode: SupportedCountryCodes.US,
+  })
+  return NextResponse.json(data)
+}

--- a/src/data/recentActivity/getPublicRecentActivityByDateRange.ts
+++ b/src/data/recentActivity/getPublicRecentActivityByDateRange.ts
@@ -1,0 +1,128 @@
+import 'server-only'
+
+import { Prisma, UserInternalStatus } from '@prisma/client'
+import { compact } from 'lodash-es'
+
+import { getClientUserWithENSData } from '@/clientModels/clientUser/clientUser'
+import { getClientUserAction } from '@/clientModels/clientUserAction/clientUserAction'
+import { queryDTSIPeopleBySlugForUserActions } from '@/data/dtsi/queries/queryDTSIPeopleBySlugForUserActions'
+import { getENSDataMapFromCryptoAddressesAndFailGracefully } from '@/data/web3/getENSDataFromCryptoAddress'
+import { prismaClient } from '@/utils/server/prismaClient'
+
+interface RecentActivityByDateRangeConfig {
+  startDate: string
+  endDate: string
+  offset: number
+  countryCode: string
+}
+
+// The reason this is duplicate from `./getPublicRecentActivity.ts` is because this is for external use and
+// we don't want to arbitrarily change the data that is returned when new actions are added.
+const fetchFromPrisma = async (config: RecentActivityByDateRangeConfig) => {
+  const where: Prisma.UserActionWhereInput = {
+    countryCode: config.countryCode,
+    datetimeCreated: {
+      gte: new Date(config.startDate),
+      lte: new Date(config.endDate),
+    },
+  }
+
+  const [data, count] = await Promise.all([
+    prismaClient.userAction
+      .findMany({
+        orderBy: {
+          datetimeCreated: 'desc',
+        },
+        take: 1000,
+        skip: config.offset,
+        include: {
+          user: {
+            include: { primaryUserCryptoAddress: true, address: true },
+          },
+          userActionEmail: {
+            include: {
+              userActionEmailRecipients: true,
+            },
+          },
+          nftMint: true,
+          userActionCall: true,
+          userActionDonation: true,
+          userActionOptIn: true,
+          userActionVoterRegistration: true,
+          userActionTweetAtPerson: true,
+          userActionVoterAttestation: true,
+          userActionRsvpEvent: true,
+          userActionViewKeyRaces: true,
+          userActionVotingInformationResearched: {
+            include: {
+              address: true,
+            },
+          },
+          userActionVotingDay: true,
+          userActionRefer: true,
+          userActionPoll: {
+            include: {
+              userActionPollAnswers: true,
+            },
+          },
+          userActionViewKeyPage: true,
+        },
+        where,
+      })
+      .then(userActions =>
+        userActions.filter(
+          ({ user: { internalStatus } }) => internalStatus === UserInternalStatus.VISIBLE,
+        ),
+      ),
+    prismaClient.userAction.count({ where }),
+  ])
+
+  return { count, data }
+}
+
+export const getPublicRecentActivityByDateRange = async (
+  config: RecentActivityByDateRangeConfig,
+) => {
+  const { count, data } = await fetchFromPrisma(config)
+  const dtsiSlugs = new Set<string>()
+
+  data.forEach(userAction => {
+    if (userAction.userActionCall?.recipientDtsiSlug) {
+      dtsiSlugs.add(userAction.userActionCall.recipientDtsiSlug)
+    } else if (userAction.userActionEmail) {
+      userAction.userActionEmail.userActionEmailRecipients.forEach(userActionEmailRecipient => {
+        if (userActionEmailRecipient.dtsiSlug) {
+          dtsiSlugs.add(userActionEmailRecipient.dtsiSlug)
+        }
+      })
+    } else if (userAction.userActionTweetAtPerson?.recipientDtsiSlug) {
+      dtsiSlugs.add(userAction.userActionTweetAtPerson.recipientDtsiSlug)
+    }
+  })
+
+  const dtsiPeople = await queryDTSIPeopleBySlugForUserActions(Array.from(dtsiSlugs)).then(
+    x => x.people,
+  )
+
+  const ensDataMap = await getENSDataMapFromCryptoAddressesAndFailGracefully(
+    compact(data.map(({ user }) => user.primaryUserCryptoAddress?.cryptoAddress)),
+  )
+  return {
+    count,
+    data: data.map(({ user, ...record }) => ({
+      ...getClientUserAction({ record, dtsiPeople }),
+      user: {
+        ...getClientUserWithENSData(
+          user,
+          user.primaryUserCryptoAddress?.cryptoAddress
+            ? ensDataMap[user.primaryUserCryptoAddress?.cryptoAddress]
+            : null,
+        ),
+      },
+    })),
+  }
+}
+
+export type PublicRecentActivityByDateRange = Awaited<
+  ReturnType<typeof getPublicRecentActivityByDateRange>
+>


### PR DESCRIPTION
closes #2548 

## What changed? Why?

This creates a new recent activity api route for external third party integrations.

Because this needs to support products other than ours I'm accepting the redundancy in implementation with the current recent activity route to reduce side effects with data changes on the api without prior warning (adding a new action for instance)

## Notes to reviewers

- [ ] AI Generated

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
