### PR TITLE
fix(googlePlaceUtils): ensure Google Maps API is ready before making calls

### DIFF
--- a/src/utils/web/googlePlaceUtils.ts
+++ b/src/utils/web/googlePlaceUtils.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/nextjs'
 import { isError } from 'lodash-es'
+import pRetry from 'p-retry'
 import { getDetails } from 'use-places-autocomplete'
 
 import { formatGooglePlacesResultToAddress } from '@/utils/shared/formatGooglePlacesResultToAddress'
@@ -16,7 +17,27 @@ type GooglePlacesResponse = Required<
   Pick<google.maps.places.PlaceResult, 'address_components' | 'geometry'>
 >
 
+function isGoogleMapsReady() {
+  return pRetry(
+    async () => {
+      return new Promise((resolve, reject) => {
+        if (typeof google !== 'undefined' && google.maps) {
+          resolve(true)
+        } else {
+          reject(new Error('Google Maps API not ready'))
+        }
+      })
+    },
+    {
+      retries: 10,
+      maxTimeout: 1000,
+    },
+  )
+}
+
 async function fetchAddressComponents(placeId: string) {
+  await isGoogleMapsReady()
+
   return getDetails({
     placeId,
     fields: ['address_components', 'geometry'],


### PR DESCRIPTION
## Description
This PR prevents "Cannot read properties of undefined (reading 'PlacesService')" errors by proactively checking API readiness instead of reactive error handling.

fixes [PROD-SWC-WEB-5G6](https://stand-with-crypto.sentry.io/issues/6158711764/?environment=production&project=4506490717470720&query=is%3Aunresolved%20PlacesService&referrer=issue-stream), [PROD-SWC-WEB-63D](https://stand-with-crypto.sentry.io/issues/6535250008/?environment=production&project=4506490717470720&query=is%3Aunresolved%20PlacesService&referrer=issue-stream)

## What changed? Why?
- Convert isGoogleMapsReady() to async function with p-retry
- Update fetchAddressComponents() to await readiness check

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
