### PR TITLE
fix: reduce timeout duration for ENS data retrieval from 30 seconds to 10 seconds

### DIFF
--- a/src/data/web3/getENSDataFromCryptoAddress.ts
+++ b/src/data/web3/getENSDataFromCryptoAddress.ts
@@ -24,7 +24,7 @@ async function _getENSDataMapFromCryptoAddresses(
         return null
       }),
     ),
-    SECONDS_DURATION['30_SECONDS'] * 1000,
+    SECONDS_DURATION['10_SECONDS'] * 1000,
   )
 
   const addressesWithENS = nameResult
@@ -40,7 +40,7 @@ async function _getENSDataMapFromCryptoAddresses(
         name: address.ensName!,
       }),
     ),
-    SECONDS_DURATION['30_SECONDS'] * 1000,
+    SECONDS_DURATION['10_SECONDS'] * 1000,
   )
 
   return addressesWithENS.reduce(

--- a/src/utils/shared/seconds.ts
+++ b/src/utils/shared/seconds.ts
@@ -15,5 +15,6 @@ export const SECONDS_DURATION = {
   MINUTE: 60,
   '2_MINUTES': 120,
   '30_SECONDS': 30,
+  '10_SECONDS': 10,
   SECOND: 1,
 }


### PR DESCRIPTION
## Description
This PR addresses persistent timeout issues in our server requests related to ENS (Ethereum Name Service) data retrieval.
[Vercel Logs for this error.](https://vercel.com/coinbase-vercel/swc-web/logs?statusCodes=504&selectedLogId=c52jv-1755692933749-c34830066b36&page=6&startDate=1755692880&endDate=1755692940)

## What changed? Why?
- Added a new SECONDS_DURATION value.
- Changed the timeout for ENS data retrieval from 30 to 10 seconds.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
