### PR TITLE
feat: add acquisition tracking custom fields to SendGrid contacts

### DIFF
--- a/.cursor/rules/adding-custom-fields-to-sendgrid.mdc
+++ b/.cursor/rules/adding-custom-fields-to-sendgrid.mdc
@@ -1,0 +1,67 @@
+---
+description: "Adding new custom fields to Sendgrid"
+globs:
+alwaysApply: false
+---
+
+# Adding new custom fields to Sendgrid
+
+This guide outlines the process for adding new custom fields to Sendgrid from within this codebase. The process involves defining the field name and type in the code, after which a cron job will automatically create the field in Sendgrid.
+
+## 1. Define the Custom Field Name
+
+All Sendgrid custom field names must be defined in the `SENDGRID_CUSTOM_FIELDS` array, located in [`@/utils/server/sendgrid/marketing/constants.ts`](mdc:src/utils/server/sendgrid/marketing/constants.ts).
+
+To add a new field, simply add a new string literal to this array.
+
+Example:
+```typescript
+export const SENDGRID_CUSTOM_FIELDS = [
+  'signup_date',
+  'user_actions_count',
+  'session_id',
+  'aquisition_source',
+  'aquisition_medium',
+  'aquisition_campaign',
+  'aquisition_referer',
+  'my_new_custom_field', // Add your new field here
+  ...Object.values(UserActionType).map(getSendgridUserActionCustomFieldName),
+] as const
+```
+
+Note: Fields for User Actions are automatically added to the `SENDGRID_CUSTOM_FIELDS` array by the `getSendgridUserActionCustomFieldName` function, located in [`@/utils/server/sendgrid/marketing/constants.ts`](mdc:src/utils/server/sendgrid/marketing/constants.ts).
+
+## 2. Define the Custom Field Type
+
+Next, you must specify the type for your new custom field. This is done in the `fieldTypes` object within the `checkCustomFields` function, located in the file [`@/inngest/functions/sendgridContactsCronJob/checkCustomFields.ts`](mdc:src/inngest/functions/sendgridContactsCronJob/checkCustomFields.ts).
+
+The supported field types are `Text`, `Number`, and `Date`.
+
+You will need to add a new entry to the `fieldTypes` object, where the key is your new custom field name and the value is its type.
+
+Example:
+```typescript
+const fieldTypes: Record<SendgridCustomField, FieldType> = {
+  signup_date: 'Date',
+  user_actions_count: 'Number',
+  session_id: 'Text',
+  my_new_custom_field: 'Text', // Add your new field and its type here
+  // ... other fields
+}
+```
+
+Note: Typescript will not allow typos or incorrect field names to be used in the `fieldTypes` object.
+
+## 3. Automatic Creation in Sendgrid
+
+Once you have defined the field name and type, a cron job (`sendgridContactsCronJob`) will automatically create the custom field in Sendgrid for you. The `checkCustomFields` function handles this process by:
+
+1.  Fetching all existing field definitions from Sendgrid.
+2.  Comparing them against the fields defined in `SENDGRID_CUSTOM_FIELDS`.
+3.  Creating any fields that are defined in the code but do not yet exist in Sendgrid.
+
+There is no need to manually create the fields in the Sendgrid UI.
+
+## 4. Using the Custom Field
+
+The `formatContactCustomFields` function in [`@/utils/server/sendgrid/marketing/formatContact.ts`](mdc:src/utils/server/sendgrid/marketing/formatContact.ts) will automatically map your field to the correct Sendgrid ID.

--- a/src/inngest/functions/sendgridContactsCronJob/checkCustomFields.ts
+++ b/src/inngest/functions/sendgridContactsCronJob/checkCustomFields.ts
@@ -42,6 +42,10 @@ export async function checkCustomFields() {
     signup_date: 'Date',
     user_actions_count: 'Number',
     session_id: 'Text',
+    aquisition_source: 'Text',
+    aquisition_medium: 'Text',
+    aquisition_campaign: 'Text',
+    aquisition_referer: 'Text',
     ...(Object.fromEntries(
       Object.values(UserActionType).map(actionType => [
         getSendgridUserActionCustomFieldName(actionType),

--- a/src/inngest/functions/sendgridContactsCronJob/config.ts
+++ b/src/inngest/functions/sendgridContactsCronJob/config.ts
@@ -3,7 +3,7 @@ import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 export const SENDGRID_CONTACTS_API_LIMIT = 30000
 export const SENDGRID_CONTACTS_API_LIMIT_BYTES = 3900000 // Approx 3.72MiB, server limit is 4MiB (4,194,304 bytes)
 export const SENDGRID_API_RATE_LIMIT = 5
-export const SENDGRID_API_RATE_LIMIT_COOLDOWN = 30000 // 30 seconds
+export const SENDGRID_API_RATE_LIMIT_COOLDOWN = 60000 // 1 minute
 export const DB_READ_LIMIT = 40000
 
 /**

--- a/src/inngest/functions/sendgridContactsCronJob/logic.ts
+++ b/src/inngest/functions/sendgridContactsCronJob/logic.ts
@@ -51,6 +51,10 @@ interface User {
   userSessions: {
     id: string
   }[]
+  acquisitionSource: string | null
+  acquisitionMedium: string | null
+  acquisitionCampaign: string | null
+  acquisitionReferer: string | null
 }
 
 interface BatchParams {
@@ -103,6 +107,10 @@ function convertUserToContact(user: User): SendgridContact {
           : user.datetimeCreated,
       user_actions_count: user.userActions.length,
       session_id: user.userSessions?.[0]?.id || '',
+      aquisition_source: user.acquisitionSource || '',
+      aquisition_medium: user.acquisitionMedium || '',
+      aquisition_campaign: user.acquisitionCampaign || '',
+      aquisition_referer: user.acquisitionReferer || '',
       ...completedUsersActionsCustomFields,
     },
   }
@@ -147,6 +155,10 @@ export const syncSendgridContactsProcessor = inngest.createFunction(
             userSessions: {
               select: { id: true },
             },
+            acquisitionSource: true,
+            acquisitionMedium: true,
+            acquisitionCampaign: true,
+            acquisitionReferer: true,
           },
           skip: batchParams.skip,
           take: batchParams.take,
@@ -164,7 +176,7 @@ export const syncSendgridContactsProcessor = inngest.createFunction(
 
         const validContacts = users
           .filter(user => Boolean(user.primaryUserEmailAddress?.emailAddress))
-          .map(user => convertUserToContact(user))
+          .map(convertUserToContact)
 
         if (validContacts.length === 0) {
           logger.info(`No valid contacts found`)

--- a/src/utils/server/sendgrid/marketing/constants.ts
+++ b/src/utils/server/sendgrid/marketing/constants.ts
@@ -29,6 +29,10 @@ export const SENDGRID_CUSTOM_FIELDS = [
   'signup_date',
   'user_actions_count',
   'session_id',
+  'aquisition_source',
+  'aquisition_medium',
+  'aquisition_campaign',
+  'aquisition_referer',
   ...Object.values(UserActionType).map(getSendgridUserActionCustomFieldName),
 ] as const
 export type SendgridCustomField = (typeof SENDGRID_CUSTOM_FIELDS)[number]


### PR DESCRIPTION
## What changed? Why?

Added acquisition tracking custom fields to SendGrid contacts synchronization to capture user acquisition data:

- Added `acquisitionSource`, `acquisitionMedium`, `acquisitionCampaign`, and `acquisitionReferer` fields to the user query and contact mapping
- Increased SendGrid API rate limit cooldown from 30 seconds to 1 minute for better API stability

## Notes to reviewers

- [x] AI Generated

The main changes are in:
- `src/inngest/functions/sendgridContactsCronJob/logic.ts` - Added acquisition fields to user query and contact conversion
- `src/utils/server/sendgrid/marketing/constants.ts` - Added new custom field constants
- `src/inngest/functions/sendgridContactsCronJob/config.ts` - Increased rate limit cooldown

## How has it been tested?

- [ ] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test