### PR TITLE
fix: reduce batch size for CSV user import from 250 to 150

### DIFF
--- a/src/inngest/functions/importUsersByCSV/index.ts
+++ b/src/inngest/functions/importUsersByCSV/index.ts
@@ -17,7 +17,7 @@ import { importUsersByCSVProcessor } from './logic'
 export const IMPORT_USERS_BY_CSV_COORDINATOR_EVENT_NAME = 'script/import-users-by-csv.coordinator'
 export const IMPORT_USERS_BY_CSV_COORDINATOR_FUNCTION_ID = 'script.import-users-by-csv.coordinator'
 
-const BATCH_SIZE = 250
+const BATCH_SIZE = 150
 const DEFAULT_CAMPAIGN_NAME = 'IMPORT_BY_CSV'
 
 export interface ImportUsersByCSVCoordinatorSchema {


### PR DESCRIPTION
## Description
Reduces batch size constant from `250` to `150` in the `importUsersByCSV` function.

fixes PROD-SWC-WEB-DBG

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
