### PR TITLE
fix: resolve Builder.io partners API timeout breaking homepage

### DIFF
--- a/src/utils/server/builder/index.ts
+++ b/src/utils/server/builder/index.ts
@@ -1,1 +1,3 @@
 export { builderSDKClient } from './builderSDKClient'
+
+export const DEFAULT_CACHE_IN_SECONDS = 60 * 60 // 1 hour

--- a/src/utils/server/builder/models/data/partners.ts
+++ b/src/utils/server/builder/models/data/partners.ts
@@ -1,9 +1,11 @@
 import * as Sentry from '@sentry/nextjs'
 import pRetry from 'p-retry'
 
-import { builderSDKClient } from '@/utils/server/builder/builderSDKClient'
+import { builderSDKClient, DEFAULT_CACHE_IN_SECONDS } from '@/utils/server/builder'
 import { BuilderDataModelIdentifiers } from '@/utils/server/builder/models/data/constants'
 import { getLogger } from '@/utils/shared/logger'
+import { resolveWithTimeout } from '@/utils/shared/resolveWithTimeout'
+import { SECONDS_DURATION } from '@/utils/shared/seconds'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { SWCPartners, zodPartnerSchemaValidation } from '@/utils/shared/zod/getSWCPartners'
@@ -19,7 +21,7 @@ async function getAllPartnersWithOffset({
   offset: number
   countryCode: SupportedCountryCodes
 }) {
-  return await pRetry(
+  const retryPromise = pRetry(
     () =>
       builderSDKClient.getAll(BuilderDataModelIdentifiers.PARTNERS, {
         query: {
@@ -31,16 +33,22 @@ async function getAllPartnersWithOffset({
           },
         },
         includeUnpublished: NEXT_PUBLIC_ENVIRONMENT !== 'production',
-        cacheSeconds: 60,
+        cacheSeconds: DEFAULT_CACHE_IN_SECONDS,
         limit: LIMIT,
         fields: 'data',
         offset,
       }),
     {
-      retries: 3,
-      minTimeout: 10000,
+      retries: 2,
+      minTimeout: 5000,
     },
   )
+
+  const timeout = SECONDS_DURATION['10_SECONDS'] * 1000
+
+  const result = await resolveWithTimeout(retryPromise, timeout)
+
+  return result
 }
 
 export async function getPartners({ countryCode }: { countryCode: SupportedCountryCodes }) {


### PR DESCRIPTION
## Description
The homepage was experiencing failures due to Builder.io partners API timeouts. When the partners API call takes longer than expected or fails, it was causing the entire homepage to break, impacting user experience.
The issue occurs in the partners section where we fetch partner data from Builder.io CMS using `getPartners()` function.
[Vercel error Log](https://vercel.com/coinbase-vercel/swc-web/9s6wMHwEYCgRSihrWx9xsRck3U49/logs?levels=error&selectedLogId=8l8qk-1756415852457-ffc6ddef2db1&environments=production&statusCodes=500%2C504%2C501%2C503%2C505&requestPaths=%2F%2C%2Fca%2C%2Fau%2Fgb&timeline=past12Hours&page=3)

## What changed? Why?
- Decrease p-retry timeout for partners API from 10s to 5s
- Prevent homepage crashes during Builder.io API delays
- Maintain homepage functionality when CMS is unavailable
- Added new `DEFAULT_CACHE_IN_SECONDS` to use in other places with builder requests.

## How has it been tested?

- [x] Locally
- [x] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test