### PR TITLE
feat: add links to advocates rankings on GB

### DIFF
--- a/src/app/gb/community/referrals/[[...page]]/page.tsx
+++ b/src/app/gb/community/referrals/[[...page]]/page.tsx
@@ -1,13 +1,19 @@
 import React from 'react'
 import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
 
+import { validatePageNum } from '@/components/app/pageCommunity/common/pageValidator'
 import { GbPageCommunity, PageLeaderboardInferredProps } from '@/components/app/pageCommunity/gb'
-import { GB_RECENT_ACTIVITY_PAGINATION } from '@/components/app/pageCommunity/gb/constants'
-import { getGbPageData } from '@/components/app/pageCommunity/getPageData'
+import {
+  GB_COMMUNITY_PAGINATION_DATA,
+  GB_RECENT_ACTIVITY_PAGINATION,
+} from '@/components/app/pageCommunity/gb/constants'
 import { GbRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/gb/recentActivityAndLeaderboardTabs'
 import { PageProps } from '@/types'
+import { getDistrictsLeaderboardData } from '@/utils/server/districtRankings/upsertRankings'
 import { generatePaginationStaticParams } from '@/utils/server/generatePaginationStaticParams'
 import { generateMetadataDetails } from '@/utils/server/metadataUtils'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 export const revalidate = 30 // 30 seconds
 export const dynamic = 'error'
@@ -32,14 +38,30 @@ export default async function GbCommunityRecentActivityPage(
   props: GbCommunityRecentActivityPageProps,
 ) {
   const params = await props.params
-  const { offset, pageNum, publicRecentActivity, totalPages } = await getGbPageData({
-    page: params.page,
-  })
+  const { itemsPerPage } =
+    GB_COMMUNITY_PAGINATION_DATA[GbRecentActivityAndLeaderboardTabs.TOP_CONSTITUENCIES]
+
+  const { page } = params
+  const pageNum = validatePageNum(page ?? [])
+
+  if (!pageNum) {
+    notFound()
+  }
+
+  const offset = (pageNum - 1) * itemsPerPage
+
+  const commonParams = {
+    limit: itemsPerPage,
+    offset,
+    countryCode: SupportedCountryCodes.GB,
+  }
+
+  const { items: leaderboardData, totalPages } = await getDistrictsLeaderboardData(commonParams)
 
   const dataProps: PageLeaderboardInferredProps = {
-    leaderboardData: undefined,
-    publicRecentActivity,
-    tab: GbRecentActivityAndLeaderboardTabs.RECENT_ACTIVITY,
+    leaderboardData,
+    publicRecentActivity: undefined,
+    tab: GbRecentActivityAndLeaderboardTabs.TOP_CONSTITUENCIES,
   }
 
   return (

--- a/src/app/gb/config.tsx
+++ b/src/app/gb/config.tsx
@@ -43,6 +43,11 @@ export const navbarConfig: NavbarProps = {
           icon: <Icons.MissionIcon />,
         },
         {
+          href: urls.referrals(),
+          text: 'Referrals',
+          icon: <Icons.ReferralsIcon />,
+        },
+        {
           href: urls.community(),
           text: 'Community',
           icon: <Icons.CommunityIcon />,

--- a/src/app/gb/page.tsx
+++ b/src/app/gb/page.tsx
@@ -4,6 +4,7 @@ import { getAdvocatesMapData } from '@/data/pageSpecific/getAdvocatesMapData'
 import { getHomepageData, getHomepageTopLevelMetrics } from '@/data/pageSpecific/getHomepageData'
 import { getFounders } from '@/utils/server/builder/models/data/founders'
 import { getPartners } from '@/utils/server/builder/models/data/partners'
+import { getDistrictsLeaderboardData } from '@/utils/server/districtRankings/upsertRankings'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 export const revalidate = 60 // 1 minute
@@ -19,6 +20,7 @@ export default async function GbHomePage() {
     partners,
     founders,
     dtsiHomepagePoliticians,
+    leaderboardData,
   ] = await Promise.all([
     getHomepageData({
       recentActivityLimit: 30,
@@ -29,6 +31,7 @@ export default async function GbHomePage() {
     getPartners({ countryCode }),
     getFounders({ countryCode }),
     queryDTSIHomepagePeople({ countryCode }),
+    getDistrictsLeaderboardData({ limit: 10, countryCode }),
   ])
 
   return (
@@ -36,6 +39,7 @@ export default async function GbHomePage() {
       advocatePerStateDataProps={advocatePerStateDataProps}
       dtsiHomepagePoliticians={dtsiHomepagePoliticians}
       founders={founders}
+      leaderboardData={leaderboardData.items}
       partners={partners}
       topLevelMetrics={topLevelMetrics}
       {...asyncProps}

--- a/src/components/app/homepageDialogDeeplinkLayout/gb/index.tsx
+++ b/src/components/app/homepageDialogDeeplinkLayout/gb/index.tsx
@@ -10,6 +10,7 @@ import { getAdvocatesMapData } from '@/data/pageSpecific/getAdvocatesMapData'
 import { getHomepageData, getHomepageTopLevelMetrics } from '@/data/pageSpecific/getHomepageData'
 import { getFounders } from '@/utils/server/builder/models/data/founders'
 import { getPartners } from '@/utils/server/builder/models/data/partners'
+import { getDistrictsLeaderboardData } from '@/utils/server/districtRankings/upsertRankings'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 
 const countryCode = SupportedCountryCodes.GB
@@ -31,6 +32,7 @@ export async function GBHomepageDialogDeeplinkLayout({
     partners,
     founders,
     dtsiHomepagePoliticians,
+    leaderboardData,
   ] = await Promise.all([
     getHomepageData({
       recentActivityLimit: 30,
@@ -41,6 +43,7 @@ export async function GBHomepageDialogDeeplinkLayout({
     getPartners({ countryCode }),
     getFounders({ countryCode }),
     queryDTSIHomepagePeople({ countryCode }),
+    getDistrictsLeaderboardData({ limit: 10, countryCode }),
   ])
 
   return (
@@ -57,6 +60,7 @@ export async function GBHomepageDialogDeeplinkLayout({
         advocatePerStateDataProps={advocatePerStateDataProps}
         dtsiHomepagePoliticians={dtsiHomepagePoliticians}
         founders={founders}
+        leaderboardData={leaderboardData.items}
         partners={partners}
         topLevelMetrics={topLevelMetrics}
         {...asyncProps}

--- a/src/components/app/pageCommunity/gb/index.tsx
+++ b/src/components/app/pageCommunity/gb/index.tsx
@@ -1,21 +1,72 @@
 import { GB_RECENT_ACTIVITY_PAGINATION } from '@/components/app/pageCommunity/gb/constants'
-import { getGbPageData } from '@/components/app/pageCommunity/gb/getPageData'
 import { GbRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/gb/recentActivityAndLeaderboardTabs'
+import { UserAddressProvider } from '@/components/app/pageReferrals/common/userAddress.context'
+import { GbAdvocatesLeaderboard } from '@/components/app/pageReferrals/gb/leaderboard'
+import {
+  GbYourConstituencyRank,
+  GbYourConstituencyRankingWrapper,
+  GbYourConstituencyRankSuspense,
+} from '@/components/app/pageReferrals/gb/yourConstituencyRanking'
 import { RecentActivity } from '@/components/app/recentActivity'
+import { InternalLink } from '@/components/ui/link'
 import { PageLayout } from '@/components/ui/pageLayout'
+import { PaginationLinks } from '@/components/ui/paginationLinks'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { tabListStyles, tabTriggerStyles } from '@/components/ui/tabs/styles'
+import { PublicRecentActivity } from '@/data/recentActivity/getPublicRecentActivity'
+import { DistrictRankingEntryWithRank } from '@/utils/server/districtRankings/upsertRankings'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { getIntlUrls } from '@/utils/shared/urls'
-
-type GbPageLeaderboardProps = Awaited<ReturnType<typeof getGbPageData>>
+import { cn } from '@/utils/web/cn'
 
 const countryCode = SupportedCountryCodes.GB
 const urls = getIntlUrls(countryCode)
 
+export type PageLeaderboardInferredProps =
+  | {
+      tab: GbRecentActivityAndLeaderboardTabs.RECENT_ACTIVITY
+      publicRecentActivity: PublicRecentActivity
+      leaderboardData: undefined
+    }
+  | {
+      tab: GbRecentActivityAndLeaderboardTabs.TOP_CONSTITUENCIES
+      publicRecentActivity: undefined
+      leaderboardData: DistrictRankingEntryWithRank[]
+    }
+
+const TAB_OPTIONS: {
+  value: GbRecentActivityAndLeaderboardTabs
+  label: string
+}[] = [
+  {
+    value: GbRecentActivityAndLeaderboardTabs.RECENT_ACTIVITY,
+    label: 'Recent activity',
+  },
+  {
+    value: GbRecentActivityAndLeaderboardTabs.TOP_CONSTITUENCIES,
+    label: 'Top constituencies',
+  },
+]
+
+type GbPageCommunityProps = PageLeaderboardInferredProps & {
+  offset: number
+  pageNum: number
+  totalPages?: number
+}
+
 export function GbPageCommunity({
   pageNum,
   publicRecentActivity,
-  totalPages,
-}: GbPageLeaderboardProps) {
+  totalPages = 1,
+  tab,
+  leaderboardData,
+}: GbPageCommunityProps) {
   return (
     <PageLayout>
       <PageLayout.Title>Our community</PageLayout.Title>
@@ -23,29 +74,110 @@ export function GbPageCommunity({
         See how the community is taking a stand to safeguard the future of crypto in the UK.
       </PageLayout.Subtitle>
 
-      <RecentActivity>
-        {pageNum === 1 ? (
-          <RecentActivity.DynamicList
-            actions={publicRecentActivity}
-            countryCode={countryCode}
-            pageSize={GB_RECENT_ACTIVITY_PAGINATION.itemsPerPage}
-          />
-        ) : (
-          <RecentActivity.List actions={publicRecentActivity} />
+      <div className="text-center">
+        {/* Mobile: Select */}
+        <div className="sm:hidden">
+          <Select value={tab}>
+            <SelectTrigger className="mx-auto mb-10 min-h-14 w-full rounded-full bg-secondary px-4 text-base font-semibold">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="rounded-2xl font-bold">
+              <SelectItem
+                className="pl-4 text-muted-foreground opacity-100"
+                disabled
+                value={'first'}
+              >
+                Select View
+              </SelectItem>
+              {TAB_OPTIONS.map(option => (
+                <SelectItem key={option.value} value={option.value}>
+                  <InternalLink
+                    className={cn(tabTriggerStyles, 'px-0')}
+                    href={urls.community({
+                      tab: option.value,
+                    })}
+                  >
+                    {option.label}
+                  </InternalLink>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Desktop: TabsList */}
+        <div className="mb-8 hidden text-center sm:mb-4 sm:block">
+          <div className={cn(tabListStyles, 'mx-auto')}>
+            {TAB_OPTIONS.map(option => (
+              <InternalLink
+                className={tabTriggerStyles}
+                data-state={tab === option.value ? 'active' : undefined}
+                href={urls.community({
+                  tab: option.value,
+                })}
+                key={option.value}
+              >
+                {option.label}
+              </InternalLink>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-8 lg:space-y-10">
+        {tab === GbRecentActivityAndLeaderboardTabs.RECENT_ACTIVITY && (
+          <RecentActivity>
+            {pageNum === 1 ? (
+              <RecentActivity.DynamicList
+                actions={publicRecentActivity}
+                countryCode={countryCode}
+                pageSize={GB_RECENT_ACTIVITY_PAGINATION.itemsPerPage}
+              />
+            ) : (
+              <RecentActivity.List actions={publicRecentActivity} />
+            )}
+            <RecentActivity.Footer className="flex justify-center">
+              <RecentActivity.Pagination
+                currentPageNumber={pageNum}
+                getPageUrl={pageNumber =>
+                  urls.community({
+                    pageNum: pageNumber,
+                    tab: GbRecentActivityAndLeaderboardTabs.RECENT_ACTIVITY,
+                  })
+                }
+                totalPages={totalPages}
+              />
+            </RecentActivity.Footer>
+          </RecentActivity>
         )}
-        <RecentActivity.Footer className="flex justify-center">
-          <RecentActivity.Pagination
-            currentPageNumber={pageNum}
-            getPageUrl={pageNumber =>
-              urls.community({
-                pageNum: pageNumber,
-                tab: GbRecentActivityAndLeaderboardTabs.RECENT_ACTIVITY,
-              })
-            }
-            totalPages={totalPages}
-          />
-        </RecentActivity.Footer>
-      </RecentActivity>
+        {tab === GbRecentActivityAndLeaderboardTabs.TOP_CONSTITUENCIES && (
+          <>
+            <GbYourConstituencyRankingWrapper>
+              <GbYourConstituencyRankSuspense>
+                <UserAddressProvider countryCode={countryCode}>
+                  <GbYourConstituencyRank />
+                </UserAddressProvider>
+              </GbYourConstituencyRankSuspense>
+            </GbYourConstituencyRankingWrapper>
+            <GbAdvocatesLeaderboard data={leaderboardData} />
+            {totalPages > 1 && (
+              <div className="flex justify-center">
+                <PaginationLinks
+                  currentPageNumber={pageNum}
+                  getPageUrl={pageNumber => {
+                    if (pageNumber < 1 || pageNumber > totalPages) {
+                      return ''
+                    }
+
+                    return urls.community({ pageNum: pageNumber, tab })
+                  }}
+                  totalPages={totalPages}
+                />
+              </div>
+            )}
+          </>
+        )}
+      </div>
     </PageLayout>
   )
 }

--- a/src/components/app/pageHome/gb/index.tsx
+++ b/src/components/app/pageHome/gb/index.tsx
@@ -1,3 +1,4 @@
+import { LoginDialogWrapper } from '@/components/app/authentication/loginDialogWrapper'
 import { DTSIFormattedLetterGrade } from '@/components/app/dtsiFormattedLetterGrade'
 import { DelayedRecentActivityWithMap } from '@/components/app/pageHome/common/delayedRecentActivity'
 import { FoundersCarousel } from '@/components/app/pageHome/common/foundersCarousel'
@@ -6,9 +7,21 @@ import { PartnerGrid } from '@/components/app/pageHome/common/partnerGrid'
 import { HomepagePoliticiansSection } from '@/components/app/pageHome/common/politiciansSection'
 import { TopLevelMetrics } from '@/components/app/pageHome/common/topLevelMetrics'
 import { HomePageProps } from '@/components/app/pageHome/common/types'
+import { GbRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/gb/recentActivityAndLeaderboardTabs'
+import { UserAddressProvider } from '@/components/app/pageReferrals/common/userAddress.context'
+import { GbAdvocatesLeaderboard } from '@/components/app/pageReferrals/gb/leaderboard'
+import {
+  GbYourConstituencyRank,
+  GbYourConstituencyRankingWrapper,
+  GbYourConstituencyRankSuspense,
+} from '@/components/app/pageReferrals/gb/yourConstituencyRanking'
+import { RecentActivity } from '@/components/app/recentActivity'
+import { UserActionFormReferDialog } from '@/components/app/userActionFormRefer/dialog'
 import { UserActionGridCTAs } from '@/components/app/userActionGridCTAs'
 import { Button } from '@/components/ui/button'
 import { InternalLink } from '@/components/ui/link'
+import { ResponsiveTabsOrSelect } from '@/components/ui/responsiveTabsOrSelect'
+import { DistrictRankingEntryWithRank } from '@/utils/server/districtRankings/upsertRankings'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { getIntlUrls } from '@/utils/shared/urls'
 
@@ -25,7 +38,10 @@ export function GbPageHome({
   countUsers,
   advocatePerStateDataProps,
   dtsiHomepagePoliticians,
-}: Omit<HomePageProps, 'leaderboardData'>) {
+  leaderboardData,
+}: HomePageProps & {
+  leaderboardData: DistrictRankingEntryWithRank[]
+}) {
   return (
     <>
       <GbHero />
@@ -39,24 +55,77 @@ export function GbPageHome({
         />
       </section>
 
-      {countUsers && actions && (
-        <HomePageSection>
-          <HomePageSection.Title>
-            <span className="text-primary-cta">Brits</span> believe in crypto
-          </HomePageSection.Title>
+      <HomePageSection>
+        <HomePageSection.Title>Our community</HomePageSection.Title>
+        <HomePageSection.Subtitle className="md:hidden">
+          See how our community is taking a stand to safeguard the future of crypto in the UK.
+        </HomePageSection.Subtitle>
 
-          <HomePageSection.Subtitle>
-            See how the community is taking a stand to safeguard the future of crypto in the UK.
-          </HomePageSection.Subtitle>
-          <DelayedRecentActivityWithMap
-            actions={actions}
-            advocatesMapPageData={advocatePerStateDataProps}
-            countUsers={countUsers.count}
-            countryCode={countryCode}
-            showDonateButton={false}
+        <RecentActivity>
+          <ResponsiveTabsOrSelect
+            analytics={'Homepage Our Community Tabs'}
+            data-testid="community-leaderboard-tabs"
+            defaultValue={GbRecentActivityAndLeaderboardTabs.RECENT_ACTIVITY}
+            options={[
+              {
+                value: GbRecentActivityAndLeaderboardTabs.RECENT_ACTIVITY,
+                label: 'Recent activity',
+                content: (
+                  <>
+                    <HomePageSection.Subtitle className="hidden md:block">
+                      See how our community is taking a stand to safeguard the future of crypto in
+                      the UK.
+                    </HomePageSection.Subtitle>
+                    {countUsers && actions && (
+                      <DelayedRecentActivityWithMap
+                        actions={actions}
+                        advocatesMapPageData={advocatePerStateDataProps}
+                        countUsers={countUsers.count}
+                        countryCode={countryCode}
+                        showDonateButton={false}
+                      />
+                    )}
+                  </>
+                ),
+              },
+              {
+                value: GbRecentActivityAndLeaderboardTabs.TOP_CONSTITUENCIES,
+                label: 'Top constituencies',
+                content: (
+                  <div className="space-y-4">
+                    <HomePageSection.Subtitle className="hidden md:block">
+                      See which constituency has the most number of advocates.
+                    </HomePageSection.Subtitle>
+
+                    <GbYourConstituencyRankingWrapper>
+                      <GbYourConstituencyRankSuspense>
+                        <UserAddressProvider countryCode={countryCode}>
+                          <GbYourConstituencyRank />
+                        </UserAddressProvider>
+                      </GbYourConstituencyRankSuspense>
+                    </GbYourConstituencyRankingWrapper>
+                    <GbAdvocatesLeaderboard data={leaderboardData} />
+                    <div className="mx-auto flex w-fit justify-center gap-2">
+                      <LoginDialogWrapper
+                        authenticatedContent={
+                          <UserActionFormReferDialog countryCode={countryCode}>
+                            <Button className="w-full">Refer</Button>
+                          </UserActionFormReferDialog>
+                        }
+                      >
+                        <Button className="w-full">Join</Button>
+                      </LoginDialogWrapper>
+                      <Button asChild variant="secondary">
+                        <InternalLink href={urls.referrals()}>View all</InternalLink>
+                      </Button>
+                    </div>
+                  </div>
+                ),
+              },
+            ]}
           />
-        </HomePageSection>
-      )}
+        </RecentActivity>
+      </HomePageSection>
 
       {partners && (
         <HomePageSection>


### PR DESCRIPTION
closes #2511 

## What changed? Why?

* Added constituencies rankings to the homepage.
* Added constituencies rankings to community page.
* Added link to the referrals page.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
