### PR TITLE
feat: add locale to all builder.io data model requests

### DIFF
--- a/src/utils/server/builder/models/data/bills.ts
+++ b/src/utils/server/builder/models/data/bills.ts
@@ -6,6 +6,7 @@ import { BuilderDataModelIdentifiers } from '@/utils/server/builder/models/data/
 import { getLogger } from '@/utils/shared/logger'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { DEFAULT_LOCALE } from '@/utils/shared/supportedLocales'
 import {
   BillChamberOrigin,
   BillKeyDateCategory,
@@ -41,6 +42,7 @@ async function getBillFromBuilderIO(filters: BillFilters): Promise<SWCBill | nul
             },
             ...(isProduction && { published: 'published' }),
           },
+          locale: DEFAULT_LOCALE,
           includeUnpublished: !isProduction,
           cacheSeconds: 60,
         }),
@@ -121,6 +123,7 @@ function getAllBillsWithOffset({
           ...(isProduction && { published: 'published' }),
           data: stateCode ? filterByStateCode : filterByCountryCode,
         },
+        locale: DEFAULT_LOCALE,
         includeUnpublished: !isProduction,
         cacheSeconds: 60,
         limit: LIMIT,

--- a/src/utils/server/builder/models/data/events.ts
+++ b/src/utils/server/builder/models/data/events.ts
@@ -6,6 +6,7 @@ import { BuilderDataModelIdentifiers } from '@/utils/server/builder/models/data/
 import { getLogger } from '@/utils/shared/logger'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { DEFAULT_LOCALE } from '@/utils/shared/supportedLocales'
 import { SWCEvents, zodEventSchemaValidation } from '@/utils/shared/zod/getSWCEvents'
 
 const logger = getLogger(`builderIOEvents`)
@@ -32,6 +33,7 @@ export async function getEvent({
             },
             ...(NEXT_PUBLIC_ENVIRONMENT === 'production' && { published: 'published' }),
           },
+          locale: DEFAULT_LOCALE,
           includeUnpublished: NEXT_PUBLIC_ENVIRONMENT !== 'production',
           cacheSeconds: 60,
         }),
@@ -77,6 +79,7 @@ async function getAllEventsWithOffset({
             countryCode: countryCode.toUpperCase(),
           },
         },
+        locale: DEFAULT_LOCALE,
         includeUnpublished: NEXT_PUBLIC_ENVIRONMENT !== 'production',
         cacheSeconds: 60,
         limit: LIMIT,

--- a/src/utils/server/builder/models/data/founders.ts
+++ b/src/utils/server/builder/models/data/founders.ts
@@ -6,6 +6,7 @@ import { BuilderDataModelIdentifiers } from '@/utils/server/builder/models/data/
 import { getLogger } from '@/utils/shared/logger'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { DEFAULT_LOCALE } from '@/utils/shared/supportedLocales'
 import { SWCFounder, zodFoundersSchemaValidation } from '@/utils/shared/zod/getSWCFounders'
 
 const logger = getLogger(`builderIOFounders`)
@@ -22,6 +23,7 @@ async function getAllFounders({ countryCode }: { countryCode: SupportedCountryCo
             },
           },
         },
+        locale: DEFAULT_LOCALE,
         includeUnpublished: NEXT_PUBLIC_ENVIRONMENT !== 'production',
         fields: 'data',
       }),

--- a/src/utils/server/builder/models/data/news.ts
+++ b/src/utils/server/builder/models/data/news.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_SUPPORTED_COUNTRY_CODE,
   SupportedCountryCodes,
 } from '@/utils/shared/supportedCountries'
+import { DEFAULT_LOCALE } from '@/utils/shared/supportedLocales'
 
 interface InternalNews {
   id: string
@@ -83,6 +84,7 @@ async function getAllNewsWithOffset(
         sort: {
           'data.publicationDate': -1,
         },
+        locale: DEFAULT_LOCALE,
         includeUnpublished: NEXT_PUBLIC_ENVIRONMENT !== 'production',
         cacheSeconds: 60,
         fields: 'data,createdDate,id',

--- a/src/utils/server/builder/models/data/partners.ts
+++ b/src/utils/server/builder/models/data/partners.ts
@@ -8,6 +8,7 @@ import { resolveWithTimeout } from '@/utils/shared/resolveWithTimeout'
 import { SECONDS_DURATION } from '@/utils/shared/seconds'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { DEFAULT_LOCALE } from '@/utils/shared/supportedLocales'
 import { SWCPartners, zodPartnerSchemaValidation } from '@/utils/shared/zod/getSWCPartners'
 
 const logger = getLogger(`builderIOPartners`)
@@ -32,6 +33,7 @@ async function getAllPartnersWithOffset({
             },
           },
         },
+        locale: DEFAULT_LOCALE,
         includeUnpublished: NEXT_PUBLIC_ENVIRONMENT !== 'production',
         cacheSeconds: DEFAULT_CACHE_IN_SECONDS,
         limit: LIMIT,

--- a/src/utils/server/builder/models/data/petitions.ts
+++ b/src/utils/server/builder/models/data/petitions.ts
@@ -6,6 +6,7 @@ import { BuilderDataModelIdentifiers } from '@/utils/server/builder/models/data/
 import { getLogger } from '@/utils/shared/logger'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { DEFAULT_LOCALE } from '@/utils/shared/supportedLocales'
 import {
   SWCPetitionFromBuilderIO,
   zodPetitionSchemaValidation,
@@ -34,6 +35,7 @@ export async function getAllPetitionsFromBuilderIO({
             },
             ...(isProduction && { published: 'published' }),
           },
+          locale: DEFAULT_LOCALE,
           includeUnpublished: !isProduction,
           cacheSeconds: 60,
           limit: LIMIT,
@@ -86,6 +88,7 @@ export async function getPetitionFromBuilderIO(
             },
             ...(isProduction && { published: 'published' }),
           },
+          locale: DEFAULT_LOCALE,
           includeUnpublished: !isProduction,
           cacheSeconds: 60,
         }),

--- a/src/utils/server/builder/models/data/polls.ts
+++ b/src/utils/server/builder/models/data/polls.ts
@@ -6,6 +6,7 @@ import { BuilderDataModelIdentifiers } from '@/utils/server/builder/models/data/
 import { getLogger } from '@/utils/shared/logger'
 import { NEXT_PUBLIC_ENVIRONMENT } from '@/utils/shared/sharedEnv'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { DEFAULT_LOCALE } from '@/utils/shared/supportedLocales'
 import { SWCPoll, zodPollSchemaValidation } from '@/utils/shared/zod/getSWCPolls'
 
 const logger = getLogger(`builderIOPolls`)
@@ -28,6 +29,7 @@ async function getAllPollsWithOffset({
           },
           ...(NEXT_PUBLIC_ENVIRONMENT === 'production' && { published: 'published' }),
         },
+        locale: DEFAULT_LOCALE,
         includeUnpublished: NEXT_PUBLIC_ENVIRONMENT !== 'production',
         cacheSeconds: 60,
         limit: LIMIT,

--- a/src/utils/server/builder/models/data/questionnaire.ts
+++ b/src/utils/server/builder/models/data/questionnaire.ts
@@ -5,6 +5,7 @@ import { builderSDKClient } from '@/utils/server/builder'
 import { BuilderDataModelIdentifiers } from '@/utils/server/builder/models/data/constants'
 import { getLogger } from '@/utils/shared/logger'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { DEFAULT_LOCALE } from '@/utils/shared/supportedLocales'
 import {
   QUESTION_ANSWER_OPTIONS,
   SWCQuestionnaireAnswers,
@@ -31,6 +32,7 @@ export async function getQuestionnaire({
               countryCode: countryCode.toUpperCase(),
             },
           },
+          locale: DEFAULT_LOCALE,
           fields: 'data',
         }),
       { retries: 3, minTimeout: 5000 },

--- a/src/utils/server/builder/models/page/utils/getPageContent.ts
+++ b/src/utils/server/builder/models/page/utils/getPageContent.ts
@@ -4,6 +4,7 @@ import pRetry from 'p-retry'
 import { builderSDKClient } from '@/utils/server/builder/builderSDKClient'
 import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/constants'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { DEFAULT_LOCALE } from '@/utils/shared/supportedLocales'
 
 export async function getPageContent(
   pageModelName: BuilderPageModelIdentifiers,
@@ -24,6 +25,7 @@ export async function getPageContent(
     // Set cachebust to true to get the latest content.
     // This should only be used to generate static pages.
     cachebust: true,
+    locale: DEFAULT_LOCALE,
   }
 
   const content = await pRetry(

--- a/src/utils/server/builder/models/page/utils/getPageDetails.ts
+++ b/src/utils/server/builder/models/page/utils/getPageDetails.ts
@@ -4,6 +4,7 @@ import pRetry from 'p-retry'
 import { builderSDKClient } from '@/utils/server/builder/builderSDKClient'
 import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/constants'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { DEFAULT_LOCALE } from '@/utils/shared/supportedLocales'
 
 export interface PageMetadata {
   title: string
@@ -28,6 +29,7 @@ export async function getPageDetails(
     },
     // Set prerender to false to return JSON instead of HTML
     prerender: false,
+    locale: DEFAULT_LOCALE,
     fields: 'data',
   }
 

--- a/src/utils/server/builder/models/page/utils/getPagePaths.ts
+++ b/src/utils/server/builder/models/page/utils/getPagePaths.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/nextjs'
 import { builderSDKClient } from '@/utils/server/builder/builderSDKClient'
 import { BuilderPageModelIdentifiers } from '@/utils/server/builder/models/page/constants'
 import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { DEFAULT_LOCALE } from '@/utils/shared/supportedLocales'
 
 interface GetPagePathsInput {
   pageModelName: BuilderPageModelIdentifiers
@@ -27,6 +28,7 @@ export async function getPagePaths({
       sort: {
         createdDate: -1,
       },
+      locale: DEFAULT_LOCALE,
       fields: 'data,createdDate',
       cachebust: true,
     })


### PR DESCRIPTION
## What changed? Why?

If we add localization on builder.io and don't pass the locale param on the request, instead of the field content, we're going to receive an object with the localized values, which is not the expected behavior and must break a lot of things on our side.

To prevent this from happening, we should add the 'locale' param on all the builder.io requests to data models.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
