### PR TITLE
Fixing recent activity by date limit in dtsi query

### DIFF
--- a/src/data/dtsi/queries/queryDTSIPeopleBySlugForUserActions.ts
+++ b/src/data/dtsi/queries/queryDTSIPeopleBySlugForUserActions.ts
@@ -6,7 +6,7 @@ import { DTSI_PeopleBySlugQuery, DTSI_PeopleBySlugQueryVariables } from '@/data/
 
 const query = /* GraphQL */ `
   query PeopleBySlug($slugs: [String!]!) {
-    people(limit: 100, offset: 0, slugIn: $slugs) {
+    people(limit: 1000, offset: 0, slugIn: $slugs) {
       ...PersonCard
     }
   }

--- a/src/data/recentActivity/getPublicRecentActivityByDateRange.ts
+++ b/src/data/recentActivity/getPublicRecentActivityByDateRange.ts
@@ -27,15 +27,13 @@ const fetchFromPrisma = async (config: RecentActivityByDateRangeConfig) => {
     },
   }
 
-  const limit = 1000
-
   const [data, count] = await Promise.all([
     prismaClient.userAction
       .findMany({
         orderBy: {
           datetimeCreated: 'desc',
         },
-        take: limit,
+        take: 1000,
         skip: config.offset,
         include: {
           user: {
@@ -76,7 +74,7 @@ const fetchFromPrisma = async (config: RecentActivityByDateRangeConfig) => {
           ({ user: { internalStatus } }) => internalStatus === UserInternalStatus.VISIBLE,
         ),
       ),
-    prismaClient.userAction.count({ where, take: limit }),
+    prismaClient.userAction.count({ where }),
   ])
 
   return { count, data }

--- a/src/data/recentActivity/getPublicRecentActivityByDateRange.ts
+++ b/src/data/recentActivity/getPublicRecentActivityByDateRange.ts
@@ -27,13 +27,15 @@ const fetchFromPrisma = async (config: RecentActivityByDateRangeConfig) => {
     },
   }
 
+  const limit = 1000
+
   const [data, count] = await Promise.all([
     prismaClient.userAction
       .findMany({
         orderBy: {
           datetimeCreated: 'desc',
         },
-        take: 1000,
+        take: limit,
         skip: config.offset,
         include: {
           user: {
@@ -74,7 +76,7 @@ const fetchFromPrisma = async (config: RecentActivityByDateRangeConfig) => {
           ({ user: { internalStatus } }) => internalStatus === UserInternalStatus.VISIBLE,
         ),
       ),
-    prismaClient.userAction.count({ where }),
+    prismaClient.userAction.count({ where, take: limit }),
   ])
 
   return { count, data }


### PR DESCRIPTION
## Description
This PR implements changes to address #2595.

## What changed? Why?
- Changed query to get person in DTSI changing limit to `1000`, because the limit on SWC DB side is `1000` and we need to reach same limit to get all person's from DTSI API.

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
