### PR TITLE
feat: implement GB referrals page and update related components

### DIFF
--- a/src/app/api/public/referrals/[countryCode]/[stateCode]/[districtNumber]/by-state/route.ts
+++ b/src/app/api/public/referrals/[countryCode]/[stateCode]/[districtNumber]/by-state/route.ts
@@ -8,6 +8,7 @@ import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import {
   zodAUStateDistrict,
   zodCAProvinceDistrict,
+  zodGbRegionConstituency,
   zodUSStateDistrict,
 } from '@/validation/fields/zodAddress'
 
@@ -18,7 +19,7 @@ const ZOD_SCHEMA_BY_COUNTRY_CODE_MAP: Record<SupportedCountryCodes, ZodTypeAny> 
   [SupportedCountryCodes.US]: zodUSStateDistrict,
   [SupportedCountryCodes.AU]: zodAUStateDistrict,
   [SupportedCountryCodes.CA]: zodCAProvinceDistrict,
-  [SupportedCountryCodes.GB]: undefined as unknown as ZodTypeAny, // TODO: implement GB schema
+  [SupportedCountryCodes.GB]: zodGbRegionConstituency,
 }
 
 export async function GET(

--- a/src/app/api/public/referrals/[countryCode]/[stateCode]/[districtNumber]/route.ts
+++ b/src/app/api/public/referrals/[countryCode]/[stateCode]/[districtNumber]/route.ts
@@ -8,6 +8,7 @@ import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import {
   zodAUStateDistrict,
   zodCAProvinceDistrict,
+  zodGbRegionConstituency,
   zodUSStateDistrict,
 } from '@/validation/fields/zodAddress'
 
@@ -18,7 +19,7 @@ const ZOD_SCHEMA_BY_COUNTRY_CODE_MAP: Record<SupportedCountryCodes, ZodTypeAny> 
   [SupportedCountryCodes.US]: zodUSStateDistrict,
   [SupportedCountryCodes.AU]: zodAUStateDistrict,
   [SupportedCountryCodes.CA]: zodCAProvinceDistrict,
-  [SupportedCountryCodes.GB]: undefined as unknown as ZodTypeAny, // TODO: implement GB schema
+  [SupportedCountryCodes.GB]: zodGbRegionConstituency,
 }
 
 export async function GET(

--- a/src/app/gb/config.tsx
+++ b/src/app/gb/config.tsx
@@ -43,6 +43,11 @@ export const navbarConfig: NavbarProps = {
           icon: <Icons.MissionIcon />,
         },
         {
+          href: urls.referrals(),
+          text: 'Referrals',
+          icon: <Icons.ReferralsIcon />,
+        },
+        {
           href: urls.community(),
           text: 'Community',
           icon: <Icons.CommunityIcon />,

--- a/src/app/gb/referrals/[[...page]]/page.tsx
+++ b/src/app/gb/referrals/[[...page]]/page.tsx
@@ -1,0 +1,70 @@
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { z } from 'zod'
+
+import { GB_COMMUNITY_PAGINATION_DATA } from '@/components/app/pageCommunity/gb/constants'
+import { GbRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/gb/recentActivityAndLeaderboardTabs'
+import { GbPageReferrals } from '@/components/app/pageReferrals/gb'
+import { PageProps } from '@/types'
+import { getDistrictsLeaderboardData } from '@/utils/server/districtRankings/upsertRankings'
+import { generatePaginationStaticParams } from '@/utils/server/generatePaginationStaticParams'
+import { generateMetadataDetails } from '@/utils/server/metadataUtils'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+
+export const revalidate = 60 // 1 minute
+export const dynamic = 'error'
+export const dynamicParams = true
+const countryCode = SupportedCountryCodes.GB
+
+const TOTAL_PREGENERATED_PAGES =
+  GB_COMMUNITY_PAGINATION_DATA[GbRecentActivityAndLeaderboardTabs.TOP_CONSTITUENCIES].totalPages
+
+type Props = PageProps<{ page: string[] }>
+
+export async function generateMetadata(_props: Props): Promise<Metadata> {
+  return generateMetadataDetails({
+    title: 'Constituencies Leaderboard',
+    description: 'See which constituencies have the most number of advocates',
+  })
+}
+
+const pageValidator = z.string().pipe(z.coerce.number().int().gte(1).lte(50))
+const validatePageNum = ([pageParam]: (string | undefined)[]) => {
+  if (!pageParam) {
+    return 1
+  }
+  const val = pageValidator.safeParse(pageParam)
+  if (val.success) {
+    return val.data
+  }
+  return null
+}
+
+export async function generateStaticParams() {
+  return generatePaginationStaticParams(TOTAL_PREGENERATED_PAGES)
+}
+
+export default async function ReferralsPage(props: Props) {
+  const params = await props.params
+  const { itemsPerPage } =
+    GB_COMMUNITY_PAGINATION_DATA[GbRecentActivityAndLeaderboardTabs.TOP_CONSTITUENCIES]
+  const { page } = params
+  const pageNum = validatePageNum(page ?? [])
+  if (!pageNum) {
+    notFound()
+  }
+
+  const offset = (pageNum - 1) * itemsPerPage
+
+  const commonParams = {
+    limit: itemsPerPage,
+    offset,
+    countryCode,
+  }
+
+  const { items: leaderboardData, totalPages } = await getDistrictsLeaderboardData(commonParams)
+
+  return (
+    <GbPageReferrals leaderboardData={leaderboardData} page={pageNum} totalPages={totalPages} />
+  )
+}

--- a/src/components/app/pageCommunity/gb/constants.tsx
+++ b/src/components/app/pageCommunity/gb/constants.tsx
@@ -1,3 +1,4 @@
+import { GbRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/gb/recentActivityAndLeaderboardTabs'
 import { toBool } from '@/utils/shared/toBool'
 
 const maybeIgnorePreGeneration = (num: number) =>
@@ -13,4 +14,17 @@ export const GB_RECENT_ACTIVITY_PAGINATION: PaginationConfig = {
   totalPages: 10,
   itemsPerPage: 30,
   totalPregeneratedPages: maybeIgnorePreGeneration(10),
+}
+
+export const GB_COMMUNITY_PAGINATION_DATA: Record<
+  GbRecentActivityAndLeaderboardTabs,
+  PaginationConfig
+> = {
+  [GbRecentActivityAndLeaderboardTabs.RECENT_ACTIVITY]: GB_RECENT_ACTIVITY_PAGINATION,
+
+  [GbRecentActivityAndLeaderboardTabs.TOP_CONSTITUENCIES]: {
+    totalPages: 13,
+    itemsPerPage: 50,
+    totalPregeneratedPages: maybeIgnorePreGeneration(13),
+  },
 }

--- a/src/components/app/pageHome/gb/recentActivityAndLeaderboardTabs.tsx
+++ b/src/components/app/pageHome/gb/recentActivityAndLeaderboardTabs.tsx
@@ -1,4 +1,5 @@
 // These enum values are used in the URL. If you change them, you'll break the URL.
 export enum GbRecentActivityAndLeaderboardTabs {
   RECENT_ACTIVITY = 'recent-activity',
+  TOP_CONSTITUENCIES = 'top-constituencies',
 }

--- a/src/components/app/pageReferrals/common/userAddress.context.tsx
+++ b/src/components/app/pageReferrals/common/userAddress.context.tsx
@@ -17,7 +17,7 @@ import { useMutableCurrentUserAddress } from '@/hooks/useCurrentUserAddress'
 import { useGetElectoralZoneFromAddress } from '@/hooks/useGetElectoralZoneFromAddress'
 import { useGetElectoralZoneRank } from '@/hooks/useGetElectoralZoneRank'
 import { useGoogleMapsScript } from '@/hooks/useGoogleMapsScript'
-import { StateCode } from '@/utils/server/districtRankings/types'
+import { AdministrativeArea } from '@/utils/server/districtRankings/types'
 import { ElectoralZone } from '@/utils/server/swcCivic/types'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import {
@@ -42,7 +42,7 @@ interface UserAddressContextType {
   isLoading: boolean
   electoralZone: ElectoralZone | null
   electoralZoneRanking: GetDistrictRankResponse | null
-  administrativeArea: StateCode | null
+  administrativeArea: AdministrativeArea | null
   isAddressFromProfile: boolean
 }
 
@@ -106,12 +106,13 @@ export const UserAddressProvider = ({
     return electoralZone.countryCode.toLowerCase() === countryCode.toLowerCase()
   }, [electoralZone, countryCode])
 
-  const administrativeArea = useMemo<StateCode | null>(() => {
-    if (electoralZone?.administrativeArea) return electoralZone.administrativeArea as StateCode
+  const administrativeArea = useMemo<AdministrativeArea | null>(() => {
+    if (electoralZone?.administrativeArea)
+      return electoralZone.administrativeArea as AdministrativeArea
 
     //when the administrativeArea is null, we use Google Maps as a fallback
     if (!isAddressLoading && addressDetails?.administrativeAreaLevel1) {
-      return addressDetails.administrativeAreaLevel1 as StateCode
+      return addressDetails.administrativeAreaLevel1 as AdministrativeArea
     }
 
     return null

--- a/src/components/app/pageReferrals/gb/heading.tsx
+++ b/src/components/app/pageReferrals/gb/heading.tsx
@@ -1,0 +1,19 @@
+import { PageReferralsHeading } from '@/components/app/pageReferrals/common/heading'
+
+interface GbPageReferralsHeadingProps {
+  regionName?: string
+}
+
+export function GbPageReferralsHeading({ regionName }: GbPageReferralsHeadingProps) {
+  return (
+    <PageReferralsHeading
+      leaderboardSubtitle={
+        regionName
+          ? `See which constituencies in ${regionName} have the most advocates.`
+          : 'See which constituencies have the most number of Stand With Crypto advocates.'
+      }
+      leaderboardTitle="Constituencies Leaderboard"
+      stateName={regionName}
+    />
+  )
+}

--- a/src/components/app/pageReferrals/gb/index.tsx
+++ b/src/components/app/pageReferrals/gb/index.tsx
@@ -1,0 +1,71 @@
+import { GB_COMMUNITY_PAGINATION_DATA } from '@/components/app/pageCommunity/gb/constants'
+import { GbRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/gb/recentActivityAndLeaderboardTabs'
+import { AuAdvocatesLeaderboard } from '@/components/app/pageReferrals/au/leaderboard'
+import { PageReferralsWrapper } from '@/components/app/pageReferrals/common'
+import {
+  ReferralsCounter,
+  UserReferralsCount,
+} from '@/components/app/pageReferrals/common/referralsCounter'
+import { UserAddressProvider } from '@/components/app/pageReferrals/common/userAddress.context'
+import { GbPageReferralsHeading } from '@/components/app/pageReferrals/gb/heading'
+import { GbAdvocatesLeaderboard } from '@/components/app/pageReferrals/gb/leaderboard'
+import { GbUserConstituencyRank } from '@/components/app/pageReferrals/gb/userConstituencyRank'
+import {
+  GbYourConstituencyRank,
+  GbYourConstituencyRankingWrapper,
+  GbYourConstituencyRankSuspense,
+} from '@/components/app/pageReferrals/gb/yourConstituencyRanking'
+import { UserReferralUrlWithApi } from '@/components/app/pageUserProfile/common/userReferralUrl'
+import { PaginationLinks } from '@/components/ui/paginationLinks'
+import { DistrictRankingEntryWithRank } from '@/utils/server/districtRankings/upsertRankings'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { getIntlUrls } from '@/utils/shared/urls'
+
+interface PageReferralsProps {
+  leaderboardData: DistrictRankingEntryWithRank[]
+  page: number
+  region?: string
+  totalPages?: number
+}
+
+const countryCode = SupportedCountryCodes.GB as const
+
+export function GbPageReferrals(props: PageReferralsProps) {
+  const { page, leaderboardData, region } = props
+
+  const tab = GbRecentActivityAndLeaderboardTabs.TOP_CONSTITUENCIES
+  const urls = getIntlUrls(countryCode)
+  const totalPages = props.totalPages || GB_COMMUNITY_PAGINATION_DATA[tab].totalPages
+
+  return (
+    <PageReferralsWrapper>
+      <GbPageReferralsHeading regionName={region} />
+
+      <GbYourConstituencyRankingWrapper>
+        <GbYourConstituencyRankSuspense>
+          <UserAddressProvider countryCode={countryCode} filterByAdministrativeArea={!!region}>
+            {!region && (
+              <>
+                <UserReferralUrlWithApi />
+                <ReferralsCounter>
+                  <UserReferralsCount />
+                  <GbUserConstituencyRank />
+                </ReferralsCounter>
+              </>
+            )}
+
+            <GbYourConstituencyRank />
+          </UserAddressProvider>
+        </GbYourConstituencyRankSuspense>
+      </GbYourConstituencyRankingWrapper>
+      <GbAdvocatesLeaderboard data={leaderboardData} />
+      <div className="flex justify-center">
+        <PaginationLinks
+          currentPageNumber={page}
+          getPageUrl={pageNumber => urls.referrals({ pageNum: pageNumber, stateCode: region })}
+          totalPages={totalPages}
+        />
+      </div>
+    </PageReferralsWrapper>
+  )
+}

--- a/src/components/app/pageReferrals/gb/leaderboard.tsx
+++ b/src/components/app/pageReferrals/gb/leaderboard.tsx
@@ -1,0 +1,22 @@
+import { AdvocatesLeaderboard } from '@/components/app/pageReferrals/common/leaderboard'
+import { DistrictRankingEntryWithRank } from '@/utils/server/districtRankings/upsertRankings'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+
+interface GbAdvocatesLeaderboardProps {
+  data: DistrictRankingEntryWithRank[]
+}
+
+const countryCode = SupportedCountryCodes.GB as const
+
+export function GbAdvocatesLeaderboard(props: GbAdvocatesLeaderboardProps) {
+  const { data } = props
+
+  return (
+    <AdvocatesLeaderboard
+      countryCode={countryCode}
+      data={data}
+      formatLabel={entry => `${entry.state} - ${entry.district}`}
+      title="Top constituencies"
+    />
+  )
+}

--- a/src/components/app/pageReferrals/gb/userConstituencyRank.tsx
+++ b/src/components/app/pageReferrals/gb/userConstituencyRank.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { UserLocationRanking } from '@/components/app/pageReferrals/common/userLocationRank'
+
+export function GbUserConstituencyRank({ className }: { className?: string }) {
+  return (
+    <UserLocationRanking
+      className={className}
+      finishProfileText="Finish your profile to see your constituency ranking"
+      label="Constituency ranking"
+      notFoundText="N/A"
+    />
+  )
+}

--- a/src/components/app/pageReferrals/gb/yourConstituencyRanking.tsx
+++ b/src/components/app/pageReferrals/gb/yourConstituencyRanking.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import {
+  YourLocationRank,
+  YourLocationRanking,
+  YourLocationRankingConfig,
+  YourLocationRankSuspense,
+} from '@/components/app/pageReferrals/common/yourLocationRanking'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+
+const config: YourLocationRankingConfig = {
+  countryCode: SupportedCountryCodes.GB,
+  placeholder: 'Enter your address',
+  title: 'Your constituency',
+  notFoundMessage: 'Constituency not found, please try a different address.',
+  notFromCountryMessage: `Looks like your address is not from the UK, so it can't be used to filter`,
+  formatLabel: (stateName: string, zoneName: string) => `${stateName} - ${zoneName}`,
+  getStateName: (regionName: string) => regionName,
+}
+
+export function GbYourConstituencyRankingWrapper({ children }: { children: React.ReactNode }) {
+  return <YourLocationRanking value={config}>{children}</YourLocationRanking>
+}
+
+export function GbYourConstituencyRank() {
+  return <YourLocationRank />
+}
+
+export function GbYourConstituencyRankSuspense({ children }: { children: React.ReactNode }) {
+  return <YourLocationRankSuspense>{children}</YourLocationRankSuspense>
+}

--- a/src/hooks/useGetElectoralZoneRank.ts
+++ b/src/hooks/useGetElectoralZoneRank.ts
@@ -1,14 +1,14 @@
 import useSWR, { SWRConfiguration } from 'swr'
 
 import { GetDistrictRankResponse } from '@/app/api/public/referrals/[countryCode]/[stateCode]/[districtNumber]/route'
-import { StateCode } from '@/utils/server/districtRankings/types'
+import { AdministrativeArea } from '@/utils/server/districtRankings/types'
 import { fetchReq } from '@/utils/shared/fetchReq'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { apiUrls } from '@/utils/shared/urls'
 
 interface useGetElectoralZoneRankProps {
   countryCode: SupportedCountryCodes
-  stateCode: StateCode | null
+  stateCode: AdministrativeArea | null
   electoralZone: string | null
   filteredByState?: boolean
   config?: SWRConfiguration<GetDistrictRankResponse>

--- a/src/inngest/functions/districtsRankings/updateRankings.ts
+++ b/src/inngest/functions/districtsRankings/updateRankings.ts
@@ -20,6 +20,7 @@ import {
 import { US_STATE_CODE_TO_DISTRICT_COUNT_MAP } from '@/utils/shared/stateMappings/usStateDistrictUtils'
 import { USStateCode } from '@/utils/shared/stateMappings/usStateUtils'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { GB_REGIONS } from '@/utils/shared/stateMappings/gbCountryUtils'
 
 const UPDATE_DISTRICT_RANKINGS_CRON_JOB_FUNCTION_ID = 'script.update-districts-rankings'
 const UPDATE_DISTRICT_RANKINGS_CRON_JOB_SCHEDULE = '0 */1 * * *' // every 1 hour
@@ -34,7 +35,7 @@ const COUNTRY_CODE_TO_STATES_CODES_MAP: Record<SupportedCountryCodes, string[]> 
   [SupportedCountryCodes.CA]: Object.keys(
     CA_PROVINCES_AND_TERRITORIES_CODE_TO_DISPLAY_NAME_MAP,
   ) as CAProvinceOrTerritoryCode[],
-  [SupportedCountryCodes.GB]: [],
+  [SupportedCountryCodes.GB]: GB_REGIONS,
   [SupportedCountryCodes.AU]: Object.keys(AU_STATE_CODE_TO_DISPLAY_NAME_MAP) as AUStateCode[],
 }
 
@@ -42,6 +43,7 @@ const COUNTRIES_TO_UPDATE_RANKINGS_FOR = [
   SupportedCountryCodes.US,
   SupportedCountryCodes.CA,
   SupportedCountryCodes.AU,
+  SupportedCountryCodes.GB,
 ]
 
 interface ExecutionResult {

--- a/src/utils/server/districtRankings/gb/getRankingData.ts
+++ b/src/utils/server/districtRankings/gb/getRankingData.ts
@@ -1,0 +1,79 @@
+import { UserActionType } from '@prisma/client'
+
+import {
+  AdvocatesCountByDistrictQueryResult,
+  ReferralsCountByDistrictQueryResult,
+} from '@/utils/server/districtRankings/types'
+import { prismaClient } from '@/utils/server/prismaClient'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { GB_REGIONS, GBRegion } from '@/utils/shared/stateMappings/gbCountryUtils'
+
+export interface AdvocatesCountResult {
+  state: string
+  district: string
+  count: number
+}
+
+function isValidConstituency(constituency: string): boolean {
+  return GB_REGIONS.includes(constituency)
+}
+
+export async function getGBAdvocatesCountByConstituency(
+  region: GBRegion,
+): Promise<AdvocatesCountResult[]> {
+  const results = await prismaClient.$queryRaw<AdvocatesCountByDistrictQueryResult[]>`
+    SELECT
+      a.swc_civic_administrative_area as state,
+      a.electoral_zone as district,
+      COUNT(DISTINCT u.id) as count
+    FROM user_action ua
+    INNER JOIN user u ON ua.user_id = u.id
+    INNER JOIN address a ON u.address_id = a.id
+    WHERE ua.action_type = ${UserActionType.OPT_IN}
+      AND a.country_code = ${SupportedCountryCodes.GB}
+      AND a.swc_civic_administrative_area = ${region}
+    GROUP BY
+      state,
+      district
+    HAVING COUNT(DISTINCT u.id) > 0
+  `
+
+  return results
+    .filter(result => isValidConstituency(result.state))
+    .map(({ state, district, count }) => ({
+      state: state as GBRegion,
+      district: district!,
+      count: Number(count),
+    }))
+}
+
+export async function getGBReferralsCountByConstituency(
+  region: GBRegion,
+): Promise<AdvocatesCountResult[]> {
+  const results = await prismaClient.$queryRaw<ReferralsCountByDistrictQueryResult[]>`
+    SELECT
+      a.swc_civic_administrative_area as state,
+      a.electoral_zone as district,
+      COUNT(DISTINCT ua.id) as refer_actions_count,
+      SUM(uar.referrals_count) as referrals
+    FROM user_action ua
+    INNER JOIN user_action_refer uar ON ua.id = uar.id
+    INNER JOIN address a ON uar.address_id = a.id
+    WHERE ua.action_type = ${UserActionType.REFER}
+      AND uar.referrals_count > 0
+      AND a.country_code = ${SupportedCountryCodes.GB}
+      AND a.swc_civic_administrative_area = ${region}
+    GROUP BY
+      state,
+      district
+    HAVING SUM(uar.referrals_count) > 0
+  `
+
+  return results
+    .filter(result => isValidConstituency(result.state))
+    .map(result => ({
+      state: result.state as GBRegion,
+      district: result.district!,
+      count: Number(result.referrals),
+    }))
+}

--- a/src/utils/server/districtRankings/getRankingData.ts
+++ b/src/utils/server/districtRankings/getRankingData.ts
@@ -7,23 +7,29 @@ import {
   getCAReferralsCountByDistrict,
 } from '@/utils/server/districtRankings/ca/getRankingData'
 import {
+  getGBAdvocatesCountByConstituency,
+  getGBReferralsCountByConstituency,
+} from '@/utils/server/districtRankings/gb/getRankingData'
+import {
   getUSAdvocatesCountByDistrict,
   getUSReferralsCountByDistrict,
 } from '@/utils/server/districtRankings/us/getRankingData'
 import { AUStateCode } from '@/utils/shared/stateMappings/auStateUtils'
 import { CAProvinceOrTerritoryCode } from '@/utils/shared/stateMappings/caProvinceUtils'
+import { GBRegion } from '@/utils/shared/stateMappings/gbCountryUtils'
 import { USStateCode } from '@/utils/shared/stateMappings/usStateUtils'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 export interface AdvocatesCountResult {
-  state: USStateCode | CAProvinceOrTerritoryCode | AUStateCode
+  // string because GB regions are string on the database
+  state: USStateCode | CAProvinceOrTerritoryCode | AUStateCode | GBRegion
   district: string
   count: number
 }
 
 interface StateCode {
   [SupportedCountryCodes.US]: USStateCode
-  [SupportedCountryCodes.GB]: string // TODO: Implement
+  [SupportedCountryCodes.GB]: GBRegion
   [SupportedCountryCodes.CA]: CAProvinceOrTerritoryCode
   [SupportedCountryCodes.AU]: AUStateCode
 }
@@ -36,9 +42,7 @@ const GET_ADVOCATES_BY_COUNTRY_CODE_MAP: {
   [K in SupportedCountryCodes]: GetAdvocatesFunction<K>
 } = {
   [SupportedCountryCodes.US]: getUSAdvocatesCountByDistrict,
-  [SupportedCountryCodes.GB]: async () => {
-    throw new Error('Not implemented')
-  },
+  [SupportedCountryCodes.GB]: getGBAdvocatesCountByConstituency,
   [SupportedCountryCodes.CA]: getCAAdvocatesCountByDistrict,
   [SupportedCountryCodes.AU]: getAUAdvocatesCountByDistrict,
 }
@@ -47,9 +51,7 @@ const GET_REFERRALS_BY_COUNTRY_CODE_MAP: {
   [K in SupportedCountryCodes]: GetAdvocatesFunction<K>
 } = {
   [SupportedCountryCodes.US]: getUSReferralsCountByDistrict,
-  [SupportedCountryCodes.GB]: async () => {
-    throw new Error('Not implemented')
-  },
+  [SupportedCountryCodes.GB]: getGBReferralsCountByConstituency,
   [SupportedCountryCodes.CA]: getCAReferralsCountByDistrict,
   [SupportedCountryCodes.AU]: getAUReferralsCountByDistrict,
 }

--- a/src/utils/server/districtRankings/types.ts
+++ b/src/utils/server/districtRankings/types.ts
@@ -1,8 +1,9 @@
 import { AUStateCode } from '@/utils/shared/stateMappings/auStateUtils'
 import { CAProvinceOrTerritoryCode } from '@/utils/shared/stateMappings/caProvinceUtils'
+import { GBRegion } from '@/utils/shared/stateMappings/gbCountryUtils'
 import { USStateCode } from '@/utils/shared/stateMappings/usStateUtils'
 
-export type StateCode = USStateCode | CAProvinceOrTerritoryCode | AUStateCode
+export type AdministrativeArea = USStateCode | CAProvinceOrTerritoryCode | AUStateCode | GBRegion
 
 export interface AdvocatesCountByDistrictQueryResult {
   state: string

--- a/src/utils/server/districtRankings/upsertRankings.ts
+++ b/src/utils/server/districtRankings/upsertRankings.ts
@@ -2,7 +2,7 @@
 
 import { chunk } from 'lodash-es'
 
-import { StateCode } from '@/utils/server/districtRankings/types'
+import { AdministrativeArea } from '@/utils/server/districtRankings/types'
 import { redis, redisWithCache } from '@/utils/server/redis'
 import { getLogger } from '@/utils/shared/logger'
 import { US_STATE_CODE_TO_DISTRICT_COUNT_MAP } from '@/utils/shared/stateMappings/usStateDistrictUtils'
@@ -10,12 +10,12 @@ import { USStateCode } from '@/utils/shared/stateMappings/usStateUtils'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 export interface DistrictRankingEntry {
-  state: StateCode
+  state: AdministrativeArea
   district: string
   count: number
 }
 
-export type MemberKey = `${StateCode}:${string}`
+export type MemberKey = `${AdministrativeArea}:${string}`
 type RedisEntryData = Omit<DistrictRankingEntry, 'count'>
 
 const getLog = (redisKey: string) => getLogger(redisKey)
@@ -60,7 +60,7 @@ export const getMemberKey = (data: RedisEntryData): MemberKey => `${data.state}:
 const parseMemberKey = (key: MemberKey): RedisEntryData => {
   const parts = key.split(':')
   const [state, district] = parts
-  return { state: state as StateCode, district }
+  return { state: state as AdministrativeArea, district }
 }
 
 async function maybeInitializeUSCacheKey(countryCode: SupportedCountryCodes) {

--- a/src/utils/shared/stateMappings/gbCountryUtils.ts
+++ b/src/utils/shared/stateMappings/gbCountryUtils.ts
@@ -5,6 +5,23 @@ export const GB_MAIN_COUNTRY_CODE_TO_DISPLAY_NAME_MAP = {
   WLS: 'Wales',
 } as const
 
+export const GB_REGIONS: string[] = [
+  'Wales',
+  'Northern Ireland',
+  'London',
+  'Scotland',
+  'East of England',
+  'North East England',
+  'South West England',
+  'North West England',
+  'East Midlands England',
+  'South East England',
+  'West Midlands England',
+  'Yorkshire and The Humber',
+]
+
+export type GBRegion = (typeof GB_REGIONS)[number]
+
 export type GBCountryCode = keyof typeof GB_MAIN_COUNTRY_CODE_TO_DISPLAY_NAME_MAP
 
 export const getGBCountryNameFromCode = (code: string) => {

--- a/src/validation/fields/zodAddress.ts
+++ b/src/validation/fields/zodAddress.ts
@@ -13,6 +13,7 @@ import {
   US_STATE_CODE_TO_DISPLAY_NAME_MAP,
   USStateCode,
 } from '@/utils/shared/stateMappings/usStateUtils'
+import { GB_REGIONS, GBRegion } from '@/utils/shared/stateMappings/gbCountryUtils'
 
 export const zodAddress = object({
   googlePlaceId: string().optional(),
@@ -76,5 +77,10 @@ export const zodCAProvinceDistrict = object({
       val in CA_PROVINCES_AND_TERRITORIES_CODE_TO_DISPLAY_NAME_MAP,
     'Invalid province/territory code',
   ),
+  district: string(),
+})
+
+export const zodGbRegionConstituency = object({
+  state: string().refine((val): val is GBRegion => GB_REGIONS.includes(val), 'Invalid state code'),
   district: string(),
 })


### PR DESCRIPTION
closes #2511 

## What changed? Why?

- Add new referrals page for Great Britain, including constituency rankings and leaderboards.
- Introduce GB-specific components for handling user constituency rankings and displaying referral data.
- Update API routes and validation schemas to support GB data structures.
- Enhance navigation by adding a "Referrals" link in the GB navbar.
- Refactor existing components to accommodate the new GB structure and improve code organization.
## PlanetScale deploy request

<!-- See "Updating the PlanetScale schema" section in docs/Contributing.md -->

## Notes to reviewers

- [ ] AI Generated

<!-- Here’s where you can give brief guidance on how to review the PR.
(Often it’s helpful to tell reviewers where the “main change” of the PR can be found,
if other diffs in the PR are “ripples” caused by it.)
You can also highlight anything to which you’d like to draw reviewers’ attention. -->

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
