### PR TITLE
feat: add "EU" to SupportedCountryCodes enum

### DIFF
--- a/docs/Access location.md
+++ b/docs/Access location.md
@@ -160,6 +160,7 @@ enum SupportedCountryCodes {
   GB = 'gb',
   CA = 'ca',
   AU = 'au',
+  EU = 'eu',
 }
 
 const COUNTRY_CODE_REGEX_PATTERN = new RegExp(

--- a/src/app/api/public/referrals/[countryCode]/[stateCode]/[districtNumber]/by-state/route.ts
+++ b/src/app/api/public/referrals/[countryCode]/[stateCode]/[districtNumber]/by-state/route.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 
 import { NextRequest, NextResponse } from 'next/server'
-import { ZodTypeAny } from 'zod'
+import { any as zodAny, ZodTypeAny } from 'zod'
 
 import { getDistrictRankByState } from '@/utils/server/districtRankings/upsertRankings'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
@@ -20,6 +20,8 @@ const ZOD_SCHEMA_BY_COUNTRY_CODE_MAP: Record<SupportedCountryCodes, ZodTypeAny> 
   [SupportedCountryCodes.AU]: zodAUStateDistrict,
   [SupportedCountryCodes.CA]: zodCAProvinceDistrict,
   [SupportedCountryCodes.GB]: zodGbRegionConstituency,
+  // TODO(EU): Add schema if applies
+  [SupportedCountryCodes.EU]: zodAny(),
 }
 
 export async function GET(

--- a/src/app/api/public/referrals/[countryCode]/[stateCode]/[districtNumber]/route.ts
+++ b/src/app/api/public/referrals/[countryCode]/[stateCode]/[districtNumber]/route.ts
@@ -1,7 +1,7 @@
 import 'server-only'
 
 import { NextRequest, NextResponse } from 'next/server'
-import { ZodTypeAny } from 'zod'
+import { any as zodAny, ZodTypeAny } from 'zod'
 
 import { getDistrictRank } from '@/utils/server/districtRankings/upsertRankings'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
@@ -20,6 +20,8 @@ const ZOD_SCHEMA_BY_COUNTRY_CODE_MAP: Record<SupportedCountryCodes, ZodTypeAny> 
   [SupportedCountryCodes.AU]: zodAUStateDistrict,
   [SupportedCountryCodes.CA]: zodCAProvinceDistrict,
   [SupportedCountryCodes.GB]: zodGbRegionConstituency,
+  // TODO(EU): Add EU schema if applies
+  [SupportedCountryCodes.EU]: zodAny(),
 }
 
 export async function GET(

--- a/src/app/eu/config.tsx
+++ b/src/app/eu/config.tsx
@@ -1,0 +1,53 @@
+/* eslint-disable @next/next/no-img-element */
+
+import { FooterProps } from '@/components/app/footer'
+import { NavbarProps } from '@/components/app/navbar'
+import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { euExternalUrls, getIntlUrls } from '@/utils/shared/urls'
+
+const countryCode = SupportedCountryCodes.EU
+
+const urls = getIntlUrls(countryCode)
+
+//TODO(EU): Add EU navbar items
+export const navbarConfig: NavbarProps = {
+  countryCode,
+  logo: {
+    src: '/logo/shield.svg',
+    width: 40,
+    height: 40,
+  },
+  items: [
+    {
+      href: urls.manifesto(),
+      text: 'Manifesto',
+    },
+    {
+      href: urls.community(),
+      text: 'Community',
+    },
+  ],
+}
+
+//TODO(EU): Add EU footer items
+export const footerConfig: FooterProps = {
+  countryCode,
+  title: 'Join the Movement',
+  subtitle:
+    'Join to show your support and protect the future of crypto in Europe. #standwithcrypto',
+  links: [
+    { href: urls.termsOfService(), text: 'Terms of service' },
+    { href: urls.privacyPolicy(), text: 'Privacy' },
+  ],
+  socialLinks: [
+    {
+      href: euExternalUrls.twitter(),
+      text: 'Twitter / X',
+    },
+    {
+      href: euExternalUrls.linkedin(),
+      text: 'LinkedIn',
+    },
+  ],
+  sendFeedbackLink: euExternalUrls.emailFeedback(),
+}

--- a/src/components/app/authentication/constants.tsx
+++ b/src/components/app/authentication/constants.tsx
@@ -43,4 +43,11 @@ export const COUNTRY_SPECIFIC_LOGIN_CONTENT: Record<
     footerContent: AUFooterContent,
     iconSrc: '/au/logo/shield.svg',
   },
+  // TODO(EU): Add footer content
+  [SupportedCountryCodes.EU]: {
+    title: DEFAULT_TITLE,
+    subtitle: 'Join the Stand With Crypto movement to make your voice heard in the European Union',
+    footerContent: () => <></>,
+    iconSrc: '',
+  },
 }

--- a/src/components/app/builder/builderPageLayout.tsx
+++ b/src/components/app/builder/builderPageLayout.tsx
@@ -14,6 +14,7 @@ const navbarConfigsByCountry: Record<SupportedCountryCodes, Promise<NavbarProps>
   [DEFAULT_SUPPORTED_COUNTRY_CODE]: import('@/app/[countryCode]/config').then(
     module => module.navbarConfig,
   ),
+  [SupportedCountryCodes.EU]: import('@/app/eu/config').then(module => module.navbarConfig),
 }
 
 const footerConfigsByCountry: Record<SupportedCountryCodes, Promise<FooterProps>> = {
@@ -23,6 +24,7 @@ const footerConfigsByCountry: Record<SupportedCountryCodes, Promise<FooterProps>
   [DEFAULT_SUPPORTED_COUNTRY_CODE]: import('@/app/[countryCode]/config').then(
     module => module.footerConfig,
   ),
+  [SupportedCountryCodes.EU]: import('@/app/eu/config').then(module => module.footerConfig),
 }
 
 const getNavbarConfig = (countryCode: SupportedCountryCodes) => navbarConfigsByCountry[countryCode]

--- a/src/components/app/navbarGlobalBanner/common/constants.tsx
+++ b/src/components/app/navbarGlobalBanner/common/constants.tsx
@@ -11,4 +11,6 @@ export const GLOBAL_NAVBAR_BANNER_BY_COUNTRY_CODE: Record<SupportedCountryCodes,
   [SupportedCountryCodes.AU]: <AuNavbarGlobalBanner />,
   [SupportedCountryCodes.GB]: <GbNavbarGlobalBanner />,
   [SupportedCountryCodes.CA]: <CaNavbarGlobalBanner />,
+  // TODO(EU): Add EU navbar global banner
+  [SupportedCountryCodes.EU]: null,
 }

--- a/src/components/app/navbarGlobalBanner/common/redirectbannerContent.tsx
+++ b/src/components/app/navbarGlobalBanner/common/redirectbannerContent.tsx
@@ -40,6 +40,12 @@ const DISCLAIMER_BANNER_COUNTRY_CODES_MAP: Record<
     emoji: '🇺🇸',
     countryCode: SupportedCountryCodes.US,
   },
+  [SupportedCountryCodes.EU]: {
+    label: 'European Union',
+    url: getIntlUrls(SupportedCountryCodes.EU).home(),
+    emoji: '🇪🇺',
+    countryCode: SupportedCountryCodes.EU,
+  },
 }
 
 export function RedirectBannerContent({ countryCode }: { countryCode: SupportedCountryCodes }) {

--- a/src/components/app/notFoundLayout.tsx
+++ b/src/components/app/notFoundLayout.tsx
@@ -12,6 +12,7 @@ import * as usConfig from '@/app/[countryCode]/config'
 import { TopLevelClientLogic } from '@/app/[countryCode]/topLevelClientLogic'
 import * as auConfig from '@/app/au/config'
 import * as caConfig from '@/app/ca/config'
+import * as euConfig from '@/app/eu/config'
 import * as gbConfig from '@/app/gb/config'
 import { CookieConsent } from '@/components/app/cookieConsent'
 import { Footer } from '@/components/app/footer'
@@ -30,6 +31,7 @@ const PAGE_LAYOUT_CONFIG_BY_COUNTRY_CODE: Record<SupportedCountryCodes, typeof u
   [SupportedCountryCodes.AU]: auConfig,
   [SupportedCountryCodes.GB]: gbConfig,
   [SupportedCountryCodes.CA]: caConfig,
+  [SupportedCountryCodes.EU]: euConfig,
 }
 
 export function NotFoundLayout({ children }: { children: React.ReactNode }) {

--- a/src/components/app/pageAdvocatesHeatmap/constants.ts
+++ b/src/components/app/pageAdvocatesHeatmap/constants.ts
@@ -22,6 +22,7 @@ interface RegionCoords {
   [SupportedCountryCodes.GB]: GBStateCoords
   [SupportedCountryCodes.CA]: never
   [SupportedCountryCodes.AU]: never
+  [SupportedCountryCodes.EU]: never
 }
 
 export type AreaCoordinates = USStateCoords | GBStateCoords

--- a/src/components/app/pageHome/eu/recentActivityAndLeaderboardTabs.tsx
+++ b/src/components/app/pageHome/eu/recentActivityAndLeaderboardTabs.tsx
@@ -1,0 +1,5 @@
+// These enum values are used in the URL. If you change them, you'll break the URL.
+export enum EuRecentActivityAndLeaderboardTabs {
+  RECENT_ACTIVITY = 'recent-activity',
+  TOP_DIVISIONS = 'top-divisions',
+}

--- a/src/components/app/pagePetitionDetails/debugger/useMockedPetitionData.ts
+++ b/src/components/app/pagePetitionDetails/debugger/useMockedPetitionData.ts
@@ -192,6 +192,13 @@ const MOCK_CITIES_BY_COUNTRY: Record<SupportedCountryCodes, string[]> = {
     'Bathurst, NSW',
     'Albany, WA',
   ],
+  [SupportedCountryCodes.EU]: [
+    'Berlin, DE',
+    'Hamburg, DE',
+    'Munich, DE',
+    'Cologne, DE',
+    'Frankfurt, DE',
+  ],
 }
 
 export interface MockRecentSignatory {

--- a/src/components/app/pagePetitionDetails/debugger/useMockedPetitionData.ts
+++ b/src/components/app/pagePetitionDetails/debugger/useMockedPetitionData.ts
@@ -193,11 +193,80 @@ const MOCK_CITIES_BY_COUNTRY: Record<SupportedCountryCodes, string[]> = {
     'Albany, WA',
   ],
   [SupportedCountryCodes.EU]: [
+    // Germany
     'Berlin, DE',
-    'Hamburg, DE',
     'Munich, DE',
-    'Cologne, DE',
-    'Frankfurt, DE',
+    // France
+    'Paris, FR',
+    'Lyon, FR',
+    // Italy
+    'Rome, IT',
+    'Milan, IT',
+    // Spain
+    'Madrid, ES',
+    'Barcelona, ES',
+    // Netherlands
+    'Amsterdam, NL',
+    'Rotterdam, NL',
+    // Poland
+    'Warsaw, PL',
+    'Krakow, PL',
+    // Belgium
+    'Brussels, BE',
+    'Antwerp, BE',
+    // Austria
+    'Vienna, AT',
+    'Graz, AT',
+    // Portugal
+    'Lisbon, PT',
+    'Porto, PT',
+    // Czech Republic
+    'Prague, CZ',
+    'Brno, CZ',
+    // Hungary
+    'Budapest, HU',
+    'Debrecen, HU',
+    // Romania
+    'Bucharest, RO',
+    'Cluj-Napoca, RO',
+    // Sweden
+    'Stockholm, SE',
+    'Gothenburg, SE',
+    // Denmark
+    'Copenhagen, DK',
+    'Aarhus, DK',
+    // Finland
+    'Helsinki, FI',
+    'Tampere, FI',
+    // Ireland
+    'Dublin, IE',
+    'Cork, IE',
+    // Greece
+    'Athens, GR',
+    'Thessaloniki, GR',
+    // Croatia
+    'Zagreb, HR',
+    'Split, HR',
+    // Slovenia
+    'Ljubljana, SI',
+    // Slovakia
+    'Bratislava, SK',
+    // Bulgaria
+    'Sofia, BG',
+    'Plovdiv, BG',
+    // Lithuania
+    'Vilnius, LT',
+    'Kaunas, LT',
+    // Latvia
+    'Riga, LV',
+    // Estonia
+    'Tallinn, EE',
+    // Luxembourg
+    'Luxembourg City, LU',
+    // Malta
+    'Valletta, MT',
+    // Cyprus
+    'Nicosia, CY',
   ],
 }
 

--- a/src/components/app/pageVoterGuide/constants/ctas.tsx
+++ b/src/components/app/pageVoterGuide/constants/ctas.tsx
@@ -14,6 +14,7 @@ const COUNTRY_VOTER_GUIDE_CTAS: Record<SupportedCountryCodes, VoterGuideStep[]> 
   [SupportedCountryCodes.CA]: CA_VOTER_GUIDE_CTAS,
   [SupportedCountryCodes.GB]: GB_VOTER_GUIDE_CTAS,
   [SupportedCountryCodes.AU]: AU_VOTER_GUIDE_CTAS,
+  [SupportedCountryCodes.EU]: [], // TODO(EU): Add EU voter guide CTAs if applicable
 }
 
 export function getVoterGuideCTAsByCountry(countryCode: SupportedCountryCodes) {

--- a/src/components/app/sms/smsOptInConsentText.tsx
+++ b/src/components/app/sms/smsOptInConsentText.tsx
@@ -10,6 +10,8 @@ const SMS_OPT_IN_CONSENT: Record<SupportedCountryCodes, string> = {
     'I authorize SWC International Ltd and its service providers to contact me at this number via text (SMS) for cryptocurrency advocacy purposes. Message and data rates may apply. To opt-out at any time reply "STOP".',
   [SupportedCountryCodes.AU]:
     'I authorize SWC International Ltd and its service providers to contact me at this number via text (SMS) for cryptocurrency advocacy purposes. Message and data rates may apply. To opt-out at any time reply "STOP".',
+  [SupportedCountryCodes.EU]:
+    'I authorize SWC International Ltd and its service providers to contact me at this number via text (SMS) for cryptocurrency advocacy purposes. Message and data rates may apply. To opt-out at any time reply "STOP".',
 }
 
 export function SMSOptInConsentText({

--- a/src/components/app/updateUserProfileForm/step1/constants.ts
+++ b/src/components/app/updateUserProfileForm/step1/constants.ts
@@ -8,5 +8,6 @@ export const DISCLAIMERS_BY_COUNTRY_CODE: Record<SupportedCountryCodes, string> 
   gb: 'You are about to change your viewing country based on the address you have chosen',
   ca: 'You are about to change your viewing country based on the address you have chosen',
   au: 'You are about to change your viewing country based on the address you have chosen',
+  //TODO(EU): Enable translated strings here
   eu: 'You are about to change your viewing country based on the address you have chosen',
 }

--- a/src/components/app/updateUserProfileForm/step1/constants.ts
+++ b/src/components/app/updateUserProfileForm/step1/constants.ts
@@ -8,4 +8,5 @@ export const DISCLAIMERS_BY_COUNTRY_CODE: Record<SupportedCountryCodes, string> 
   gb: 'You are about to change your viewing country based on the address you have chosen',
   ca: 'You are about to change your viewing country based on the address you have chosen',
   au: 'You are about to change your viewing country based on the address you have chosen',
+  eu: 'You are about to change your viewing country based on the address you have chosen',
 }

--- a/src/components/app/userActionFormEmailCongressperson/common/useEmailActionCampaignMetadata.ts
+++ b/src/components/app/userActionFormEmailCongressperson/common/useEmailActionCampaignMetadata.ts
@@ -5,6 +5,8 @@ import { CampaignMetadata as AUCampaignMetadata } from '@/components/app/userAct
 import { getCAEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/ca/campaigns'
 import { CampaignMetadata as CACampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/ca/campaigns/types'
 import { EmailActionCampaignNames } from '@/components/app/userActionFormEmailCongressperson/common/types'
+import { getEUEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/eu/campaigns'
+import { CampaignMetadata as EUCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/eu/campaigns/types'
 import { getGBEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/gb/campaigns'
 import { CampaignMetadata as GBCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/gb/campaigns/types'
 import { getUSEmailActionCampaignMetadata } from '@/components/app/userActionFormEmailCongressperson/us/campaigns'
@@ -13,6 +15,7 @@ import { gracefullyError } from '@/utils/shared/gracefullyError'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { AUUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/au/auUserActionCampaigns'
 import { CAUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/ca/caUserActionCampaigns'
+import { EUUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/eu/euUserActionCampaigns'
 import { GBUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/gb/gbUserActionCampaigns'
 import { USUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/us/usUserActionCampaigns'
 
@@ -26,6 +29,7 @@ interface CampaignMetadataMap {
   [SupportedCountryCodes.AU]: AUCampaignMetadata
   [SupportedCountryCodes.CA]: CACampaignMetadata
   [SupportedCountryCodes.GB]: GBCampaignMetadata
+  [SupportedCountryCodes.EU]: EUCampaignMetadata
 }
 type CampaignMetadata<TCountryCode extends SupportedCountryCodes> =
   CampaignMetadataMap[TCountryCode]
@@ -44,6 +48,8 @@ export function useEmailActionCampaignMetadata<TCountryCode extends SupportedCou
         return getCAEmailActionCampaignMetadata(campaignName as CAUserActionEmailCampaignName)
       case SupportedCountryCodes.GB:
         return getGBEmailActionCampaignMetadata(campaignName as GBUserActionEmailCampaignName)
+      case SupportedCountryCodes.EU:
+        return getEUEmailActionCampaignMetadata(campaignName as EUUserActionEmailCampaignName)
       default:
         return gracefullyError({
           msg: `useEmailActionCampaignMetadata received invalid country code`,

--- a/src/components/app/userActionFormEmailCongressperson/eu/campaigns/index.ts
+++ b/src/components/app/userActionFormEmailCongressperson/eu/campaigns/index.ts
@@ -1,0 +1,22 @@
+import { gracefullyError } from '@/utils/shared/gracefullyError'
+import { EUUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/eu/euUserActionCampaigns'
+
+import { CampaignMetadata } from './types'
+
+export function getEUEmailActionCampaignMetadata(
+  campaignName: EUUserActionEmailCampaignName,
+): CampaignMetadata | null {
+  // TODO(EU): Implement EU campaign metadata when campaigns are added
+  return gracefullyError({
+    msg: `getEUEmailActionCampaignMetadata received unsupported campaign name: ${campaignName}`,
+    fallback: null,
+    hint: {
+      tags: {
+        domain: 'getEUEmailActionCampaignMetadata',
+      },
+      extra: {
+        campaignName,
+      },
+    },
+  })
+}

--- a/src/components/app/userActionFormEmailCongressperson/eu/campaigns/types.ts
+++ b/src/components/app/userActionFormEmailCongressperson/eu/campaigns/types.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+import { GetTextProps } from '@/components/app/userActionFormEmailCongressperson/common/emailBodyUtils'
+import { useGetDTSIPeopleFromAddress } from '@/hooks/useGetDTSIPeopleFromAddress'
+import { EUUserActionEmailCampaignName } from '@/utils/shared/userActionCampaigns/eu/euUserActionCampaigns'
+import { YourPoliticianCategory } from '@/utils/shared/yourPoliticianCategory/eu'
+import { zodAddress } from '@/validation/fields/zodAddress'
+
+export interface CampaignMetadata {
+  campaignName: EUUserActionEmailCampaignName
+  dialogTitle: string
+  dialogSubtitle: string
+  politicianCategory: YourPoliticianCategory
+  subject: string
+  getEmailBodyText: (
+    props?: GetTextProps & {
+      address?: string
+      dtsiPeopleFromAddressResponse?: ReturnType<typeof useGetDTSIPeopleFromAddress>
+      addressSchema?: z.infer<typeof zodAddress> | null
+    },
+  ) => string
+}

--- a/src/components/app/userActionGridCTAs/constants/ctas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/ctas.tsx
@@ -7,6 +7,7 @@ import {
 
 import { AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY } from './au/auCtas'
 import { CA_USER_ACTION_CTAS_FOR_GRID_DISPLAY } from './ca/caCtas'
+import { EU_USER_ACTION_CTAS_FOR_GRID_DISPLAY } from './eu/euCtas'
 import { GB_USER_ACTION_CTAS_FOR_GRID_DISPLAY } from './gb/gbCtas'
 import { US_USER_ACTION_CTAS_FOR_GRID_DISPLAY } from './us/usCtas'
 
@@ -16,6 +17,7 @@ const COUNTRY_USER_ACTION_CTAS_FOR_GRID_DISPLAY: Record<SupportedCountryCodes, U
     [SupportedCountryCodes.GB]: GB_USER_ACTION_CTAS_FOR_GRID_DISPLAY,
     [SupportedCountryCodes.CA]: CA_USER_ACTION_CTAS_FOR_GRID_DISPLAY,
     [SupportedCountryCodes.AU]: AU_USER_ACTION_CTAS_FOR_GRID_DISPLAY,
+    [SupportedCountryCodes.EU]: EU_USER_ACTION_CTAS_FOR_GRID_DISPLAY,
   }
 
 export function getUserActionCTAsByCountry(countryCode: SupportedCountryCodes) {

--- a/src/components/app/userActionGridCTAs/constants/eu/euCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/eu/euCtas.tsx
@@ -4,6 +4,7 @@ import { LoginDialogWrapper } from '@/components/app/authentication/loginDialogW
 import { UserActionGridCTA } from '@/components/app/userActionGridCTAs/types'
 import { UserActionOptInCampaignName } from '@/utils/shared/userActionCampaigns/common'
 
+//TODO(EU): Enable translated strings here
 export const EU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
   [UserActionType.OPT_IN]: {
     title: 'Join Stand With Crypto EU',

--- a/src/components/app/userActionGridCTAs/constants/eu/euCtas.tsx
+++ b/src/components/app/userActionGridCTAs/constants/eu/euCtas.tsx
@@ -1,0 +1,29 @@
+import { UserActionType } from '@prisma/client'
+
+import { LoginDialogWrapper } from '@/components/app/authentication/loginDialogWrapper'
+import { UserActionGridCTA } from '@/components/app/userActionGridCTAs/types'
+import { UserActionOptInCampaignName } from '@/utils/shared/userActionCampaigns/common'
+
+export const EU_USER_ACTION_CTAS_FOR_GRID_DISPLAY: UserActionGridCTA = {
+  [UserActionType.OPT_IN]: {
+    title: 'Join Stand With Crypto EU',
+    description: `Join the movement to make your voice heard.`,
+    mobileCTADescription: 'Join the movement to make your voice heard.',
+    campaignsModalDescription: `Join the movement to make your voice heard.`,
+    image: '/actionTypeIcons/optIn.png',
+    campaigns: [
+      {
+        actionType: UserActionType.OPT_IN,
+        campaignName: UserActionOptInCampaignName.DEFAULT,
+        isCampaignActive: true,
+        title: 'Join Stand With Crypto EU',
+        description: `Join the movement to make your voice heard.`,
+        canBeTriggeredMultipleTimes: false,
+        WrapperComponent: ({ children }) => (
+          <LoginDialogWrapper authenticatedContent={children}>{children}</LoginDialogWrapper>
+        ),
+      },
+    ],
+  },
+  // TODO(EU): Add more action types when EU campaigns are implemented
+}

--- a/src/data/dtsi/queries/constants.ts
+++ b/src/data/dtsi/queries/constants.ts
@@ -42,6 +42,10 @@ export const PERSON_ROLE_GROUPINGS_FOR_ALL_PEOPLE_QUERY: Record<
     DTSI_PersonGrouping.NEXT_CA_SENATE,
     DTSI_PersonGrouping.RUNNING_FOR_CA_SENATE,
   ],
+  [SupportedCountryCodes.EU]: [
+    // TODO(EU): Add EU-specific person groupings when they become available in DTSI
+    // For now, using an empty array as placeholder
+  ],
 }
 
 export const PERSON_ROLE_GROUPINGS_FOR_STATE_SPECIFIC_QUERY: Record<
@@ -64,6 +68,10 @@ export const PERSON_ROLE_GROUPINGS_FOR_STATE_SPECIFIC_QUERY: Record<
     DTSI_PersonGrouping.RUNNING_FOR_CA_SENATE,
     DTSI_PersonGrouping.RUNNING_FOR_CA_HOUSE_OF_COMMONS,
   ],
+  [SupportedCountryCodes.EU]: [
+    // TODO(EU): Add EU-specific state-specific person groupings when they become available in DTSI
+    // For now, using an empty array as placeholder
+  ],
 }
 
 export const PERSON_ROLE_GROUPINGS_FOR_SENATE_SPECIFIC_QUERY: Record<
@@ -74,6 +82,9 @@ export const PERSON_ROLE_GROUPINGS_FOR_SENATE_SPECIFIC_QUERY: Record<
   [SupportedCountryCodes.AU]: [DTSI_PersonGrouping.RUNNING_FOR_AU_SENATE],
   [SupportedCountryCodes.GB]: [DTSI_PersonGrouping.RUNNING_FOR_UK_HOUSE_OF_LORDS],
   [SupportedCountryCodes.CA]: [DTSI_PersonGrouping.RUNNING_FOR_CA_SENATE],
+  [SupportedCountryCodes.EU]: [
+    // TODO(EU): Add EU-specific senate-like groupings when they become available in DTSI
+  ],
 }
 
 export const PERSON_ROLE_GROUPINGS_FOR_HOUSE_SPECIFIC_QUERY: Record<
@@ -84,6 +95,9 @@ export const PERSON_ROLE_GROUPINGS_FOR_HOUSE_SPECIFIC_QUERY: Record<
   [SupportedCountryCodes.AU]: [DTSI_PersonGrouping.RUNNING_FOR_AU_HOUSE_OF_REPS],
   [SupportedCountryCodes.GB]: [DTSI_PersonGrouping.RUNNING_FOR_UK_HOUSE_OF_COMMONS],
   [SupportedCountryCodes.CA]: [DTSI_PersonGrouping.RUNNING_FOR_CA_HOUSE_OF_COMMONS],
+  [SupportedCountryCodes.EU]: [
+    // TODO(EU): Add EU-specific house-like groupings when they become available in DTSI
+  ],
 }
 
 export const PERSON_ROLE_GROUPINGS_FOR_DISTRICT_SPECIFIC_QUERY: Record<
@@ -94,6 +108,9 @@ export const PERSON_ROLE_GROUPINGS_FOR_DISTRICT_SPECIFIC_QUERY: Record<
   [SupportedCountryCodes.AU]: [DTSI_PersonGrouping.RUNNING_FOR_AU_HOUSE_OF_REPS],
   [SupportedCountryCodes.GB]: [DTSI_PersonGrouping.RUNNING_FOR_UK_HOUSE_OF_COMMONS],
   [SupportedCountryCodes.CA]: [DTSI_PersonGrouping.RUNNING_FOR_CA_HOUSE_OF_COMMONS],
+  [SupportedCountryCodes.EU]: [
+    // TODO(EU): Add EU-specific district-like groupings when they become available in DTSI
+  ],
 }
 
 export const PERSON_ROLE_GROUPINGS_FOR_CURRENT_PEOPLE_BY_CONGRESS_DISTRICT_QUERY: Record<
@@ -118,5 +135,8 @@ export const PERSON_ROLE_GROUPINGS_FOR_CURRENT_PEOPLE_BY_CONGRESS_DISTRICT_QUERY
   [SupportedCountryCodes.CA]: [
     DTSI_PersonGrouping.CURRENT_CA_HOUSE_OF_COMMONS,
     DTSI_PersonGrouping.CURRENT_CA_SENATE,
+  ],
+  [SupportedCountryCodes.EU]: [
+    // TODO(EU): Add EU-specific current people by congress district groupings when they become available in DTSI
   ],
 }

--- a/src/data/dtsi/queries/queryDTSIAllPeople.ts
+++ b/src/data/dtsi/queries/queryDTSIAllPeople.ts
@@ -18,6 +18,7 @@ const PEOPLE_OUTSIDE_FILTERS_TO_INCLUDE: Record<SupportedCountryCodes, string[]>
   [SupportedCountryCodes.CA]: [],
   [SupportedCountryCodes.GB]: [],
   [SupportedCountryCodes.AU]: [],
+  [SupportedCountryCodes.EU]: [],
 }
 
 const query = /* GraphQL */ `

--- a/src/inngest/functions/districtsRankings/updateRankings.ts
+++ b/src/inngest/functions/districtsRankings/updateRankings.ts
@@ -35,6 +35,8 @@ interface StateCodesByCountry {
   [SupportedCountryCodes.CA]: CAProvinceOrTerritoryCode[]
   [SupportedCountryCodes.GB]: GBRegion[]
   [SupportedCountryCodes.AU]: AUStateCode[]
+  // TODO(EU): Add EU country codes when applicable
+  [SupportedCountryCodes.EU]: string[]
 }
 
 const COUNTRY_CODE_TO_STATES_CODES_MAP: StateCodesByCountry = {
@@ -44,6 +46,7 @@ const COUNTRY_CODE_TO_STATES_CODES_MAP: StateCodesByCountry = {
   ) as CAProvinceOrTerritoryCode[],
   [SupportedCountryCodes.GB]: [...GB_NUTS_1_AREA_NAMES],
   [SupportedCountryCodes.AU]: Object.keys(AU_STATE_CODE_TO_DISPLAY_NAME_MAP) as AUStateCode[],
+  [SupportedCountryCodes.EU]: [],
 }
 
 const COUNTRIES_TO_UPDATE_RANKINGS_FOR = [
@@ -83,6 +86,7 @@ export const updateDistrictsRankings = inngest.createFunction(
       [SupportedCountryCodes.CA]: initialExecutionResults,
       [SupportedCountryCodes.GB]: initialExecutionResults,
       [SupportedCountryCodes.AU]: initialExecutionResults,
+      [SupportedCountryCodes.EU]: initialExecutionResults,
     }
 
     await step.run('Sync Referrals Without Address', async () => {

--- a/src/inngest/functions/eventNotification/index.ts
+++ b/src/inngest/functions/eventNotification/index.ts
@@ -13,6 +13,7 @@ const countryCodeToTimezoneMap: Record<SupportedCountryCodes, string> = {
   [SupportedCountryCodes.GB]: 'Europe/London',
   [SupportedCountryCodes.CA]: 'America/Toronto',
   [SupportedCountryCodes.AU]: 'Australia/Sydney',
+  [SupportedCountryCodes.EU]: 'Europe/London',
 }
 
 export const globalSendEventNotifications = ORDERED_SUPPORTED_COUNTRIES.map(countryCode => {

--- a/src/inngest/functions/eventNotification/index.ts
+++ b/src/inngest/functions/eventNotification/index.ts
@@ -13,6 +13,7 @@ const countryCodeToTimezoneMap: Record<SupportedCountryCodes, string> = {
   [SupportedCountryCodes.GB]: 'Europe/London',
   [SupportedCountryCodes.CA]: 'America/Toronto',
   [SupportedCountryCodes.AU]: 'Australia/Sydney',
+  //TODO(EU): Validate which timezone is best for EU
   [SupportedCountryCodes.EU]: 'Europe/London',
 }
 

--- a/src/mocks/models/mockUserAction.ts
+++ b/src/mocks/models/mockUserAction.ts
@@ -17,6 +17,7 @@ const activeActionTypesByCountry: Record<SupportedCountryCodes, readonly UserAct
   [SupportedCountryCodes.CA]: [UserActionType.OPT_IN, UserActionType.TWEET],
   [SupportedCountryCodes.GB]: [UserActionType.OPT_IN, UserActionType.TWEET],
   [SupportedCountryCodes.AU]: [UserActionType.OPT_IN, UserActionType.TWEET],
+  [SupportedCountryCodes.EU]: [UserActionType.OPT_IN, UserActionType.TWEET],
 }
 
 export function mockCreateUserActionInput({

--- a/src/utils/server/builder/models/data/questionnaire.ts
+++ b/src/utils/server/builder/models/data/questionnaire.ts
@@ -71,6 +71,7 @@ function normalizeQuestionnaire(
     [SupportedCountryCodes.AU]: questionnaire.questionnaireAu,
     [SupportedCountryCodes.CA]: questionnaire.questionnaireCa,
     [SupportedCountryCodes.GB]: questionnaire.questionnaireGb,
+    [SupportedCountryCodes.EU]: questionnaire.questionnaireEu,
   }
 
   return {

--- a/src/utils/server/districtRankings/eu/getRankingData.ts
+++ b/src/utils/server/districtRankings/eu/getRankingData.ts
@@ -1,0 +1,18 @@
+import { AdvocatesCountResult } from '@/utils/server/districtRankings/getRankingData'
+import { logger } from '@/utils/shared/logger'
+
+export async function getEUAdvocatesCountByDistrict(
+  countryCode: string,
+): Promise<AdvocatesCountResult[]> {
+  logger.info('getEUAdvocatesCountByDistrict', { countryCode })
+  // TODO(EU): Implement EU advocates count by district
+  return []
+}
+
+export async function getEUReferralsCountByDistrict(
+  countryCode: string,
+): Promise<AdvocatesCountResult[]> {
+  logger.info('getEUReferralsCountByDistrict', { countryCode })
+  // TODO(EU): Implement EU referrals count by district
+  return []
+}

--- a/src/utils/server/districtRankings/getRankingData.ts
+++ b/src/utils/server/districtRankings/getRankingData.ts
@@ -7,6 +7,10 @@ import {
   getCAReferralsCountByDistrict,
 } from '@/utils/server/districtRankings/ca/getRankingData'
 import {
+  getEUAdvocatesCountByDistrict,
+  getEUReferralsCountByDistrict,
+} from '@/utils/server/districtRankings/eu/getRankingData'
+import {
   getGBAdvocatesCountByConstituency,
   getGBReferralsCountByConstituency,
 } from '@/utils/server/districtRankings/gb/getRankingData'
@@ -32,6 +36,8 @@ interface StateCode {
   [SupportedCountryCodes.GB]: GBRegion
   [SupportedCountryCodes.CA]: CAProvinceOrTerritoryCode
   [SupportedCountryCodes.AU]: AUStateCode
+  // TODO(EU): Add EU country codes when applicable
+  [SupportedCountryCodes.EU]: string
 }
 
 type GetAdvocatesFunction<T extends SupportedCountryCodes> = (
@@ -45,6 +51,7 @@ const GET_ADVOCATES_BY_COUNTRY_CODE_MAP: {
   [SupportedCountryCodes.GB]: getGBAdvocatesCountByConstituency,
   [SupportedCountryCodes.CA]: getCAAdvocatesCountByDistrict,
   [SupportedCountryCodes.AU]: getAUAdvocatesCountByDistrict,
+  [SupportedCountryCodes.EU]: getEUAdvocatesCountByDistrict,
 }
 
 const GET_REFERRALS_BY_COUNTRY_CODE_MAP: {
@@ -54,6 +61,7 @@ const GET_REFERRALS_BY_COUNTRY_CODE_MAP: {
   [SupportedCountryCodes.GB]: getGBReferralsCountByConstituency,
   [SupportedCountryCodes.CA]: getCAReferralsCountByDistrict,
   [SupportedCountryCodes.AU]: getAUReferralsCountByDistrict,
+  [SupportedCountryCodes.EU]: getEUReferralsCountByDistrict,
 }
 
 export async function getAdvocatesCountByDistrict<T extends SupportedCountryCodes>(

--- a/src/utils/server/email/sendMail.ts
+++ b/src/utils/server/email/sendMail.ts
@@ -39,12 +39,18 @@ const SENDGRID_SENDER_GB = requiredOutsideLocalEnv(
   'SENDGRID_SENDER_GB',
   'Sendgrid Email Sends',
 )
+const SENDGRID_SENDER_EU = requiredOutsideLocalEnv(
+  process.env.SENDGRID_SENDER_EU,
+  'SENDGRID_SENDER_EU',
+  'Sendgrid Email Sends',
+)
 
 const COUNTRY_CODE_TO_SENDGRID_SENDER: Record<SupportedCountryCodes, string | undefined> = {
   [SupportedCountryCodes.US]: SENDGRID_SENDER_US,
   [SupportedCountryCodes.GB]: SENDGRID_SENDER_GB,
   [SupportedCountryCodes.CA]: SENDGRID_SENDER_CA,
   [SupportedCountryCodes.AU]: SENDGRID_SENDER_AU,
+  [SupportedCountryCodes.EU]: SENDGRID_SENDER_EU,
 }
 
 if (SENDGRID_API_KEY) {

--- a/src/utils/server/quorum/getQuorumPoliticianFromDTSIPerson.ts
+++ b/src/utils/server/quorum/getQuorumPoliticianFromDTSIPerson.ts
@@ -118,4 +118,5 @@ const MANUAL_MATCHES: Record<SupportedCountryCodes, Record<string, string>> = {
   [SupportedCountryCodes.CA]: {},
   [SupportedCountryCodes.AU]: {},
   [SupportedCountryCodes.GB]: {},
+  [SupportedCountryCodes.EU]: {},
 }

--- a/src/utils/server/quorum/utils/fetchQuorum.ts
+++ b/src/utils/server/quorum/utils/fetchQuorum.ts
@@ -22,6 +22,8 @@ const COUNTRY_CODE_TO_QUORUM_MOST_RECENT_REGION: Record<SupportedCountryCodes, s
   [SupportedCountryCodes.CA]: '201',
   [SupportedCountryCodes.GB]: '204',
   [SupportedCountryCodes.AU]: '200',
+  // TODO(EU): Add EU quorum most recent region
+  [SupportedCountryCodes.EU]: '',
 }
 
 // filters for legislators/parliamentarians

--- a/src/utils/server/sms/messages.ts
+++ b/src/utils/server/sms/messages.ts
@@ -37,11 +37,19 @@ const AU_SMS_MESSAGES: SMSMessages = {
   bulkWelcomeMessage: `Thank you for being a Stand With Crypto advocate. Message & data rates may apply. Message frequency varies. Reply HELP for help or STOP to opt out.`,
 }
 
+// TODO(EU): Validate and fix these messages when applicable
+const EU_SMS_MESSAGES: SMSMessages = {
+  welcomeMessage: `Thanks for subscribing to Stand With Crypto! You can expect news, opportunities to engage, and critical updates on crypto policy. Browse our resources and research where your elected officials stand on crypto at ${fullUrl(`/${SupportedCountryCodes.EU}`)}\n\nMessage & data rates may apply. Message frequency varies. Reply HELP for help or STOP to opt out.`,
+  helpMessage: `Reply STOP to unsubscribe. Contact Stand With Crypto Support at eu@swcinternational.org`,
+  bulkWelcomeMessage: `Thank you for being a Stand With Crypto advocate. Message & data rates may apply. Message frequency varies. Reply HELP for help or STOP to opt out.`,
+}
+
 const SMS_MESSAGES: Record<SupportedCountryCodes, SMSMessages> = {
   [SupportedCountryCodes.US]: US_SMS_MESSAGES,
   [SupportedCountryCodes.GB]: GB_SMS_MESSAGES,
   [SupportedCountryCodes.CA]: CA_SMS_MESSAGES,
   [SupportedCountryCodes.AU]: AU_SMS_MESSAGES,
+  [SupportedCountryCodes.EU]: EU_SMS_MESSAGES,
 }
 
 export const getSMSMessages = (countryCode: SupportedCountryCodes) => {

--- a/src/utils/server/sms/utils/getCountryCodeFromPhoneNumber.test.ts
+++ b/src/utils/server/sms/utils/getCountryCodeFromPhoneNumber.test.ts
@@ -6,7 +6,10 @@ import {
   SUPPORTED_COUNTRY_CODES_TO_LIBPHONENUMBER_CODE,
   SUPPORTED_PHONE_NUMBER_COUNTRY_CODES,
 } from '@/utils/shared/phoneNumber'
-import { ORDERED_SUPPORTED_COUNTRIES } from '@/utils/shared/supportedCountries'
+import {
+  ORDERED_SUPPORTED_COUNTRIES,
+  SupportedCountryCodes,
+} from '@/utils/shared/supportedCountries'
 
 describe('getCountryCodeFromPhoneNumber', () => {
   it.each(ORDERED_SUPPORTED_COUNTRIES)(
@@ -15,7 +18,13 @@ describe('getCountryCodeFromPhoneNumber', () => {
       const phoneNumber = fakerFields.phoneNumber(
         SUPPORTED_COUNTRY_CODES_TO_LIBPHONENUMBER_CODE[countryCode],
       )
-      expect(getCountryCodeFromPhoneNumber(phoneNumber)).toBe(countryCode)
+
+      //TODO(EU): remove this when EU-specific phone handling is done
+      // EU phone numbers are mapped to GB, so we expect GB to be returned for EU
+      const expectedCountryCode =
+        countryCode === SupportedCountryCodes.EU ? SupportedCountryCodes.GB : countryCode
+
+      expect(getCountryCodeFromPhoneNumber(phoneNumber)).toBe(expectedCountryCode)
     },
   )
 
@@ -26,7 +35,12 @@ describe('getCountryCodeFromPhoneNumber', () => {
         .phoneNumber(SUPPORTED_COUNTRY_CODES_TO_LIBPHONENUMBER_CODE[countryCode])
         .replace(SUPPORTED_PHONE_NUMBER_COUNTRY_CODES[countryCode], '')
 
-      expect(getCountryCodeFromPhoneNumber(phoneNumber, countryCode)).toBe(countryCode)
+      //TODO(EU): remove this when EU-specific phone handling is done
+      // EU phone numbers are mapped to GB, so we expect GB to be returned for EU
+      const expectedCountryCode =
+        countryCode === SupportedCountryCodes.EU ? SupportedCountryCodes.GB : countryCode
+
+      expect(getCountryCodeFromPhoneNumber(phoneNumber, countryCode)).toBe(expectedCountryCode)
     },
   )
 })

--- a/src/utils/shared/intl/displayNames.ts
+++ b/src/utils/shared/intl/displayNames.ts
@@ -5,6 +5,7 @@ const _countryCodeToDisplayName = {
   [SupportedCountryCodes.CA]: 'Canada',
   [SupportedCountryCodes.GB]: 'United Kingdom',
   [SupportedCountryCodes.AU]: 'Australia',
+  [SupportedCountryCodes.EU]: 'European Union',
 } as const
 export type CountryDisplayName =
   (typeof _countryCodeToDisplayName)[keyof typeof _countryCodeToDisplayName]
@@ -21,6 +22,7 @@ export const COUNTRY_CODE_TO_DISPLAY_NAME_WITH_PREFIX: Record<SupportedCountryCo
   [SupportedCountryCodes.CA]: COUNTRY_CODE_TO_DISPLAY_NAME[SupportedCountryCodes.CA],
   [SupportedCountryCodes.GB]: `the ${COUNTRY_CODE_TO_DISPLAY_NAME[SupportedCountryCodes.GB]}`,
   [SupportedCountryCodes.AU]: COUNTRY_CODE_TO_DISPLAY_NAME[SupportedCountryCodes.AU],
+  [SupportedCountryCodes.EU]: COUNTRY_CODE_TO_DISPLAY_NAME[SupportedCountryCodes.EU],
 }
 
 export const COUNTRY_CODE_TO_DEMONYM: Record<SupportedCountryCodes, string> = {
@@ -28,4 +30,5 @@ export const COUNTRY_CODE_TO_DEMONYM: Record<SupportedCountryCodes, string> = {
   [SupportedCountryCodes.GB]: 'British',
   [SupportedCountryCodes.CA]: 'Canadian',
   [SupportedCountryCodes.AU]: 'Australian',
+  [SupportedCountryCodes.EU]: 'European',
 }

--- a/src/utils/shared/phoneNumber.test.ts
+++ b/src/utils/shared/phoneNumber.test.ts
@@ -47,6 +47,16 @@ const TEST_PHONE_NUMBERS: Record<SupportedCountryCodes, string[]> = {
     '421345678',
     '61421345678',
   ],
+  [SupportedCountryCodes.EU]: [
+    '+44 117 2345678',
+    '+44 117 234 5678',
+    '(117) 234 5678',
+    '44 117 234-5678',
+    '44 (117) 234 5678',
+    '+44117 2345678',
+    '1172345678',
+    '441172345678',
+  ],
 }
 
 const EXPECTED_PHONE_NUMBERS: Record<SupportedCountryCodes, string[]> = {
@@ -54,6 +64,7 @@ const EXPECTED_PHONE_NUMBERS: Record<SupportedCountryCodes, string[]> = {
   [SupportedCountryCodes.CA]: ['+12228883333'],
   [SupportedCountryCodes.GB]: ['+441172345678'],
   [SupportedCountryCodes.AU]: ['+61421345678'],
+  [SupportedCountryCodes.EU]: ['+441172345678'],
 }
 
 const NOT_SUPPORTED_PHONE_NUMBERS = ['+55 11 99999-9999', '+5511999999999', '+55(11)999999999']

--- a/src/utils/shared/phoneNumber.ts
+++ b/src/utils/shared/phoneNumber.ts
@@ -16,6 +16,8 @@ export const SUPPORTED_COUNTRY_CODES_TO_LIBPHONENUMBER_CODE: Record<
   [SupportedCountryCodes.CA]: 'CA',
   [SupportedCountryCodes.GB]: 'GB',
   [SupportedCountryCodes.AU]: 'AU',
+  // TODO(EU): Update when EU-specific phone handling is needed
+  [SupportedCountryCodes.EU]: 'DE',
 }
 
 export const SUPPORTED_PHONE_NUMBER_COUNTRY_CODES: Record<SupportedCountryCodes, string> = {
@@ -23,6 +25,8 @@ export const SUPPORTED_PHONE_NUMBER_COUNTRY_CODES: Record<SupportedCountryCodes,
   [SupportedCountryCodes.CA]: '+1',
   [SupportedCountryCodes.GB]: '+44',
   [SupportedCountryCodes.AU]: '+61',
+  // TODO(EU): Update when EU-specific phone handling is needed
+  [SupportedCountryCodes.EU]: '+999',
 }
 
 // https://stackoverflow.com/a/43687969

--- a/src/utils/shared/phoneNumber.ts
+++ b/src/utils/shared/phoneNumber.ts
@@ -17,7 +17,7 @@ export const SUPPORTED_COUNTRY_CODES_TO_LIBPHONENUMBER_CODE: Record<
   [SupportedCountryCodes.GB]: 'GB',
   [SupportedCountryCodes.AU]: 'AU',
   // TODO(EU): Update when EU-specific phone handling is needed
-  [SupportedCountryCodes.EU]: 'DE',
+  [SupportedCountryCodes.EU]: 'GB',
 }
 
 export const SUPPORTED_PHONE_NUMBER_COUNTRY_CODES: Record<SupportedCountryCodes, string> = {
@@ -26,7 +26,7 @@ export const SUPPORTED_PHONE_NUMBER_COUNTRY_CODES: Record<SupportedCountryCodes,
   [SupportedCountryCodes.GB]: '+44',
   [SupportedCountryCodes.AU]: '+61',
   // TODO(EU): Update when EU-specific phone handling is needed
-  [SupportedCountryCodes.EU]: '+999',
+  [SupportedCountryCodes.EU]: '+44',
 }
 
 // https://stackoverflow.com/a/43687969

--- a/src/utils/shared/sms/smsSupportedCountries.ts
+++ b/src/utils/shared/sms/smsSupportedCountries.ts
@@ -5,6 +5,8 @@ const SMS_SUPPORTED_COUNTRIES: Record<SupportedCountryCodes, boolean> = {
   [SupportedCountryCodes.GB]: true,
   [SupportedCountryCodes.CA]: true,
   [SupportedCountryCodes.AU]: true,
+  // TODO(EU): Update when EU-specific SMS handling is needed
+  [SupportedCountryCodes.EU]: false,
 }
 
 export const isSmsSupportedInCountry = (countryCode: SupportedCountryCodes | string) => {
@@ -16,6 +18,7 @@ const COUNTRY_REQUIRES_OPT_IN_CONFIRMATION: Record<SupportedCountryCodes, boolea
   [SupportedCountryCodes.GB]: true,
   [SupportedCountryCodes.CA]: true,
   [SupportedCountryCodes.AU]: true,
+  [SupportedCountryCodes.EU]: true,
 }
 
 export const requiresOptInConfirmation = (countryCode: SupportedCountryCodes | string) => {

--- a/src/utils/shared/stateUtils.ts
+++ b/src/utils/shared/stateUtils.ts
@@ -23,6 +23,7 @@ const GET_STATE_NAME_BY_COUNTRY_CODE_MAP: Record<SupportedCountryCodes, (code: s
     [SupportedCountryCodes.CA]: getCAProvinceOrTerritoryNameFromCode,
     [SupportedCountryCodes.GB]: getGBCountryNameFromCode,
     [SupportedCountryCodes.US]: getUSStateNameFromStateCode,
+    [SupportedCountryCodes.EU]: (code: string) => code, // TODO(EU): Update when EU-specific country name resolution is needed
   }
 
 export function getStateNameResolver(countryCode: SupportedCountryCodes) {
@@ -34,6 +35,7 @@ const TERRITORY_DIVISION_BY_COUNTRY_CODE: Record<SupportedCountryCodes, string> 
   [SupportedCountryCodes.CA]: 'Province',
   [SupportedCountryCodes.GB]: 'Country',
   [SupportedCountryCodes.US]: 'State',
+  [SupportedCountryCodes.EU]: 'Country',
 }
 
 export function getTerritoryDivisionByCountryCode(countryCode: SupportedCountryCodes) {
@@ -45,6 +47,7 @@ const ELECTORAL_ZONE_DESCRIPTOR_BY_COUNTRY_CODE: Record<SupportedCountryCodes, s
   [SupportedCountryCodes.GB]: 'constituency',
   [SupportedCountryCodes.CA]: 'constituency',
   [SupportedCountryCodes.AU]: 'constituency',
+  [SupportedCountryCodes.EU]: 'constituency',
 }
 
 export function getElectoralZoneDescriptorByCountryCode(countryCode: SupportedCountryCodes) {
@@ -59,6 +62,7 @@ const IS_VALID_STATE_CODE_BY_COUNTRY_CODE: Record<
   [SupportedCountryCodes.GB]: isValidGBCountryCode,
   [SupportedCountryCodes.CA]: isValidCAProvinceOrTerritoryCode,
   [SupportedCountryCodes.AU]: isValidAUStateCode,
+  [SupportedCountryCodes.EU]: () => false, // TODO(EU): Update when EU-specific state code validation is needed
 }
 
 export function isValidStateCodeByCountryCode(countryCode: SupportedCountryCodes, code: string) {

--- a/src/utils/shared/supportedCountries.ts
+++ b/src/utils/shared/supportedCountries.ts
@@ -5,6 +5,7 @@ export enum SupportedCountryCodes {
   GB = 'gb',
   CA = 'ca',
   AU = 'au',
+  EU = 'eu',
 }
 
 export const DEFAULT_SUPPORTED_COUNTRY_CODE = SupportedCountryCodes.US
@@ -13,6 +14,7 @@ export const ORDERED_SUPPORTED_COUNTRIES: readonly SupportedCountryCodes[] = [
   SupportedCountryCodes.GB,
   SupportedCountryCodes.CA,
   SupportedCountryCodes.AU,
+  SupportedCountryCodes.EU,
 ]
 
 export const COUNTRY_CODE_TO_LOCALE: Record<SupportedCountryCodes, SupportedLocale> = {
@@ -20,6 +22,7 @@ export const COUNTRY_CODE_TO_LOCALE: Record<SupportedCountryCodes, SupportedLoca
   [SupportedCountryCodes.GB]: SupportedLocale.EN_US,
   [SupportedCountryCodes.CA]: SupportedLocale.EN_US,
   [SupportedCountryCodes.AU]: SupportedLocale.EN_US,
+  [SupportedCountryCodes.EU]: SupportedLocale.EN_US,
 }
 
 // Two lowercase letters (e.g., "us", "gb")

--- a/src/utils/shared/supportedCountries.ts
+++ b/src/utils/shared/supportedCountries.ts
@@ -22,6 +22,7 @@ export const COUNTRY_CODE_TO_LOCALE: Record<SupportedCountryCodes, SupportedLoca
   [SupportedCountryCodes.GB]: SupportedLocale.EN_US,
   [SupportedCountryCodes.CA]: SupportedLocale.EN_US,
   [SupportedCountryCodes.AU]: SupportedLocale.EN_US,
+  //TODO(EU): This need to be dynamic based on the EU country
   [SupportedCountryCodes.EU]: SupportedLocale.EN_US,
 }
 

--- a/src/utils/shared/urls/externalUrls.ts
+++ b/src/utils/shared/urls/externalUrls.ts
@@ -58,3 +58,11 @@ export const caExternalUrls = {
   emailFeedback: () => 'info@swcinternational.org',
   quorumPrivacyPolicy: () => 'https://www.quorum.us/privacy-policy/',
 }
+
+// TODO(EU): Add EU external URLs
+export const euExternalUrls = {
+  twitter: () => 'https://x.com/StandWCrypto_EU',
+  linkedin: () => 'https://www.linkedin.com/company/stand-with-crypto-eu',
+  emailFeedback: () => 'info@swcinternational.org',
+  quorumPrivacyPolicy: () => 'https://www.quorum.us/privacy-policy/',
+}

--- a/src/utils/shared/urls/index.ts
+++ b/src/utils/shared/urls/index.ts
@@ -1,5 +1,6 @@
 import { AuRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/au/recentActivityAndLeaderboardTabs'
 import { CaRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/ca/recentActivityAndLeaderboardTabs'
+import { EuRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/eu/recentActivityAndLeaderboardTabs'
 import { GbRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/gb/recentActivityAndLeaderboardTabs'
 import { UsRecentActivityAndLeaderboardTabs } from '@/components/app/pageHome/us/recentActivityAndLeaderboardTabs'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
@@ -56,6 +57,10 @@ const COUNTRY_CODE_TO_RACES_ROUTES_SEGMENTS: Record<
     state: 'province',
     district: 'constituency',
   },
+  [SupportedCountryCodes.EU]: {
+    state: 'country',
+    district: 'constituency',
+  },
 }
 
 type RecentActivityAndLeaderboardTabs =
@@ -63,7 +68,7 @@ type RecentActivityAndLeaderboardTabs =
   | AuRecentActivityAndLeaderboardTabs
   | CaRecentActivityAndLeaderboardTabs
   | GbRecentActivityAndLeaderboardTabs
-
+  | EuRecentActivityAndLeaderboardTabs
 export const getIntlPrefix = (countryCode: SupportedCountryCodes) =>
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   countryCode === DEFAULT_SUPPORTED_COUNTRY_CODE ? '' : `/${countryCode}`

--- a/src/utils/shared/userActionCampaigns/eu/euUserActionCampaigns.ts
+++ b/src/utils/shared/userActionCampaigns/eu/euUserActionCampaigns.ts
@@ -1,0 +1,38 @@
+import { UserActionType } from '@prisma/client'
+
+import { UserActionOptInCampaignName } from '@/utils/shared/userActionCampaigns/common'
+
+export const EU_ACTIVE_CLIENT_USER_ACTION_WITH_CAMPAIGN = [
+  UserActionType.OPT_IN,
+  UserActionType.TWEET,
+  UserActionType.REFER,
+  // TODO(EU): Add more action types when EU campaigns are implemented
+] as const
+
+export type EUActiveClientUserActionWithCampaignType =
+  (typeof EU_ACTIVE_CLIENT_USER_ACTION_WITH_CAMPAIGN)[number]
+
+export enum EUUserActionTweetCampaignName {
+  DEFAULT = 'DEFAULT',
+}
+
+export enum EUUserActionReferCampaignName {
+  DEFAULT = 'DEFAULT',
+}
+
+// TODO(EU): Add EU-specific campaign enums when needed
+export type EUUserActionEmailCampaignName = string
+
+export interface EUUserActionCampaigns {
+  [UserActionType.OPT_IN]: UserActionOptInCampaignName
+  [UserActionType.TWEET]: EUUserActionTweetCampaignName
+  [UserActionType.REFER]: EUUserActionReferCampaignName
+  // TODO(EU): Add more action types when campaigns are implemented
+}
+
+export const EU_USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP: EUUserActionCampaigns = {
+  [UserActionType.OPT_IN]: UserActionOptInCampaignName.DEFAULT,
+  [UserActionType.TWEET]: EUUserActionTweetCampaignName.DEFAULT,
+  [UserActionType.REFER]: EUUserActionReferCampaignName.DEFAULT,
+  // TODO(EU): Add more mappings when campaigns are implemented
+}

--- a/src/utils/shared/userActionCampaigns/index.ts
+++ b/src/utils/shared/userActionCampaigns/index.ts
@@ -14,6 +14,12 @@ import {
   CAUserActionCampaigns,
 } from '@/utils/shared/userActionCampaigns/ca/caUserActionCampaigns'
 import {
+  EU_ACTIVE_CLIENT_USER_ACTION_WITH_CAMPAIGN,
+  EU_USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP,
+  EUActiveClientUserActionWithCampaignType,
+  EUUserActionCampaigns,
+} from '@/utils/shared/userActionCampaigns/eu/euUserActionCampaigns'
+import {
   GB_ACTIVE_CLIENT_USER_ACTION_WITH_CAMPAIGN,
   GB_USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP,
   GBActiveClientUserActionWithCampaignType,
@@ -32,6 +38,7 @@ export interface CountryActiveClientUserActionWithCampaignType {
   [SupportedCountryCodes.GB]: GBActiveClientUserActionWithCampaignType
   [SupportedCountryCodes.CA]: CAActiveClientUserActionWithCampaignType
   [SupportedCountryCodes.AU]: AUActiveClientUserActionWithCampaignType
+  [SupportedCountryCodes.EU]: EUActiveClientUserActionWithCampaignType
 }
 
 export type ActiveClientUserActionWithCampaignType =
@@ -44,6 +51,7 @@ export const COUNTRY_ACTIVE_CLIENT_USER_ACTION_WITH_CAMPAIGN: {
   [SupportedCountryCodes.GB]: GB_ACTIVE_CLIENT_USER_ACTION_WITH_CAMPAIGN,
   [SupportedCountryCodes.CA]: CA_ACTIVE_CLIENT_USER_ACTION_WITH_CAMPAIGN,
   [SupportedCountryCodes.AU]: AU_ACTIVE_CLIENT_USER_ACTION_WITH_CAMPAIGN,
+  [SupportedCountryCodes.EU]: EU_ACTIVE_CLIENT_USER_ACTION_WITH_CAMPAIGN,
 }
 
 export interface CountryUserActionCampaigns {
@@ -51,6 +59,7 @@ export interface CountryUserActionCampaigns {
   [SupportedCountryCodes.GB]: GBUserActionCampaigns
   [SupportedCountryCodes.CA]: CAUserActionCampaigns
   [SupportedCountryCodes.AU]: AUUserActionCampaigns
+  [SupportedCountryCodes.EU]: EUUserActionCampaigns
 }
 
 export type UserActionCampaignNames =
@@ -58,6 +67,7 @@ export type UserActionCampaignNames =
   | GBUserActionCampaigns[keyof GBUserActionCampaigns]
   | CAUserActionCampaigns[keyof CAUserActionCampaigns]
   | AUUserActionCampaigns[keyof AUUserActionCampaigns]
+  | EUUserActionCampaigns[keyof EUUserActionCampaigns]
 
 export type UserActionCampaign = CountryUserActionCampaigns[SupportedCountryCodes]
 
@@ -68,6 +78,7 @@ export const COUNTRY_USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP: {
   [SupportedCountryCodes.GB]: GB_USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP,
   [SupportedCountryCodes.CA]: CA_USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP,
   [SupportedCountryCodes.AU]: AU_USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP,
+  [SupportedCountryCodes.EU]: EU_USER_ACTION_TO_CAMPAIGN_NAME_DEFAULT_MAP,
 }
 
 export function isActionSupportedForCountry<

--- a/src/utils/shared/yourPoliticianCategory/eu.ts
+++ b/src/utils/shared/yourPoliticianCategory/eu.ts
@@ -2,6 +2,8 @@ import { DTSIPeopleByElectoralZoneQueryResult } from '@/data/dtsi/queries/queryD
 
 export type YourPoliticianCategory = 'mep' | 'commissioner' | 'all'
 
+//TODO(EU): Enable translated strings in all the functions below
+
 export const YOUR_POLITICIAN_CATEGORY_OPTIONS: readonly YourPoliticianCategory[] = [
   'mep',
   'commissioner',

--- a/src/utils/shared/yourPoliticianCategory/eu.ts
+++ b/src/utils/shared/yourPoliticianCategory/eu.ts
@@ -1,0 +1,52 @@
+import { DTSIPeopleByElectoralZoneQueryResult } from '@/data/dtsi/queries/queryDTSIPeopleByElectoralZone'
+
+export type YourPoliticianCategory = 'mep' | 'commissioner' | 'all'
+
+export const YOUR_POLITICIAN_CATEGORY_OPTIONS: readonly YourPoliticianCategory[] = [
+  'mep',
+  'commissioner',
+  'all',
+]
+
+export function getEUPoliticianCategoryDisplayName(
+  category: YourPoliticianCategory,
+  {
+    maxCount,
+  }: {
+    maxCount?: number
+  } = {},
+) {
+  switch (category) {
+    case 'mep':
+      return maxCount === 1 ? 'Member of European Parliament' : 'Members of European Parliament'
+    case 'commissioner':
+      return maxCount === 1 ? 'European Commissioner' : 'European Commissioners'
+    case 'all':
+      return maxCount === 1 ? 'politician' : 'politicians'
+  }
+}
+
+export function getYourPoliticianCategoryShortDisplayName(
+  category: YourPoliticianCategory,
+  {
+    maxCount,
+  }: {
+    maxCount?: number
+  } = {},
+) {
+  switch (category) {
+    case 'mep':
+      return maxCount === 1 ? 'MEP' : 'MEPs'
+    case 'commissioner':
+      return maxCount === 1 ? 'Commissioner' : 'Commissioners'
+    case 'all':
+      return maxCount === 1 ? 'politician' : 'politicians'
+  }
+}
+
+export function filterDTSIPeopleByEUPoliticalCategory(category: YourPoliticianCategory) {
+  return (dtsiPerson: DTSIPeopleByElectoralZoneQueryResult[number]): boolean => {
+    // TODO(EU): Add EU-specific political category filter
+    return true
+  }
+}

--- a/src/utils/shared/yourPoliticianCategory/eu.ts
+++ b/src/utils/shared/yourPoliticianCategory/eu.ts
@@ -47,6 +47,10 @@ export function getYourPoliticianCategoryShortDisplayName(
 export function filterDTSIPeopleByEUPoliticalCategory(category: YourPoliticianCategory) {
   return (dtsiPerson: DTSIPeopleByElectoralZoneQueryResult[number]): boolean => {
     // TODO(EU): Add EU-specific political category filter
+    // Simple usage to avoid unused parameter warnings (remove this "if" when adding the filters)
+    if (category === 'all' || dtsiPerson) {
+      return true
+    }
     return true
   }
 }

--- a/src/utils/shared/yourPoliticianCategory/index.ts
+++ b/src/utils/shared/yourPoliticianCategory/index.ts
@@ -10,6 +10,11 @@ import {
   YourPoliticianCategory as CAYourPoliticianCategory,
 } from '@/utils/shared/yourPoliticianCategory/ca'
 import {
+  filterDTSIPeopleByEUPoliticalCategory,
+  getEUPoliticianCategoryDisplayName,
+  YourPoliticianCategory as EUYourPoliticianCategory,
+} from '@/utils/shared/yourPoliticianCategory/eu'
+import {
   filterDTSIPeopleByGBPoliticalCategory,
   getGBPoliticianCategoryDisplayName,
   YourPoliticianCategory as GBYourPoliticianCategory,
@@ -26,6 +31,7 @@ interface Props {
     | USYourPoliticianCategory
     | AUYourPoliticianCategory
     | CAYourPoliticianCategory
+    | EUYourPoliticianCategory
     | GBYourPoliticianCategory
 }
 export function getYourPoliticianCategoryDisplayName(props: Props) {
@@ -38,6 +44,8 @@ export function getYourPoliticianCategoryDisplayName(props: Props) {
       return getAUPoliticianCategoryDisplayName(category as AUYourPoliticianCategory)
     case SupportedCountryCodes.CA:
       return getCAPoliticianCategoryDisplayName(category as CAYourPoliticianCategory)
+    case SupportedCountryCodes.EU:
+      return getEUPoliticianCategoryDisplayName(category as EUYourPoliticianCategory)
     case SupportedCountryCodes.GB:
       return getGBPoliticianCategoryDisplayName(category as GBYourPoliticianCategory)
   }
@@ -54,6 +62,9 @@ export function filterDTSIPeopleByPoliticalCategory(args: Props) {
     }
     case SupportedCountryCodes.CA: {
       return filterDTSIPeopleByCAPoliticalCategory(category as CAYourPoliticianCategory)
+    }
+    case SupportedCountryCodes.EU: {
+      return filterDTSIPeopleByEUPoliticalCategory(category as EUYourPoliticianCategory)
     }
     case SupportedCountryCodes.GB: {
       return filterDTSIPeopleByGBPoliticalCategory(category as GBYourPoliticianCategory)

--- a/src/utils/shared/zod/getSWCQuestionnaire.ts
+++ b/src/utils/shared/zod/getSWCQuestionnaire.ts
@@ -24,6 +24,7 @@ export const zodQuestionnaireSchemaValidation = z.object({
   questionnaireAu: z.array(zodQuestionnaireAnswerSchema),
   questionnaireCa: z.array(zodQuestionnaireAnswerSchema),
   questionnaireGb: z.array(zodQuestionnaireAnswerSchema),
+  questionnaireEu: z.array(zodQuestionnaireAnswerSchema),
 })
 
 export type SWCQuestionnaireEntry = Zod.infer<typeof zodQuestionnaireSchemaValidation>

--- a/src/validation/fields/zodState.ts
+++ b/src/validation/fields/zodState.ts
@@ -51,6 +51,13 @@ const COUNTRY_CODE_TO_ZOD_STATE_MAP: Record<
       required_error: 'Please enter a valid AU state',
     },
   },
+  [SupportedCountryCodes.EU]: {
+    // TODO(EU): Add countries map if applies
+    stateMap: {},
+    zodOptions: {
+      required_error: 'Please enter a valid EU country',
+    },
+  },
 }
 
 type ZodStateReturn<T extends SupportedCountryCodes> = T extends SupportedCountryCodes.US


### PR DESCRIPTION
## What changed? Why?

This PR adds the "EU" to the SupportedCountryCodes enum.
All the changes were made to enable the EU on the SupportedCountryCodes.
Everywhere we need to change something in the future was flagged with `// TODO(EU):`. 

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
