### PR TITLE
Fixing polls other input limit

### DIFF
--- a/src/components/app/pagePolls/pollItem.tsx
+++ b/src/components/app/pagePolls/pollItem.tsx
@@ -20,6 +20,8 @@ interface PollItemProps {
   shouldShowOtherField?: boolean
 }
 
+const FIELD_MAX_LENGTH = 191
+
 export function PollItem({
   value,
   displayName,
@@ -90,6 +92,7 @@ export function PollItem({
               className="hidden"
               {...register('answers')}
               disabled={isDisabled}
+              maxLength={FIELD_MAX_LENGTH}
               type="radio"
               value={value}
             />


### PR DESCRIPTION
fixes PROD-SWC-WEB-CV1

## What changed? Why?
- Fixing other input length limit. Because customer today can put more then 191 characters.

## How has it been tested?

- [X] Locally
- [X] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
