### PR TITLE
feat: add webpack-retry-chunk-load-plugin for improved chunk loading …

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import bundleAnalyzer from '@next/bundle-analyzer'
 import { withSentryConfig } from '@sentry/nextjs'
 import type { NextConfig } from 'next'
+import { RetryChunkLoadPlugin } from 'webpack-retry-chunk-load-plugin'
 
 const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
@@ -247,6 +248,17 @@ const nextConfig: NextConfig = {
         hostname: 'cdn.builder.io',
       },
     ],
+  },
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      config.plugins.push(
+        new RetryChunkLoadPlugin({
+          maxRetries: 3,
+          retryDelay: 1000,
+        }),
+      )
+    }
+    return config
   },
   async headers() {
     return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -176,6 +176,7 @@
         "tsconfig-paths": "^4.2.0",
         "tsx": "^4.7.0",
         "typescript": "^5.7.2",
+        "webpack-retry-chunk-load-plugin": "^3.1.1",
         "yargs": "^17.7.2"
       }
     },
@@ -38740,6 +38741,35 @@
         "ansi-html-community": "0.0.8",
         "html-entities": "^2.1.0",
         "strip-ansi": "^6.0.0"
+      }
+    },
+    "node_modules/webpack-retry-chunk-load-plugin": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/webpack-retry-chunk-load-plugin/-/webpack-retry-chunk-load-plugin-3.1.1.tgz",
+      "integrity": "sha512-BKq/7EcelyWUUI6SeBaUKB1G+fSZP0rlxIwRQ+aO6mK5tffljaHdpJ4I2q54rpaaKjSbwbZRQlaITXe93SL9nA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier": "^2.6.2"
+      },
+      "peerDependencies": {
+        "webpack": ">=5.0.0"
+      }
+    },
+    "node_modules/webpack-retry-chunk-load-plugin/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -206,6 +206,7 @@
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.7.0",
     "typescript": "^5.7.2",
+    "webpack-retry-chunk-load-plugin": "^3.1.1",
     "yargs": "^17.7.2"
   },
   "overrides": {


### PR DESCRIPTION
## Description
This PR addresses persistent Hydration issues in client side related to bad connection or unavailable server.
[PROD-SWC-WEB-12R](https://stand-with-crypto.sentry.io/issues/5018485674/events/481104b8941d44358ba61b640dc7a683/?project=4506490717470720)

fixes PROD-SWC-WEB-12R

## What changed? Why?
- Integrated RetryChunkLoadPlugin into webpack configuration to handle chunk loading failures with a maximum of 3 retries and a delay of 1000ms.

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
