### PR TITLE
fix(og-image): add support for WebP profile pictures in OpenGraph generation

### DIFF
--- a/src/components/app/pagePoliticianDetails/common/generateOgImage.tsx
+++ b/src/components/app/pagePoliticianDetails/common/generateOgImage.tsx
@@ -13,6 +13,18 @@ import {
 } from '@/utils/dtsi/dtsiStanceScoreUtils'
 import { OPEN_GRAPH_IMAGE_DIMENSIONS } from '@/utils/server/generateOpenGraphImageUrl'
 
+/**
+ * Checks if an image format is supported by ImageResponse/Satori
+ * Supported formats: PNG, JPEG, SVG
+ * Unsupported formats: WebP, GIF, etc.
+ */
+function isImageFormatSupportedByImageResponse(url: string): boolean {
+  const supportedExtensions = ['.png', '.jpg', '.jpeg', '.svg']
+  const lowercaseUrl = url.toLowerCase()
+
+  return supportedExtensions.some(ext => lowercaseUrl.includes(ext))
+}
+
 export async function generateOgImage({ params }: { params: { dtsiSlug: string } }) {
   const person = await getPoliticianDetailsData(params.dtsiSlug)
 
@@ -39,6 +51,11 @@ export async function generateOgImage({ params }: { params: { dtsiSlug: string }
       OPEN_GRAPH_IMAGE_DIMENSIONS,
     )
   }
+
+  const profilePictureSrc = isImageFormatSupportedByImageResponse(person.profilePictureUrl)
+    ? person.profilePictureUrl
+    : null
+
   const shouldHideStanceScores = shouldPersonHaveStanceScoresHidden(person)
   const letterGrade = convertDTSIPersonStanceScoreToLetterGrade(person) ?? '?'
   let letterImage
@@ -93,7 +110,7 @@ export async function generateOgImage({ params }: { params: { dtsiSlug: string }
         </div>
         <div />
         <div tw="w-full flex flex-col text-center justify-center items-center">
-          {person.profilePictureUrl ? (
+          {profilePictureSrc ? (
             <div
               style={{
                 display: 'flex',
@@ -101,7 +118,7 @@ export async function generateOgImage({ params }: { params: { dtsiSlug: string }
             >
               <img
                 alt={dtsiPersonFullName(person)}
-                src={person.profilePictureUrl}
+                src={profilePictureSrc}
                 style={{
                   borderRadius: '50%',
                   overflow: 'hidden',


### PR DESCRIPTION
## Description
This PR addresses OpenGraph image generation failures when politician profile pictures use unsupported formats by Next.js ImageResponse API.
[Vercel error Log](https://vercel.com/coinbase-vercel/swc-web/logs?levels=error&selectedLogId=pplcb-1756330802087-d7ba95fa4227)

## What changed? Why?
- Added image format validation to detect unsupported formats (WebP) before passing to ImageResponse
- Skip profile pictures with unsupported formats to prevent OpenGraph generation failures
- Maintains fallback to placeholder image when format is not supported, ensuring consistent behavior

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
