### PR TITLE
Fix/refactor: reduce layout shift on referrals and improve code

### DIFF
--- a/src/app/au/referrals/[[...page]]/page.tsx
+++ b/src/app/au/referrals/[[...page]]/page.tsx
@@ -23,8 +23,8 @@ type Props = PageProps<{ page: string[] }>
 
 export async function generateMetadata(_props: Props): Promise<Metadata> {
   return generateMetadataDetails({
-    title: 'District Leaderboard',
-    description: 'See which districts have the most number of advocates',
+    title: 'Divisions Leaderboard',
+    description: 'See which divisions have the most number of advocates',
   })
 }
 

--- a/src/app/ca/referrals/[[...page]]/page.tsx
+++ b/src/app/ca/referrals/[[...page]]/page.tsx
@@ -23,8 +23,8 @@ type Props = PageProps<{ page: string[] }>
 
 export async function generateMetadata(_props: Props): Promise<Metadata> {
   return generateMetadataDetails({
-    title: 'District Leaderboard',
-    description: 'See which districts have the most number of advocates',
+    title: 'Constituencies Leaderboard',
+    description: 'See which constituencies have the most number of advocates',
   })
 }
 

--- a/src/components/app/pageCommunity/au/index.tsx
+++ b/src/components/app/pageCommunity/au/index.tsx
@@ -3,6 +3,7 @@ import { AuRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/au
 import { AuAdvocatesLeaderboard } from '@/components/app/pageReferrals/au/leaderboard'
 import {
   AuYourDivisionRank,
+  AuYourDivisionRankingWrapper,
   AuYourDivisionRankSuspense,
 } from '@/components/app/pageReferrals/au/yourDivisionRanking'
 import { UserAddressProvider } from '@/components/app/pageReferrals/common/userAddress.context'
@@ -152,11 +153,13 @@ export function AuPageCommunity({
 
         {tab === AuRecentActivityAndLeaderboardTabs.TOP_DIVISIONS && leaderboardData && (
           <>
-            <AuYourDivisionRankSuspense>
-              <UserAddressProvider countryCode={countryCode}>
-                <AuYourDivisionRank />
-              </UserAddressProvider>
-            </AuYourDivisionRankSuspense>
+            <AuYourDivisionRankingWrapper>
+              <AuYourDivisionRankSuspense>
+                <UserAddressProvider countryCode={countryCode}>
+                  <AuYourDivisionRank />
+                </UserAddressProvider>
+              </AuYourDivisionRankSuspense>
+            </AuYourDivisionRankingWrapper>
             <AuAdvocatesLeaderboard data={leaderboardData} />
             {totalPages > 1 && (
               <div className="flex justify-center">

--- a/src/components/app/pageCommunity/ca/index.tsx
+++ b/src/components/app/pageCommunity/ca/index.tsx
@@ -3,6 +3,7 @@ import { CaRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/ca
 import { CaAdvocatesLeaderboard } from '@/components/app/pageReferrals/ca/leaderboard'
 import {
   CaYourConstituencyRank,
+  CaYourConstituencyRankingWrapper,
   CaYourConstituencyRankSuspense,
 } from '@/components/app/pageReferrals/ca/yourConstituencyRanking'
 import { UserAddressProvider } from '@/components/app/pageReferrals/common/userAddress.context'
@@ -151,11 +152,13 @@ export function CaPageCommunity({
         )}
         {tab === CaRecentActivityAndLeaderboardTabs.TOP_CONSTITUENCIES && (
           <>
-            <CaYourConstituencyRankSuspense>
-              <UserAddressProvider countryCode={countryCode}>
-                <CaYourConstituencyRank />
-              </UserAddressProvider>
-            </CaYourConstituencyRankSuspense>
+            <CaYourConstituencyRankingWrapper>
+              <CaYourConstituencyRankSuspense>
+                <UserAddressProvider countryCode={countryCode}>
+                  <CaYourConstituencyRank />
+                </UserAddressProvider>
+              </CaYourConstituencyRankSuspense>
+            </CaYourConstituencyRankingWrapper>
             <CaAdvocatesLeaderboard data={leaderboardData} />
             {totalPages > 1 && (
               <div className="flex justify-center">

--- a/src/components/app/pageCommunity/us/index.tsx
+++ b/src/components/app/pageCommunity/us/index.tsx
@@ -4,6 +4,7 @@ import { UserAddressProvider } from '@/components/app/pageReferrals/common/userA
 import { USAdvocatesLeaderboard } from '@/components/app/pageReferrals/us/leaderboard'
 import {
   UsYourDistrictRank,
+  UsYourDistrictRankingWrapper,
   UsYourDistrictRankSuspense,
 } from '@/components/app/pageReferrals/us/yourDistrictRanking'
 import { RecentActivity } from '@/components/app/recentActivity'
@@ -187,11 +188,13 @@ export function UsPageCommunity({
         )}
         {tab === UsRecentActivityAndLeaderboardTabs.TOP_DISTRICTS && (
           <>
-            <UsYourDistrictRankSuspense>
-              <UserAddressProvider countryCode={countryCode}>
-                <UsYourDistrictRank />
-              </UserAddressProvider>
-            </UsYourDistrictRankSuspense>
+            <UsYourDistrictRankingWrapper>
+              <UsYourDistrictRankSuspense>
+                <UserAddressProvider countryCode={countryCode}>
+                  <UsYourDistrictRank />
+                </UserAddressProvider>
+              </UsYourDistrictRankSuspense>
+            </UsYourDistrictRankingWrapper>
             <USAdvocatesLeaderboard data={leaderboardData} />
           </>
         )}

--- a/src/components/app/pageCommunity/us/stateSpecificPage.tsx
+++ b/src/components/app/pageCommunity/us/stateSpecificPage.tsx
@@ -4,6 +4,7 @@ import { UserAddressProvider } from '@/components/app/pageReferrals/common/userA
 import { USAdvocatesLeaderboard } from '@/components/app/pageReferrals/us/leaderboard'
 import {
   UsYourDistrictRank,
+  UsYourDistrictRankingWrapper,
   UsYourDistrictRankSuspense,
 } from '@/components/app/pageReferrals/us/yourDistrictRanking'
 import { RecentActivity } from '@/components/app/recentActivity'
@@ -90,11 +91,13 @@ export function UsStateSpecificCommunityPage({
         ) : null}
         {tab === UsRecentActivityAndLeaderboardTabs.TOP_DISTRICTS && (
           <>
-            <UsYourDistrictRankSuspense>
-              <UserAddressProvider countryCode={countryCode} filterByAdministrativeArea>
-                <UsYourDistrictRank />
-              </UserAddressProvider>
-            </UsYourDistrictRankSuspense>
+            <UsYourDistrictRankingWrapper>
+              <UsYourDistrictRankSuspense>
+                <UserAddressProvider countryCode={countryCode} filterByAdministrativeArea>
+                  <UsYourDistrictRank />
+                </UserAddressProvider>
+              </UsYourDistrictRankSuspense>
+            </UsYourDistrictRankingWrapper>
             <USAdvocatesLeaderboard data={leaderboardData} />
           </>
         )}

--- a/src/components/app/pageHome/au/index.tsx
+++ b/src/components/app/pageHome/au/index.tsx
@@ -10,6 +10,7 @@ import { HomePageProps } from '@/components/app/pageHome/common/types'
 import { AuAdvocatesLeaderboard } from '@/components/app/pageReferrals/au/leaderboard'
 import {
   AuYourDivisionRank,
+  AuYourDivisionRankingWrapper,
   AuYourDivisionRankSuspense,
 } from '@/components/app/pageReferrals/au/yourDivisionRanking'
 import { UserAddressProvider } from '@/components/app/pageReferrals/common/userAddress.context'
@@ -84,11 +85,13 @@ export function AuPageHome({
                       See which division has the most number of advocates.
                     </HomePageSection.Subtitle>
 
-                    <AuYourDivisionRankSuspense>
-                      <UserAddressProvider countryCode={countryCode}>
-                        <AuYourDivisionRank />
-                      </UserAddressProvider>
-                    </AuYourDivisionRankSuspense>
+                    <AuYourDivisionRankingWrapper>
+                      <AuYourDivisionRankSuspense>
+                        <UserAddressProvider countryCode={countryCode}>
+                          <AuYourDivisionRank />
+                        </UserAddressProvider>
+                      </AuYourDivisionRankSuspense>
+                    </AuYourDivisionRankingWrapper>
                     <AuAdvocatesLeaderboard data={leaderboardData} />
                     <div className="mx-auto flex w-fit justify-center gap-2">
                       <LoginDialogWrapper

--- a/src/components/app/pageHome/ca/index.tsx
+++ b/src/components/app/pageHome/ca/index.tsx
@@ -10,6 +10,7 @@ import { HomePageProps } from '@/components/app/pageHome/common/types'
 import { CaAdvocatesLeaderboard } from '@/components/app/pageReferrals/ca/leaderboard'
 import {
   CaYourConstituencyRank,
+  CaYourConstituencyRankingWrapper,
   CaYourConstituencyRankSuspense,
 } from '@/components/app/pageReferrals/ca/yourConstituencyRanking'
 import { UserAddressProvider } from '@/components/app/pageReferrals/common/userAddress.context'
@@ -82,11 +83,13 @@ export function CaPageHome({
                     <HomePageSection.Subtitle className="hidden md:block">
                       See which constituency has the most number of advocates.
                     </HomePageSection.Subtitle>
-                    <CaYourConstituencyRankSuspense>
-                      <UserAddressProvider countryCode={countryCode}>
-                        <CaYourConstituencyRank />
-                      </UserAddressProvider>
-                    </CaYourConstituencyRankSuspense>
+                    <CaYourConstituencyRankingWrapper>
+                      <CaYourConstituencyRankSuspense>
+                        <UserAddressProvider countryCode={countryCode}>
+                          <CaYourConstituencyRank />
+                        </UserAddressProvider>
+                      </CaYourConstituencyRankSuspense>
+                    </CaYourConstituencyRankingWrapper>
                     <CaAdvocatesLeaderboard data={leaderboardData} />
                     <div className="mx-auto flex w-fit justify-center gap-2">
                       <LoginDialogWrapper

--- a/src/components/app/pageHome/us/index.tsx
+++ b/src/components/app/pageHome/us/index.tsx
@@ -10,6 +10,7 @@ import { UserAddressProvider } from '@/components/app/pageReferrals/common/userA
 import { USAdvocatesLeaderboard } from '@/components/app/pageReferrals/us/leaderboard'
 import {
   UsYourDistrictRank,
+  UsYourDistrictRankingWrapper,
   UsYourDistrictRankSuspense,
 } from '@/components/app/pageReferrals/us/yourDistrictRanking'
 import { RecentActivity } from '@/components/app/recentActivity'
@@ -133,11 +134,13 @@ export function UsPageHome({
                       See which district has the most number of advocates.
                     </HomePageSection.Subtitle>
 
-                    <UsYourDistrictRankSuspense>
-                      <UserAddressProvider countryCode={countryCode}>
-                        <UsYourDistrictRank />
-                      </UserAddressProvider>
-                    </UsYourDistrictRankSuspense>
+                    <UsYourDistrictRankingWrapper>
+                      <UsYourDistrictRankSuspense>
+                        <UserAddressProvider countryCode={countryCode}>
+                          <UsYourDistrictRank />
+                        </UserAddressProvider>
+                      </UsYourDistrictRankSuspense>
+                    </UsYourDistrictRankingWrapper>
                     <USAdvocatesLeaderboard data={leaderboardData} />
                     <div className="mx-auto flex w-fit justify-center gap-2">
                       <LoginDialogWrapper

--- a/src/components/app/pageLocalPolicy/us/statePage/districtLeaderboardSection.tsx
+++ b/src/components/app/pageLocalPolicy/us/statePage/districtLeaderboardSection.tsx
@@ -4,6 +4,7 @@ import { UserAddressProvider } from '@/components/app/pageReferrals/common/userA
 import { USAdvocatesLeaderboard } from '@/components/app/pageReferrals/us/leaderboard'
 import {
   UsYourDistrictRank,
+  UsYourDistrictRankingWrapper,
   UsYourDistrictRankSuspense,
 } from '@/components/app/pageReferrals/us/yourDistrictRanking'
 import { getDistrictsLeaderboardDataByState } from '@/utils/server/districtRankings/upsertRankings'
@@ -43,11 +44,13 @@ export async function UsDistrictLeaderboardSection({
         </Section.SubTitle>
 
         <DistrictLeaderboard>
-          <UsYourDistrictRankSuspense>
-            <UserAddressProvider countryCode={countryCode} filterByAdministrativeArea>
-              <UsYourDistrictRank />
-            </UserAddressProvider>
-          </UsYourDistrictRankSuspense>
+          <UsYourDistrictRankingWrapper>
+            <UsYourDistrictRankSuspense>
+              <UserAddressProvider countryCode={countryCode} filterByAdministrativeArea>
+                <UsYourDistrictRank />
+              </UserAddressProvider>
+            </UsYourDistrictRankSuspense>
+          </UsYourDistrictRankingWrapper>
           <USAdvocatesLeaderboard data={leaderboardData} />
 
           {total > ITEMS_PER_PAGE && (

--- a/src/components/app/pageReferrals/au/heading.tsx
+++ b/src/components/app/pageReferrals/au/heading.tsx
@@ -1,42 +1,19 @@
-'use client'
+import { PageReferralsHeading } from '@/components/app/pageReferrals/common/heading'
 
-import { PageReferrals } from '@/components/app/pageReferrals/common'
-import { PageSubTitle } from '@/components/ui/pageSubTitle'
-import { PageTitle } from '@/components/ui/pageTitleText'
-import { useHasHydrated } from '@/hooks/useHasHydrated'
-import { useSession } from '@/hooks/useSession'
-
-interface PageReferralsHeadingProps {
+interface AuPageReferralsHeadingProps {
   stateName?: string
 }
 
-export function AuPageReferralsHeading({ stateName }: PageReferralsHeadingProps) {
-  const { isLoggedIn, isLoading } = useSession()
-  const hasHydrated = useHasHydrated()
-
-  if (!isLoggedIn || isLoading || !hasHydrated || stateName) {
-    return (
-      <PageReferrals.Heading>
-        <PageTitle>Divisions Leaderboard</PageTitle>
-        <PageSubTitle>
-          {stateName
-            ? `See which divisions in ${stateName} have the most advocates.`
-            : 'See which divisions have the most number of Stand With Crypto advocates.'}
-        </PageSubTitle>
-      </PageReferrals.Heading>
-    )
-  }
-
+export function AuPageReferralsHeading({ stateName }: AuPageReferralsHeadingProps) {
   return (
-    <PageReferrals.Heading>
-      <PageTitle>
-        Invite a friend to join
-        <br />
-        <span className="inline-block">Stand With Crypto</span>
-      </PageTitle>
-      <PageSubTitle>
-        Send your friends your unique referral code to encourage them to signup and take action
-      </PageSubTitle>
-    </PageReferrals.Heading>
+    <PageReferralsHeading
+      leaderboardSubtitle={
+        stateName
+          ? `See which divisions in ${stateName} have the most advocates.`
+          : 'See which divisions have the most number of Stand With Crypto advocates.'
+      }
+      leaderboardTitle="Divisions Leaderboard"
+      stateName={stateName}
+    />
   )
 }

--- a/src/components/app/pageReferrals/au/index.tsx
+++ b/src/components/app/pageReferrals/au/index.tsx
@@ -5,6 +5,7 @@ import { AuAdvocatesLeaderboard } from '@/components/app/pageReferrals/au/leader
 import { AuUserDivisionRank } from '@/components/app/pageReferrals/au/userDivisionRank'
 import {
   AuYourDivisionRank,
+  AuYourDivisionRankingWrapper,
   AuYourDivisionRankSuspense,
 } from '@/components/app/pageReferrals/au/yourDivisionRanking'
 import { PageReferralsWrapper } from '@/components/app/pageReferrals/common'
@@ -42,21 +43,23 @@ export function AuPageReferrals(props: PageReferralsProps) {
         stateName={stateCode ? getAUStateNameFromStateCode(stateCode) : undefined}
       />
 
-      <AuYourDivisionRankSuspense>
-        <UserAddressProvider countryCode={countryCode} filterByAdministrativeArea={!!stateCode}>
-          {!stateCode && (
-            <>
-              <UserReferralUrlWithApi />
-              <ReferralsCounter>
-                <UserReferralsCount />
-                <AuUserDivisionRank />
-              </ReferralsCounter>
-            </>
-          )}
+      <AuYourDivisionRankingWrapper>
+        <AuYourDivisionRankSuspense>
+          <UserAddressProvider countryCode={countryCode} filterByAdministrativeArea={!!stateCode}>
+            {!stateCode && (
+              <>
+                <UserReferralUrlWithApi />
+                <ReferralsCounter>
+                  <UserReferralsCount />
+                  <AuUserDivisionRank />
+                </ReferralsCounter>
+              </>
+            )}
 
-          <AuYourDivisionRank />
-        </UserAddressProvider>
-      </AuYourDivisionRankSuspense>
+            <AuYourDivisionRank />
+          </UserAddressProvider>
+        </AuYourDivisionRankSuspense>
+      </AuYourDivisionRankingWrapper>
       <AuAdvocatesLeaderboard data={leaderboardData} />
       <div className="flex justify-center">
         <PaginationLinks

--- a/src/components/app/pageReferrals/au/leaderboard.tsx
+++ b/src/components/app/pageReferrals/au/leaderboard.tsx
@@ -1,7 +1,7 @@
 import { AdvocatesLeaderboard } from '@/components/app/pageReferrals/common/leaderboard'
 import { DistrictRankingEntryWithRank } from '@/utils/server/districtRankings/upsertRankings'
 import { getAUStateNameFromStateCode } from '@/utils/shared/stateMappings/auStateUtils'
-import { COUNTRY_CODE_TO_LOCALE, SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 interface AuAdvocatesLeaderboardProps {
   data: DistrictRankingEntryWithRank[]
@@ -13,21 +13,11 @@ export function AuAdvocatesLeaderboard(props: AuAdvocatesLeaderboardProps) {
   const { data } = props
 
   return (
-    <AdvocatesLeaderboard>
-      <AdvocatesLeaderboard.Heading>
-        <AdvocatesLeaderboard.Heading.Title>Top divisions</AdvocatesLeaderboard.Heading.Title>
-        <AdvocatesLeaderboard.Heading.Subtitle>Advocates</AdvocatesLeaderboard.Heading.Subtitle>
-      </AdvocatesLeaderboard.Heading>
-      {data.map(entry => (
-        <AdvocatesLeaderboard.Row
-          count={entry.count}
-          key={`${entry.state}-${entry.district}`}
-          locale={COUNTRY_CODE_TO_LOCALE[countryCode]}
-          rank={entry.rank}
-        >
-          <AdvocatesLeaderboard.Row.Label>{`${getAUStateNameFromStateCode(entry.state)} - ${entry.district}`}</AdvocatesLeaderboard.Row.Label>
-        </AdvocatesLeaderboard.Row>
-      ))}
-    </AdvocatesLeaderboard>
+    <AdvocatesLeaderboard
+      countryCode={countryCode}
+      data={data}
+      formatLabel={entry => `${getAUStateNameFromStateCode(entry.state)} - ${entry.district}`}
+      title="Top divisions"
+    />
   )
 }

--- a/src/components/app/pageReferrals/au/yourDivisionRanking.tsx
+++ b/src/components/app/pageReferrals/au/yourDivisionRanking.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import {
-  createYourLocationRanking,
+  YourLocationRank,
+  YourLocationRanking,
   YourLocationRankingConfig,
+  YourLocationRankSuspense,
 } from '@/components/app/pageReferrals/common/yourLocationRanking'
 import { getAUStateNameFromStateCode } from '@/utils/shared/stateMappings/auStateUtils'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
@@ -17,9 +19,14 @@ const config: YourLocationRankingConfig = {
   getStateName: getAUStateNameFromStateCode,
 }
 
-const { YourLocationRank, YourLocationRankSuspense } = createYourLocationRanking(config)
+export function AuYourDivisionRankingWrapper({ children }: { children: React.ReactNode }) {
+  return <YourLocationRanking value={config}>{children}</YourLocationRanking>
+}
 
-export {
-  YourLocationRank as AuYourDivisionRank,
-  YourLocationRankSuspense as AuYourDivisionRankSuspense,
+export function AuYourDivisionRank() {
+  return <YourLocationRank />
+}
+
+export function AuYourDivisionRankSuspense({ children }: { children: React.ReactNode }) {
+  return <YourLocationRankSuspense>{children}</YourLocationRankSuspense>
 }

--- a/src/components/app/pageReferrals/au/yourDivisionRanking.tsx
+++ b/src/components/app/pageReferrals/au/yourDivisionRanking.tsx
@@ -1,118 +1,25 @@
 'use client'
 
-import { Suspense } from 'react'
-import { noop } from 'lodash-es'
-
 import {
-  DefaultPlacesSelect,
-  DefaultPlacesSelectProps,
-} from '@/components/app/pageReferrals/common/defaultPlacesSelect'
-import { LeaderboardHeading } from '@/components/app/pageReferrals/common/leaderboard/heading'
-import { useUserAddress } from '@/components/app/pageReferrals/common/userAddress.context'
-import { YourLocale } from '@/components/app/pageReferrals/common/yourLocale'
-import { YourLocationRanking } from '@/components/app/pageReferrals/common/yourLocationRanking'
-import { GooglePlacesSelectProps } from '@/components/ui/googlePlacesSelect'
+  createYourLocationRanking,
+  YourLocationRankingConfig,
+} from '@/components/app/pageReferrals/common/yourLocationRanking'
 import { getAUStateNameFromStateCode } from '@/utils/shared/stateMappings/auStateUtils'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-function Heading() {
-  return (
-    <LeaderboardHeading>
-      <LeaderboardHeading.Title>Your division</LeaderboardHeading.Title>
-      <LeaderboardHeading.Subtitle>Advocates</LeaderboardHeading.Subtitle>
-    </LeaderboardHeading>
-  )
+const config: YourLocationRankingConfig = {
+  countryCode: SupportedCountryCodes.AU,
+  placeholder: 'Enter your address',
+  title: 'Your division',
+  notFoundMessage: 'Division not found, please try a different address.',
+  notFromCountryMessage: `Looks like your address is not from Australia, so it can't be used to filter`,
+  formatLabel: (stateName: string, zoneName: string) => `${stateName} - ${zoneName}`,
+  getStateName: getAUStateNameFromStateCode,
 }
 
-function AuDefaultPlacesSelect(props: Omit<DefaultPlacesSelectProps, 'title' | 'placeholder'>) {
-  return <DefaultPlacesSelect placeholder="Enter your address" title="Your division" {...props} />
-}
+const { YourLocationRank, YourLocationRankSuspense } = createYourLocationRanking(config)
 
-function DivisionNotFound(props: Pick<GooglePlacesSelectProps, 'onChange' | 'value' | 'loading'>) {
-  return (
-    <YourLocale>
-      <AuDefaultPlacesSelect {...props} />
-      <YourLocale.Label>Division not found, please try a different address.</YourLocale.Label>
-    </YourLocale>
-  )
-}
-
-const countryCode = SupportedCountryCodes.AU
-
-export function AuYourDivisionRank() {
-  const {
-    address,
-    setMutableAddress: setAddress,
-    mutableAddress,
-    isAddressInCountry: isAddressInAustralia,
-    isLoading,
-    electoralZone: division,
-    electoralZoneRanking: divisionRanking,
-    administrativeArea: stateCode,
-    isAddressFromProfile,
-  } = useUserAddress()
-
-  if (isLoading) {
-    return (
-      <YourLocale>
-        <Heading />
-        <DefaultPlacesSelect.Loading />
-      </YourLocale>
-    )
-  }
-
-  if (!address) {
-    return (
-      <AuDefaultPlacesSelect
-        loading={isLoading}
-        onChange={setAddress}
-        value={mutableAddress === 'loading' ? null : mutableAddress}
-      />
-    )
-  }
-
-  if (!isAddressInAustralia) {
-    return (
-      <YourLocale>
-        <AuDefaultPlacesSelect
-          disabled={isAddressFromProfile}
-          onChange={setAddress}
-          value={isLoading ? null : address}
-        />
-        <YourLocale.Label>
-          Looks like your address is not from Australia, so it can't be used to filter
-        </YourLocale.Label>
-      </YourLocale>
-    )
-  }
-
-  if (!division || !stateCode || !division?.zoneName) {
-    return <DivisionNotFound onChange={setAddress} value={address} />
-  }
-
-  if (!divisionRanking) {
-    return (
-      <DivisionNotFound
-        onChange={setAddress}
-        value={mutableAddress === 'loading' ? null : address}
-      />
-    )
-  }
-
-  return (
-    <YourLocationRanking
-      countryCode={countryCode}
-      heading={<Heading />}
-      label={`${getAUStateNameFromStateCode(stateCode)} - ${division.zoneName}`}
-      locationRanking={divisionRanking}
-    />
-  )
-}
-
-export function AuYourDivisionRankSuspense({ children }: { children: React.ReactNode }) {
-  return (
-    <Suspense fallback={<AuDefaultPlacesSelect loading onChange={noop} value={null} />}>
-      {children}
-    </Suspense>
-  )
+export {
+  YourLocationRank as AuYourDivisionRank,
+  YourLocationRankSuspense as AuYourDivisionRankSuspense,
 }

--- a/src/components/app/pageReferrals/ca/heading.tsx
+++ b/src/components/app/pageReferrals/ca/heading.tsx
@@ -1,42 +1,19 @@
-'use client'
+import { PageReferralsHeading } from '@/components/app/pageReferrals/common/heading'
 
-import { PageReferrals } from '@/components/app/pageReferrals/common'
-import { PageSubTitle } from '@/components/ui/pageSubTitle'
-import { PageTitle } from '@/components/ui/pageTitleText'
-import { useHasHydrated } from '@/hooks/useHasHydrated'
-import { useSession } from '@/hooks/useSession'
-
-interface PageReferralsHeadingProps {
+interface CaPageReferralsHeadingProps {
   stateName?: string
 }
 
-export function CaPageReferralsHeading({ stateName }: PageReferralsHeadingProps) {
-  const { isLoggedIn, isLoading } = useSession()
-  const hasHydrated = useHasHydrated()
-
-  if (!isLoggedIn || isLoading || !hasHydrated || stateName) {
-    return (
-      <PageReferrals.Heading>
-        <PageTitle>Constituencies Leaderboard</PageTitle>
-        <PageSubTitle>
-          {stateName
-            ? `See which constituencies in ${stateName} have the most advocates.`
-            : 'See which constituencies have the most number of Stand With Crypto advocates.'}
-        </PageSubTitle>
-      </PageReferrals.Heading>
-    )
-  }
-
+export function CaPageReferralsHeading({ stateName }: CaPageReferralsHeadingProps) {
   return (
-    <PageReferrals.Heading>
-      <PageTitle>
-        Invite a friend to join
-        <br />
-        <span className="inline-block">Stand With Crypto</span>
-      </PageTitle>
-      <PageSubTitle>
-        Send your friends your unique referral code to encourage them to signup and take action
-      </PageSubTitle>
-    </PageReferrals.Heading>
+    <PageReferralsHeading
+      leaderboardSubtitle={
+        stateName
+          ? `See which constituencies in ${stateName} have the most advocates.`
+          : 'See which constituencies have the most number of Stand With Crypto advocates.'
+      }
+      leaderboardTitle="Constituencies Leaderboard"
+      stateName={stateName}
+    />
   )
 }

--- a/src/components/app/pageReferrals/ca/index.tsx
+++ b/src/components/app/pageReferrals/ca/index.tsx
@@ -5,6 +5,7 @@ import { CaAdvocatesLeaderboard } from '@/components/app/pageReferrals/ca/leader
 import { CaUserConstituencyRank } from '@/components/app/pageReferrals/ca/userConstituencyRank'
 import {
   CaYourConstituencyRank,
+  CaYourConstituencyRankingWrapper,
   CaYourConstituencyRankSuspense,
 } from '@/components/app/pageReferrals/ca/yourConstituencyRanking'
 import { PageReferralsWrapper } from '@/components/app/pageReferrals/common'
@@ -40,21 +41,26 @@ export function CaPageReferrals(props: PageReferralsProps) {
       <CaPageReferralsHeading
         stateName={provinceCode ? getCAProvinceOrTerritoryNameFromCode(provinceCode) : undefined}
       />
-      <CaYourConstituencyRankSuspense>
-        <UserAddressProvider countryCode={countryCode} filterByAdministrativeArea={!!provinceCode}>
-          {!provinceCode && (
-            <>
-              <UserReferralUrlWithApi />
-              <ReferralsCounter>
-                <UserReferralsCount />
-                <CaUserConstituencyRank />
-              </ReferralsCounter>
-            </>
-          )}
+      <CaYourConstituencyRankingWrapper>
+        <CaYourConstituencyRankSuspense>
+          <UserAddressProvider
+            countryCode={countryCode}
+            filterByAdministrativeArea={!!provinceCode}
+          >
+            {!provinceCode && (
+              <>
+                <UserReferralUrlWithApi />
+                <ReferralsCounter>
+                  <UserReferralsCount />
+                  <CaUserConstituencyRank />
+                </ReferralsCounter>
+              </>
+            )}
 
-          <CaYourConstituencyRank />
-        </UserAddressProvider>
-      </CaYourConstituencyRankSuspense>
+            <CaYourConstituencyRank />
+          </UserAddressProvider>
+        </CaYourConstituencyRankSuspense>
+      </CaYourConstituencyRankingWrapper>
       <CaAdvocatesLeaderboard data={leaderboardData} />
       <div className="flex justify-center">
         <PaginationLinks

--- a/src/components/app/pageReferrals/ca/leaderboard.tsx
+++ b/src/components/app/pageReferrals/ca/leaderboard.tsx
@@ -1,9 +1,7 @@
-'use client'
-
 import { AdvocatesLeaderboard } from '@/components/app/pageReferrals/common/leaderboard'
 import { DistrictRankingEntryWithRank } from '@/utils/server/districtRankings/upsertRankings'
 import { getCAProvinceOrTerritoryNameFromCode } from '@/utils/shared/stateMappings/caProvinceUtils'
-import { COUNTRY_CODE_TO_LOCALE, SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 interface CaAdvocatesLeaderboardProps {
   data: DistrictRankingEntryWithRank[]
@@ -15,21 +13,13 @@ export function CaAdvocatesLeaderboard(props: CaAdvocatesLeaderboardProps) {
   const { data } = props
 
   return (
-    <AdvocatesLeaderboard>
-      <AdvocatesLeaderboard.Heading>
-        <AdvocatesLeaderboard.Heading.Title>Top constituencies</AdvocatesLeaderboard.Heading.Title>
-        <AdvocatesLeaderboard.Heading.Subtitle>Advocates</AdvocatesLeaderboard.Heading.Subtitle>
-      </AdvocatesLeaderboard.Heading>
-      {data.map(entry => (
-        <AdvocatesLeaderboard.Row
-          count={entry.count}
-          key={`${entry.state}-${entry.district}`}
-          locale={COUNTRY_CODE_TO_LOCALE[countryCode]}
-          rank={entry.rank}
-        >
-          <AdvocatesLeaderboard.Row.Label>{`${getCAProvinceOrTerritoryNameFromCode(entry.state)} - ${entry.district}`}</AdvocatesLeaderboard.Row.Label>
-        </AdvocatesLeaderboard.Row>
-      ))}
-    </AdvocatesLeaderboard>
+    <AdvocatesLeaderboard
+      countryCode={countryCode}
+      data={data}
+      formatLabel={entry =>
+        `${getCAProvinceOrTerritoryNameFromCode(entry.state)} - ${entry.district}`
+      }
+      title="Top constituencies"
+    />
   )
 }

--- a/src/components/app/pageReferrals/ca/yourConstituencyRanking.tsx
+++ b/src/components/app/pageReferrals/ca/yourConstituencyRanking.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import {
-  createYourLocationRanking,
+  YourLocationRank,
+  YourLocationRanking,
   YourLocationRankingConfig,
+  YourLocationRankSuspense,
 } from '@/components/app/pageReferrals/common/yourLocationRanking'
 import { getCAProvinceOrTerritoryNameFromCode } from '@/utils/shared/stateMappings/caProvinceUtils'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
@@ -17,9 +19,14 @@ const config: YourLocationRankingConfig = {
   getStateName: getCAProvinceOrTerritoryNameFromCode,
 }
 
-const { YourLocationRank, YourLocationRankSuspense } = createYourLocationRanking(config)
+export function CaYourConstituencyRankingWrapper({ children }: { children: React.ReactNode }) {
+  return <YourLocationRanking value={config}>{children}</YourLocationRanking>
+}
 
-export {
-  YourLocationRank as CaYourConstituencyRank,
-  YourLocationRankSuspense as CaYourConstituencyRankSuspense,
+export function CaYourConstituencyRank() {
+  return <YourLocationRank />
+}
+
+export function CaYourConstituencyRankSuspense({ children }: { children: React.ReactNode }) {
+  return <YourLocationRankSuspense>{children}</YourLocationRankSuspense>
 }

--- a/src/components/app/pageReferrals/ca/yourConstituencyRanking.tsx
+++ b/src/components/app/pageReferrals/ca/yourConstituencyRanking.tsx
@@ -1,122 +1,25 @@
 'use client'
 
-import { Suspense } from 'react'
-import { noop } from 'lodash-es'
-
 import {
-  DefaultPlacesSelect,
-  DefaultPlacesSelectProps,
-} from '@/components/app/pageReferrals/common/defaultPlacesSelect'
-import { LeaderboardHeading } from '@/components/app/pageReferrals/common/leaderboard/heading'
-import { useUserAddress } from '@/components/app/pageReferrals/common/userAddress.context'
-import { YourLocale } from '@/components/app/pageReferrals/common/yourLocale'
-import { YourLocationRanking } from '@/components/app/pageReferrals/common/yourLocationRanking'
-import { GooglePlacesSelectProps } from '@/components/ui/googlePlacesSelect'
+  createYourLocationRanking,
+  YourLocationRankingConfig,
+} from '@/components/app/pageReferrals/common/yourLocationRanking'
 import { getCAProvinceOrTerritoryNameFromCode } from '@/utils/shared/stateMappings/caProvinceUtils'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-function Heading() {
-  return (
-    <LeaderboardHeading>
-      <LeaderboardHeading.Title>Your constituency</LeaderboardHeading.Title>
-      <LeaderboardHeading.Subtitle>Advocates</LeaderboardHeading.Subtitle>
-    </LeaderboardHeading>
-  )
+const config: YourLocationRankingConfig = {
+  countryCode: SupportedCountryCodes.CA,
+  placeholder: 'Enter your address',
+  title: 'Your constituency',
+  notFoundMessage: 'Constituency not found, please try a different address.',
+  notFromCountryMessage: `Looks like your address is not from Canada, so it can't be used to filter`,
+  formatLabel: (stateName: string, zoneName: string) => `${stateName} - ${zoneName}`,
+  getStateName: getCAProvinceOrTerritoryNameFromCode,
 }
 
-function CaDefaultPlacesSelect(props: Omit<DefaultPlacesSelectProps, 'title' | 'placeholder'>) {
-  return (
-    <DefaultPlacesSelect placeholder="Enter your address" title="Your constituency" {...props} />
-  )
-}
+const { YourLocationRank, YourLocationRankSuspense } = createYourLocationRanking(config)
 
-function ConstituencyNotFound(
-  props: Pick<GooglePlacesSelectProps, 'onChange' | 'value' | 'loading'>,
-) {
-  return (
-    <YourLocale>
-      <CaDefaultPlacesSelect {...props} />
-      <YourLocale.Label>Constituency not found, please try a different address.</YourLocale.Label>
-    </YourLocale>
-  )
-}
-
-const countryCode = SupportedCountryCodes.CA as const
-
-export function CaYourConstituencyRank() {
-  const {
-    address,
-    setMutableAddress: setAddress,
-    mutableAddress,
-    isAddressInCountry: isAddressInCanada,
-    isLoading,
-    electoralZone: constituency,
-    electoralZoneRanking,
-    administrativeArea: provinceCode,
-    isAddressFromProfile,
-  } = useUserAddress()
-
-  if (isLoading) {
-    return (
-      <YourLocale>
-        <Heading />
-        <DefaultPlacesSelect.Loading />
-      </YourLocale>
-    )
-  }
-
-  if (!address) {
-    return (
-      <CaDefaultPlacesSelect
-        loading={isLoading}
-        onChange={setAddress}
-        value={mutableAddress === 'loading' ? null : mutableAddress}
-      />
-    )
-  }
-
-  if (!isAddressInCanada) {
-    return (
-      <YourLocale>
-        <CaDefaultPlacesSelect
-          disabled={isAddressFromProfile}
-          onChange={setAddress}
-          value={isLoading ? null : address}
-        />
-        <YourLocale.Label>
-          Looks like your address is not from Canada, so it can't be used to filter
-        </YourLocale.Label>
-      </YourLocale>
-    )
-  }
-
-  if (!constituency || !constituency?.zoneName || !provinceCode) {
-    return <ConstituencyNotFound onChange={setAddress} value={address} />
-  }
-
-  if (!electoralZoneRanking) {
-    return (
-      <ConstituencyNotFound
-        onChange={setAddress}
-        value={mutableAddress === 'loading' ? null : address}
-      />
-    )
-  }
-
-  return (
-    <YourLocationRanking
-      countryCode={countryCode}
-      heading={<Heading />}
-      label={`${getCAProvinceOrTerritoryNameFromCode(provinceCode)} - ${constituency.zoneName}`}
-      locationRanking={electoralZoneRanking}
-    />
-  )
-}
-
-export function CaYourConstituencyRankSuspense({ children }: { children: React.ReactNode }) {
-  return (
-    <Suspense fallback={<CaDefaultPlacesSelect loading onChange={noop} value={null} />}>
-      {children}
-    </Suspense>
-  )
+export {
+  YourLocationRank as CaYourConstituencyRank,
+  YourLocationRankSuspense as CaYourConstituencyRankSuspense,
 }

--- a/src/components/app/pageReferrals/common/defaultPlacesSelect.tsx
+++ b/src/components/app/pageReferrals/common/defaultPlacesSelect.tsx
@@ -15,7 +15,7 @@ export function DefaultPlacesSelect({ title, placeholder, ...props }: DefaultPla
     <div className="w-full space-y-3">
       <LeaderboardHeading.Title>{title}</LeaderboardHeading.Title>
       <GooglePlacesSelect
-        className="rounded-full bg-gray-100 text-gray-600"
+        className="h-12 rounded-full bg-gray-100 text-gray-600"
         placeholder={placeholder}
         {...props}
       />

--- a/src/components/app/pageReferrals/common/heading.tsx
+++ b/src/components/app/pageReferrals/common/heading.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { PageReferrals } from '@/components/app/pageReferrals/common'
+import { PageSubTitle } from '@/components/ui/pageSubTitle'
+import { PageTitle } from '@/components/ui/pageTitleText'
+import { useHasHydrated } from '@/hooks/useHasHydrated'
+import { useSession } from '@/hooks/useSession'
+
+interface PageReferralsHeadingProps {
+  stateName?: string
+  leaderboardTitle: string
+  leaderboardSubtitle: string
+}
+
+export function PageReferralsHeading({
+  stateName,
+  leaderboardTitle,
+  leaderboardSubtitle,
+}: PageReferralsHeadingProps) {
+  const { isLoggedIn, isLoading } = useSession()
+  const hasHydrated = useHasHydrated()
+
+  if (!isLoggedIn || isLoading || !hasHydrated || stateName) {
+    return (
+      <PageReferrals.Heading>
+        <PageTitle>{leaderboardTitle}</PageTitle>
+        <PageSubTitle>{leaderboardSubtitle}</PageSubTitle>
+      </PageReferrals.Heading>
+    )
+  }
+
+  return (
+    <PageReferrals.Heading>
+      <PageTitle>
+        Invite a friend to join
+        <br />
+        <span className="inline-block">Stand With Crypto</span>
+      </PageTitle>
+      <PageSubTitle>
+        Send your friends your unique referral code to encourage them to signup and take action
+      </PageSubTitle>
+    </PageReferrals.Heading>
+  )
+}

--- a/src/components/app/pageReferrals/common/leaderboard/index.tsx
+++ b/src/components/app/pageReferrals/common/leaderboard/index.tsx
@@ -1,9 +1,50 @@
 import { LeaderboardHeading } from '@/components/app/pageReferrals/common/leaderboard/heading'
 import { LeaderboardRow } from '@/components/app/pageReferrals/common/leaderboard/row'
+import { DistrictRankingEntryWithRank } from '@/utils/server/districtRankings/upsertRankings'
+import { COUNTRY_CODE_TO_LOCALE, SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-export function AdvocatesLeaderboard({ children }: { children: React.ReactNode }) {
+// Base component for manual composition
+export function AdvocatesLeaderboardBase({ children }: { children: React.ReactNode }) {
   return <div className="space-y-3 md:space-y-4">{children}</div>
 }
 
-AdvocatesLeaderboard.Heading = LeaderboardHeading
-AdvocatesLeaderboard.Row = LeaderboardRow
+AdvocatesLeaderboardBase.Heading = LeaderboardHeading
+AdvocatesLeaderboardBase.Row = LeaderboardRow
+
+// High-level component with built-in logic
+interface AdvocatesLeaderboardProps {
+  data: DistrictRankingEntryWithRank[]
+  countryCode: SupportedCountryCodes
+  title: string
+  formatLabel: (entry: DistrictRankingEntryWithRank) => string
+}
+
+export function AdvocatesLeaderboard({
+  data,
+  countryCode,
+  title,
+  formatLabel,
+}: AdvocatesLeaderboardProps) {
+  return (
+    <AdvocatesLeaderboardBase>
+      <AdvocatesLeaderboardBase.Heading>
+        <AdvocatesLeaderboardBase.Heading.Title>{title}</AdvocatesLeaderboardBase.Heading.Title>
+        <AdvocatesLeaderboardBase.Heading.Subtitle>
+          Advocates
+        </AdvocatesLeaderboardBase.Heading.Subtitle>
+      </AdvocatesLeaderboardBase.Heading>
+      {data.map(entry => (
+        <AdvocatesLeaderboardBase.Row
+          count={entry.count}
+          key={`${entry.state}-${entry.district}`}
+          locale={COUNTRY_CODE_TO_LOCALE[countryCode]}
+          rank={entry.rank}
+        >
+          <AdvocatesLeaderboardBase.Row.Label>
+            {formatLabel(entry)}
+          </AdvocatesLeaderboardBase.Row.Label>
+        </AdvocatesLeaderboardBase.Row>
+      ))}
+    </AdvocatesLeaderboardBase>
+  )
+}

--- a/src/components/app/pageReferrals/common/userAddress.context.tsx
+++ b/src/components/app/pageReferrals/common/userAddress.context.tsx
@@ -59,8 +59,8 @@ export const UserAddressProvider = ({
 }) => {
   const profileResponse = useApiResponseForUserFullProfileInfo()
   const { setAddress: setMutableAddress, address: mutableAddress } = useMutableCurrentUserAddress()
-  const [addressDetails, setAddressDetails] = useState<z.infer<typeof zodAddress> | null>(null)
   const { isLoaded: isGoogleMapsLoaded } = useGoogleMapsScript()
+  const [addressDetails, setAddressDetails] = useState<z.infer<typeof zodAddress> | null>(null)
   const [isAddressDetailsLoading, setIsAddressDetailsLoading] = useState(false)
 
   const isAddressLoading =
@@ -90,9 +90,13 @@ export const UserAddressProvider = ({
   })
 
   const electoralZone = useMemo(() => {
-    if (!electoralZoneResponse.data) return null
-    if ('notFoundReason' in electoralZoneResponse.data) return null
-    if (!electoralZoneResponse.data.zoneName) return null
+    if (
+      !electoralZoneResponse.data ||
+      'notFoundReason' in electoralZoneResponse.data ||
+      !electoralZoneResponse.data.zoneName
+    ) {
+      return null
+    }
 
     return electoralZoneResponse.data
   }, [electoralZoneResponse.data])

--- a/src/components/app/pageReferrals/common/yourLocationRanking.tsx
+++ b/src/components/app/pageReferrals/common/yourLocationRanking.tsx
@@ -1,10 +1,21 @@
-import { isNil } from 'lodash-es'
+'use client'
+
+import { Suspense } from 'react'
+import { isNil, noop } from 'lodash-es'
 
 import { GetDistrictRankResponse } from '@/app/api/public/referrals/[countryCode]/[stateCode]/[districtNumber]/route'
+import {
+  DefaultPlacesSelect,
+  DefaultPlacesSelectProps,
+} from '@/components/app/pageReferrals/common/defaultPlacesSelect'
+import { LeaderboardHeading } from '@/components/app/pageReferrals/common/leaderboard/heading'
 import { LeaderboardRow } from '@/components/app/pageReferrals/common/leaderboard/row'
+import { useUserAddress } from '@/components/app/pageReferrals/common/userAddress.context'
 import { YourLocale } from '@/components/app/pageReferrals/common/yourLocale'
+import { GooglePlacesSelectProps } from '@/components/ui/googlePlacesSelect'
 import { COUNTRY_CODE_TO_LOCALE, SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
+// Display component (original)
 interface YourLocationRankingProps {
   locationRanking: GetDistrictRankResponse | null
   countryCode: SupportedCountryCodes
@@ -35,4 +46,123 @@ export function YourLocationRanking(props: YourLocationRankingProps) {
       </LeaderboardRow>
     </YourLocale>
   )
+}
+
+export interface YourLocationRankingConfig {
+  countryCode: SupportedCountryCodes
+  placeholder: string
+  title: string
+  notFoundMessage: string
+  notFromCountryMessage: string
+  formatLabel: (stateName: string, zoneName: string) => string
+  getStateName: (stateCode: string) => string
+}
+
+export function createYourLocationRanking(config: YourLocationRankingConfig) {
+  function Heading() {
+    return (
+      <LeaderboardHeading>
+        <LeaderboardHeading.Title>{config.title}</LeaderboardHeading.Title>
+        <LeaderboardHeading.Subtitle>Advocates</LeaderboardHeading.Subtitle>
+      </LeaderboardHeading>
+    )
+  }
+
+  function DefaultPlacesSelectWrapper(
+    props: Omit<DefaultPlacesSelectProps, 'title' | 'placeholder'>,
+  ) {
+    return <DefaultPlacesSelect placeholder={config.placeholder} title={config.title} {...props} />
+  }
+
+  function LocationNotFound(
+    props: Pick<GooglePlacesSelectProps, 'onChange' | 'value' | 'loading'>,
+  ) {
+    return (
+      <YourLocale>
+        <DefaultPlacesSelectWrapper {...props} />
+        <YourLocale.Label>{config.notFoundMessage}</YourLocale.Label>
+      </YourLocale>
+    )
+  }
+
+  function YourLocationRank() {
+    const {
+      address,
+      setMutableAddress: setAddress,
+      mutableAddress,
+      isAddressInCountry,
+      isLoading,
+      electoralZone,
+      electoralZoneRanking,
+      administrativeArea: stateCode,
+      isAddressFromProfile,
+    } = useUserAddress()
+
+    if (isLoading) {
+      return (
+        <YourLocale>
+          <Heading />
+          <DefaultPlacesSelect.Loading />
+        </YourLocale>
+      )
+    }
+
+    if (!address) {
+      return (
+        <DefaultPlacesSelectWrapper
+          loading={isLoading}
+          onChange={setAddress}
+          value={mutableAddress === 'loading' ? null : mutableAddress}
+        />
+      )
+    }
+
+    if (!isAddressInCountry) {
+      return (
+        <YourLocale>
+          <DefaultPlacesSelectWrapper
+            disabled={isAddressFromProfile}
+            onChange={setAddress}
+            value={isLoading ? null : address}
+          />
+          <YourLocale.Label>{config.notFromCountryMessage}</YourLocale.Label>
+        </YourLocale>
+      )
+    }
+
+    if (!electoralZone || !stateCode || !electoralZone?.zoneName) {
+      return <LocationNotFound onChange={setAddress} value={address} />
+    }
+
+    if (!electoralZoneRanking) {
+      return (
+        <LocationNotFound
+          onChange={setAddress}
+          value={mutableAddress === 'loading' ? null : address}
+        />
+      )
+    }
+
+    return (
+      <YourLocationRanking
+        countryCode={config.countryCode}
+        heading={<Heading />}
+        label={config.formatLabel(config.getStateName(stateCode), electoralZone.zoneName)}
+        locationRanking={electoralZoneRanking}
+      />
+    )
+  }
+
+  function YourLocationRankSuspense({ children }: { children: React.ReactNode }) {
+    return (
+      <Suspense fallback={<DefaultPlacesSelectWrapper loading onChange={noop} value={null} />}>
+        {children}
+      </Suspense>
+    )
+  }
+
+  return {
+    YourLocationRank,
+    YourLocationRankSuspense,
+  }
 }

--- a/src/components/app/pageReferrals/us/heading.tsx
+++ b/src/components/app/pageReferrals/us/heading.tsx
@@ -12,7 +12,7 @@ export function UsPageReferralsHeading({ stateName }: UsPageReferralsHeadingProp
           ? `See which districts in ${stateName} have the most advocates.`
           : 'See which districts have the most number of Stand With Crypto advocates.'
       }
-      leaderboardTitle="District Leaderboard"
+      leaderboardTitle="Stand With Crypto Advocates by District Leaderboard"
       stateName={stateName}
     />
   )

--- a/src/components/app/pageReferrals/us/heading.tsx
+++ b/src/components/app/pageReferrals/us/heading.tsx
@@ -1,42 +1,19 @@
-'use client'
+import { PageReferralsHeading } from '@/components/app/pageReferrals/common/heading'
 
-import { PageReferrals } from '@/components/app/pageReferrals/common'
-import { PageSubTitle } from '@/components/ui/pageSubTitle'
-import { PageTitle } from '@/components/ui/pageTitleText'
-import { useHasHydrated } from '@/hooks/useHasHydrated'
-import { useSession } from '@/hooks/useSession'
-
-interface PageReferralsHeadingProps {
+interface UsPageReferralsHeadingProps {
   stateName?: string
 }
 
-export function UsPageReferralsHeading({ stateName }: PageReferralsHeadingProps) {
-  const { isLoggedIn, isLoading } = useSession()
-  const hasHydrated = useHasHydrated()
-
-  if (!isLoggedIn || isLoading || !hasHydrated || stateName) {
-    return (
-      <PageReferrals.Heading>
-        <PageTitle>District Leaderboard</PageTitle>
-        <PageSubTitle>
-          {stateName
-            ? `See which districts in ${stateName} have the most advocates.`
-            : 'See which districts have the most number of Stand With Crypto advocates.'}
-        </PageSubTitle>
-      </PageReferrals.Heading>
-    )
-  }
-
+export function UsPageReferralsHeading({ stateName }: UsPageReferralsHeadingProps) {
   return (
-    <PageReferrals.Heading>
-      <PageTitle>
-        Invite a friend to join
-        <br />
-        <span className="inline-block">Stand With Crypto</span>
-      </PageTitle>
-      <PageSubTitle>
-        Send your friends your unique referral code to encourage them to signup and take action
-      </PageSubTitle>
-    </PageReferrals.Heading>
+    <PageReferralsHeading
+      leaderboardSubtitle={
+        stateName
+          ? `See which districts in ${stateName} have the most advocates.`
+          : 'See which districts have the most number of Stand With Crypto advocates.'
+      }
+      leaderboardTitle="District Leaderboard"
+      stateName={stateName}
+    />
   )
 }

--- a/src/components/app/pageReferrals/us/heading.tsx
+++ b/src/components/app/pageReferrals/us/heading.tsx
@@ -12,7 +12,7 @@ export function UsPageReferralsHeading({ stateName }: UsPageReferralsHeadingProp
           ? `See which districts in ${stateName} have the most advocates.`
           : 'See which districts have the most number of Stand With Crypto advocates.'
       }
-      leaderboardTitle="Stand With Crypto Advocates by District Leaderboard"
+      leaderboardTitle="District Leaderboard"
       stateName={stateName}
     />
   )

--- a/src/components/app/pageReferrals/us/index.tsx
+++ b/src/components/app/pageReferrals/us/index.tsx
@@ -11,6 +11,7 @@ import { USAdvocatesLeaderboard } from '@/components/app/pageReferrals/us/leader
 import { UsUserDistrictRank } from '@/components/app/pageReferrals/us/userDistrictRank'
 import {
   UsYourDistrictRank,
+  UsYourDistrictRankingWrapper,
   UsYourDistrictRankSuspense,
 } from '@/components/app/pageReferrals/us/yourDistrictRanking'
 import { UserReferralUrlWithApi } from '@/components/app/pageUserProfile/common/userReferralUrl'
@@ -41,21 +42,23 @@ export function UsPageReferrals(props: PageReferralsProps) {
       <UsPageReferralsHeading
         stateName={stateCode ? getUSStateNameFromStateCode(stateCode) : undefined}
       />
-      <UsYourDistrictRankSuspense>
-        <UserAddressProvider countryCode={countryCode} filterByAdministrativeArea={!!stateCode}>
-          {!stateCode && (
-            <>
-              <UserReferralUrlWithApi />
-              <ReferralsCounter>
-                <UserReferralsCount />
-                <UsUserDistrictRank />
-              </ReferralsCounter>
-            </>
-          )}
+      <UsYourDistrictRankingWrapper>
+        <UsYourDistrictRankSuspense>
+          <UserAddressProvider countryCode={countryCode} filterByAdministrativeArea={!!stateCode}>
+            {!stateCode && (
+              <>
+                <UserReferralUrlWithApi />
+                <ReferralsCounter>
+                  <UserReferralsCount />
+                  <UsUserDistrictRank />
+                </ReferralsCounter>
+              </>
+            )}
 
-          <UsYourDistrictRank />
-        </UserAddressProvider>
-      </UsYourDistrictRankSuspense>
+            <UsYourDistrictRank />
+          </UserAddressProvider>
+        </UsYourDistrictRankSuspense>
+      </UsYourDistrictRankingWrapper>
       <USAdvocatesLeaderboard data={leaderboardData} />
       <div className="flex justify-center">
         <PaginationLinks

--- a/src/components/app/pageReferrals/us/leaderboard.tsx
+++ b/src/components/app/pageReferrals/us/leaderboard.tsx
@@ -1,9 +1,7 @@
-'use client'
-
 import { AdvocatesLeaderboard } from '@/components/app/pageReferrals/common/leaderboard'
 import { DistrictRankingEntryWithRank } from '@/utils/server/districtRankings/upsertRankings'
 import { getUSStateNameFromStateCode } from '@/utils/shared/stateMappings/usStateUtils'
-import { COUNTRY_CODE_TO_LOCALE, SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 interface USAdvocatesLeaderboardProps {
   data: DistrictRankingEntryWithRank[]
@@ -15,21 +13,13 @@ export function USAdvocatesLeaderboard(props: USAdvocatesLeaderboardProps) {
   const { data } = props
 
   return (
-    <AdvocatesLeaderboard>
-      <AdvocatesLeaderboard.Heading>
-        <AdvocatesLeaderboard.Heading.Title>Top districts</AdvocatesLeaderboard.Heading.Title>
-        <AdvocatesLeaderboard.Heading.Subtitle>Advocates</AdvocatesLeaderboard.Heading.Subtitle>
-      </AdvocatesLeaderboard.Heading>
-      {data.map(entry => (
-        <AdvocatesLeaderboard.Row
-          count={entry.count}
-          key={`${entry.state}-${entry.district}`}
-          locale={COUNTRY_CODE_TO_LOCALE[countryCode]}
-          rank={entry.rank}
-        >
-          <AdvocatesLeaderboard.Row.Label>{`${getUSStateNameFromStateCode(entry.state)} - District ${entry.district}`}</AdvocatesLeaderboard.Row.Label>
-        </AdvocatesLeaderboard.Row>
-      ))}
-    </AdvocatesLeaderboard>
+    <AdvocatesLeaderboard
+      countryCode={countryCode}
+      data={data}
+      formatLabel={entry =>
+        `${getUSStateNameFromStateCode(entry.state)} - District ${entry.district}`
+      }
+      title="Top districts"
+    />
   )
 }

--- a/src/components/app/pageReferrals/us/yourDistrictRanking.tsx
+++ b/src/components/app/pageReferrals/us/yourDistrictRanking.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import {
-  createYourLocationRanking,
+  YourLocationRank,
+  YourLocationRanking,
   YourLocationRankingConfig,
+  YourLocationRankSuspense,
 } from '@/components/app/pageReferrals/common/yourLocationRanking'
 import { getUSStateNameFromStateCode } from '@/utils/shared/stateMappings/usStateUtils'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
@@ -17,9 +19,14 @@ const config: YourLocationRankingConfig = {
   getStateName: getUSStateNameFromStateCode,
 }
 
-const { YourLocationRank, YourLocationRankSuspense } = createYourLocationRanking(config)
+export function UsYourDistrictRankingWrapper({ children }: { children: React.ReactNode }) {
+  return <YourLocationRanking value={config}>{children}</YourLocationRanking>
+}
 
-export {
-  YourLocationRank as UsYourDistrictRank,
-  YourLocationRankSuspense as UsYourDistrictRankSuspense,
+export function UsYourDistrictRank() {
+  return <YourLocationRank />
+}
+
+export function UsYourDistrictRankSuspense({ children }: { children: React.ReactNode }) {
+  return <YourLocationRankSuspense>{children}</YourLocationRankSuspense>
 }

--- a/src/components/app/pageReferrals/us/yourDistrictRanking.tsx
+++ b/src/components/app/pageReferrals/us/yourDistrictRanking.tsx
@@ -1,118 +1,25 @@
 'use client'
 
-import { Suspense } from 'react'
-import { noop } from 'lodash-es'
-
 import {
-  DefaultPlacesSelect,
-  DefaultPlacesSelectProps,
-} from '@/components/app/pageReferrals/common/defaultPlacesSelect'
-import { LeaderboardHeading } from '@/components/app/pageReferrals/common/leaderboard/heading'
-import { useUserAddress } from '@/components/app/pageReferrals/common/userAddress.context'
-import { YourLocale } from '@/components/app/pageReferrals/common/yourLocale'
-import { YourLocationRanking } from '@/components/app/pageReferrals/common/yourLocationRanking'
-import { GooglePlacesSelectProps } from '@/components/ui/googlePlacesSelect'
+  createYourLocationRanking,
+  YourLocationRankingConfig,
+} from '@/components/app/pageReferrals/common/yourLocationRanking'
 import { getUSStateNameFromStateCode } from '@/utils/shared/stateMappings/usStateUtils'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
-function Heading() {
-  return (
-    <LeaderboardHeading>
-      <LeaderboardHeading.Title>Your district</LeaderboardHeading.Title>
-      <LeaderboardHeading.Subtitle>Advocates</LeaderboardHeading.Subtitle>
-    </LeaderboardHeading>
-  )
+const config: YourLocationRankingConfig = {
+  countryCode: SupportedCountryCodes.US,
+  placeholder: 'Enter your address',
+  title: 'Your district',
+  notFoundMessage: 'District not found, please try a different address.',
+  notFromCountryMessage: `Looks like your address is not from the United States, so it can't be used to filter`,
+  formatLabel: (stateName: string, zoneName: string) => `${stateName} - District ${zoneName}`,
+  getStateName: getUSStateNameFromStateCode,
 }
 
-function UsDefaultPlacesSelect(props: Omit<DefaultPlacesSelectProps, 'title' | 'placeholder'>) {
-  return <DefaultPlacesSelect placeholder="Enter your address" title="Your district" {...props} />
-}
+const { YourLocationRank, YourLocationRankSuspense } = createYourLocationRanking(config)
 
-function DistrictNotFound(props: Pick<GooglePlacesSelectProps, 'onChange' | 'value' | 'loading'>) {
-  return (
-    <YourLocale>
-      <UsDefaultPlacesSelect {...props} />
-      <YourLocale.Label>District not found, please try a different address.</YourLocale.Label>
-    </YourLocale>
-  )
-}
-
-const countryCode = SupportedCountryCodes.US as const
-
-export function UsYourDistrictRank() {
-  const {
-    address,
-    setMutableAddress: setAddress,
-    mutableAddress,
-    isAddressInCountry: isAddressInUS,
-    isLoading,
-    electoralZone: district,
-    electoralZoneRanking: districtRanking,
-    administrativeArea: stateCode,
-    isAddressFromProfile,
-  } = useUserAddress()
-
-  if (isLoading) {
-    return (
-      <YourLocale>
-        <Heading />
-        <DefaultPlacesSelect.Loading />
-      </YourLocale>
-    )
-  }
-
-  if (!address) {
-    return (
-      <UsDefaultPlacesSelect
-        loading={isLoading}
-        onChange={setAddress}
-        value={mutableAddress === 'loading' ? null : mutableAddress}
-      />
-    )
-  }
-
-  if (!isAddressInUS) {
-    return (
-      <YourLocale>
-        <UsDefaultPlacesSelect
-          disabled={isAddressFromProfile}
-          onChange={setAddress}
-          value={isLoading ? null : address}
-        />
-        <YourLocale.Label>
-          Looks like your address is not from the United States, so it can't be used to filter
-        </YourLocale.Label>
-      </YourLocale>
-    )
-  }
-
-  if (!district || !stateCode || !district?.zoneName) {
-    return <DistrictNotFound onChange={setAddress} value={address} />
-  }
-
-  if (!districtRanking) {
-    return (
-      <DistrictNotFound
-        onChange={setAddress}
-        value={mutableAddress === 'loading' ? null : address}
-      />
-    )
-  }
-
-  return (
-    <YourLocationRanking
-      countryCode={countryCode}
-      heading={<Heading />}
-      label={`${getUSStateNameFromStateCode(stateCode)} - District ${district.zoneName}`}
-      locationRanking={districtRanking}
-    />
-  )
-}
-
-export function UsYourDistrictRankSuspense({ children }: { children: React.ReactNode }) {
-  return (
-    <Suspense fallback={<UsDefaultPlacesSelect loading onChange={noop} value={null} />}>
-      {children}
-    </Suspense>
-  )
+export {
+  YourLocationRank as UsYourDistrictRank,
+  YourLocationRankSuspense as UsYourDistrictRankSuspense,
 }

--- a/src/components/app/pageUserProfile/common/userReferralUrl.tsx
+++ b/src/components/app/pageUserProfile/common/userReferralUrl.tsx
@@ -2,11 +2,13 @@
 import { Copy } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useApiResponseForUserFullProfileInfo } from '@/hooks/useApiResponseForUserFullProfileInfo'
 import { useCopyTextToClipboard } from '@/hooks/useCopyTextToClipboard'
 import { useCountryCode } from '@/hooks/useCountryCode'
 import { useHasHydrated } from '@/hooks/useHasHydrated'
+import { useSession } from '@/hooks/useSession'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { externalUrls } from '@/utils/shared/urls'
 import { cn } from '@/utils/web/cn'
@@ -63,6 +65,12 @@ export function UserReferralUrlWithApi() {
   const { data, isLoading } = useApiResponseForUserFullProfileInfo()
   const countryCode = useCountryCode()
   const hasHydrated = useHasHydrated()
+
+  const { isLoggedIn, isLoading: isSessionLoading } = useSession()
+
+  if (hasHydrated && isLoggedIn && (isLoading || isSessionLoading)) {
+    return <Skeleton className="h-[76px] w-full" />
+  }
 
   if (!data?.user || isLoading || !hasHydrated) {
     return null


### PR DESCRIPTION
closes #2557 

## What changed? Why?

### Improving layout shifting on referrals page

Unfortunately, it is not possible to fix entirely the layout shift without a re-design on this page, because the user session can only be validated on client-side, which means when the page is hydrated, the signed in session will pop.
**Even so**, the UX can be improved and the shift can be less harmful. The strategy used is to:

- Add a loading skeleton to the referral link (that just appeared out of nowhere before)
- Fixed the select size to remove completely the flick on the skeleton > component transition

Now, everything pops at the exact same time to the screen, which means the sensation of shaking is not felt anymore. The screen flicks once, then stops.

**Key wins**

* Zeroed the layout shift in the signed-off screen (most of the cases) - this case used to be a small shift, but it existed.

Before | After 
---|---
<img width="465" height="353" alt="image" src="https://github.com/user-attachments/assets/5bac5080-a430-41a5-839b-05627e27778b" /> | <img width="420" height="358" alt="image" src="https://github.com/user-attachments/assets/4a384d0b-05c1-41a0-8ee5-2727b5077f45" />
<sup>The other metrics can be slightly different because of the environment</sup>

* Reduced considerably the layout shifting on the worst case (signed in)

Before | After 
---|---
<img width="465" height="357" alt="image" src="https://github.com/user-attachments/assets/1c4f7054-1a2e-498d-9f21-25ee9640c090" /><img width="461" height="59" alt="image" src="https://github.com/user-attachments/assets/dc41d467-bc62-4980-9cb6-cb7cdf669b44" /> | <img width="514" height="359" alt="image" src="https://github.com/user-attachments/assets/1baedefb-0b88-427b-b442-bf3ffa1f5229" /><img width="502" height="61" alt="image" src="https://github.com/user-attachments/assets/f6726969-b053-4b3a-8890-c7df4c3c44b0" />

**Frame-by-frame updates**

Before | After 
---|---
<img width="880" height="461" alt="image" src="https://github.com/user-attachments/assets/1da34256-a748-42a1-837c-cedce8d29538" /> | <img width="925" height="404" alt="image" src="https://github.com/user-attachments/assets/afd1aa1f-0619-4aff-8b27-1d0b88b105cc" />

The other possible changes to enhance even more the flickering needs copy changes and design changes, which means that some discussion on these topics are needed. 

### Refactoring most of the rankings components

> Reduced from 90% code duplication to 5-10% (depending on the component)

> less ~40% code (to only 3 countries, the bigger the countries count, the bigger the benefit)

* Centralized the logic on commons and passed configs instead of duplicating the whole logic.
* The main changes were just labels, so now we're mostly passing it as props.
* We still exporting the base components, so if it's needed to  change the behavior for some reason, it's possible.

Pros: 
- Much easier to implement new countries.
- Less code to write on implementation.
- Change once, reflect everywhere. (For bugs, new features, etc)

Cons:
- Slightly increases the bundle size
- The base component is used everywhere, so it's a little harder to change specific behavior on specific countries - it's solved by using the base components instead of the generic one (both are exported from common files)

## Notes for reviewers

I would suggest reviewing by commits - I've committed every single context separately, so it's easier to review by context.
Every commit is self-contained, it contains the whole refactor and a single context.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
