### PR TITLE
feature: enhance type safety on translations

### DIFF
--- a/src/components/app/recentActivityRow/variantRecentActivityRow.tsx
+++ b/src/components/app/recentActivityRow/variantRecentActivityRow.tsx
@@ -224,7 +224,7 @@ const DTSIPersonName = ({
   return link
 }
 
-const getSWCDisplayText = (t: (key: string) => string) => (
+const getSWCDisplayText = (t: (key: 'standWithCrypto' | 'swc') => string) => (
   <>
     <span className="hidden sm:inline"> {t('standWithCrypto')}</span>
     <span className="sm:hidden"> {t('swc')} </span>

--- a/src/components/app/userActionFormPetitionSignature/index.tsx
+++ b/src/components/app/userActionFormPetitionSignature/index.tsx
@@ -173,7 +173,7 @@ export function UserActionFormPetitionSignature({
       )
 
       if (!validateCountryCode(address.countryCode)) {
-        const countryName = t(petitionData.countryCode.toUpperCase())
+        const countryName = t(petitionData.countryCode.toUpperCase() as keyof typeof t)
 
         form.setError('address', {
           message: t('petitionUnavailableForCountry', { countryName }),

--- a/src/utils/server/i18n/getServerTranslation.ts
+++ b/src/utils/server/i18n/getServerTranslation.ts
@@ -17,36 +17,45 @@ import {
 } from '@/utils/shared/supportedLocales'
 
 /**
- * Function to use translations in server components and server-side functions
+ * Function to use translations in server components and server-side functions with type-safe keys
  *
- * @param i18nMessages - Object with the component translations
+ * @param i18nMessages - Object with the component translations (created with createI18nMessages)
  * @param contextName - Component name (optional)
- * @returns Object translator with t() method to translate
+ * @param countryCode - Country code (optional, defaults to DEFAULT_SUPPORTED_COUNTRY_CODE)
+ * @param language - Language (optional, defaults to auto-detection)
+ * @returns Object translator with type-safe t() method to translate
  *
  * @example
  * ```tsx
- * const i18nMessages = {
- *   en: { 'title': 'Server Component Title' },
- *   de: { 'title': 'Server-Komponente Titel' },
- *   fr: { 'title': 'Titre du Composant Serveur' }
- * }
+ * const i18nMessages = createI18nMessages({
+ *   defaultMessages: {
+ *     en: { 'title': 'Server Component Title' },
+ *     de: { 'title': 'Server-Komponente Titel' },
+ *     fr: { 'title': 'Titre du Composant Serveur' }
+ *   }
+ * })
  *
- * export default function ServerComponent() {
- *   const { t } = getTranslation(i18nMessages)
+ * export default async function ServerComponent() {
+ *   const { t } = await getServerTranslation(i18nMessages)
  *
- *   return <h1>{t('title')}</h1>
+ *   return <h1>{t('title')}</h1> // 'title' is type-safe
  * }
  * ```
  */
-export async function getServerTranslation(
-  i18nMessages: I18nMessages,
+export async function getServerTranslation<T extends Record<string, string>>(
+  i18nMessages: I18nMessages<T>,
   contextName: string = 'unknown',
   countryCode: SupportedCountryCodes = DEFAULT_SUPPORTED_COUNTRY_CODE,
   language?: SupportedLanguages,
 ) {
   // Use provided language or fallback to auto-detection
   const finalLanguage = language || (await getServerLanguage())
-  const translator = createTranslator(i18nMessages, finalLanguage, countryCode, contextName)
+  const translator = createTranslator<T>({
+    messages: i18nMessages,
+    language: finalLanguage,
+    countryCode,
+    contextName,
+  })
 
   return {
     t: translator.t.bind(translator),

--- a/src/utils/server/i18n/getStaticTranslation.ts
+++ b/src/utils/server/i18n/getStaticTranslation.ts
@@ -4,15 +4,26 @@ import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
 import { SupportedLanguages } from '@/utils/shared/supportedLocales'
 
 /**
- * Creates a simple translation object with bound methods.
+ * Creates a simple translation object with bound methods and type-safe keys.
  *
  * Use it when you have the countryCode and language params, but the headers or cookies
  * are not accessible (e.g. static files, utils functions, etc).
  *
+ * @param i18nMessages - Object with the component translations (created with createI18nMessages)
+ * @param language - The language to use for translations
+ * @param countryCode - The country code to use for translations
+ * @returns Object translator with type-safe t() method to translate
+ *
  * @example
  * ```ts
- * const { t } = getStaticTranslation(messages, 'en', 'US')
- * const welcomeText = t('welcome')
+ * const messages = createI18nMessages({
+ *   defaultMessages: {
+ *     en: { welcome: 'Welcome' },
+ *     de: { welcome: 'Willkommen' }
+ *   }
+ * })
+ * const { t } = getStaticTranslation(messages, SupportedLanguages.EN, SupportedCountryCodes.US)
+ * const welcomeText = t('welcome') // 'welcome' is type-safe
  * ```
  *
  * @example
@@ -20,16 +31,20 @@ import { SupportedLanguages } from '@/utils/shared/supportedLocales'
  * // In a utility function where headers aren't available
  * function generateEmailContent(language: SupportedLanguages, countryCode: SupportedCountryCodes) {
  *   const { t } = getStaticTranslation(emailMessages, language, countryCode)
- *   return t('email.subject')
+ *   return t('email.subject') // Keys are type-safe
  * }
  * ```
  */
-export function getStaticTranslation(
-  i18nMessages: I18nMessages,
+export function getStaticTranslation<T extends Record<string, string>>(
+  i18nMessages: I18nMessages<T>,
   language: SupportedLanguages,
   countryCode: SupportedCountryCodes,
 ) {
-  const translator = createTranslator(i18nMessages, language, countryCode)
+  const translator = createTranslator<T>({
+    messages: i18nMessages,
+    language,
+    countryCode,
+  })
 
   return {
     t: translator.t.bind(translator),

--- a/src/utils/shared/i18n/commons.ts
+++ b/src/utils/shared/i18n/commons.ts
@@ -1,9 +1,9 @@
 import { createI18nMessages } from '@/utils/shared/i18n/createI18nMessages'
-import { ComponentMessages, I18nMessages } from '@/utils/shared/i18n/types'
-import { SupportedCountryCodes } from '@/utils/shared/supportedCountries'
+import { mergeI18nMessages } from '@/utils/shared/i18n/mergeI18nMessages'
+import { I18nMessages } from '@/utils/shared/i18n/types'
 
 //It's made that way to keep the extraction script working
-const i18nMessages: I18nMessages = createI18nMessages({
+const i18nMessages = createI18nMessages({
   defaultMessages: {
     en: {
       territoryDivision: 'State',
@@ -67,60 +67,6 @@ const i18nMessages: I18nMessages = createI18nMessages({
 
 export const i18nCommonMessages = i18nMessages
 
-function mergeComponentMessages(
-  commonMessages: ComponentMessages | undefined,
-  inputMessages: ComponentMessages | undefined,
-): ComponentMessages {
-  return {
-    ...commonMessages,
-    ...inputMessages,
-  }
-}
-
-function getLanguageMessages(
-  countryMessages: Record<string, ComponentMessages> | undefined,
-  languageCode: string,
-): ComponentMessages | undefined {
-  return countryMessages?.[languageCode]
-}
-
-export function withI18nCommons(messages: I18nMessages): I18nMessages {
-  const result: I18nMessages = {}
-
-  // Get all country codes from both common messages and input messages
-  const allCountryCodes = new Set([...Object.keys(i18nCommonMessages), ...Object.keys(messages)])
-
-  for (const countryCode of allCountryCodes) {
-    const typedCountryCode = countryCode as SupportedCountryCodes
-    const commonCountryMessages = i18nCommonMessages[typedCountryCode]
-    const inputCountryMessages = messages[typedCountryCode]
-
-    if (!commonCountryMessages && !inputCountryMessages) {
-      continue
-    }
-
-    // Get all language codes from both common and input messages for this country
-    const allLanguageCodes = new Set([
-      ...(commonCountryMessages ? Object.keys(commonCountryMessages) : []),
-      ...(inputCountryMessages ? Object.keys(inputCountryMessages) : []),
-    ])
-
-    const countryResult: Record<string, ComponentMessages> = {}
-
-    for (const languageCode of allLanguageCodes) {
-      const commonLanguageMessages = getLanguageMessages(commonCountryMessages, languageCode)
-      const inputLanguageMessages = getLanguageMessages(inputCountryMessages, languageCode)
-
-      // Deep merge the language messages - input messages override common messages
-      countryResult[languageCode] = mergeComponentMessages(
-        commonLanguageMessages,
-        inputLanguageMessages,
-      )
-    }
-
-    // Use Object.assign to avoid type assertion issues
-    Object.assign(result, { [typedCountryCode]: countryResult })
-  }
-
-  return result
+export function withI18nCommons<T extends Record<string, string>>(messages: I18nMessages<T>) {
+  return mergeI18nMessages(i18nCommonMessages, messages)
 }

--- a/src/utils/shared/i18n/createI18nMessages.test.ts
+++ b/src/utils/shared/i18n/createI18nMessages.test.ts
@@ -7,9 +7,9 @@ import { SupportedLanguages } from '@/utils/shared/supportedLocales'
 import { createI18nMessages } from './createI18nMessages'
 
 describe('createI18nMessages', () => {
-  describe('with no parameters', () => {
+  describe('with empty defaultMessages', () => {
     it('should return empty messages for all countries and languages', () => {
-      const result = createI18nMessages()
+      const result = createI18nMessages({ defaultMessages: {} })
 
       expect(result).toEqual({
         [SupportedCountryCodes.US]: {
@@ -80,20 +80,21 @@ describe('createI18nMessages', () => {
     })
   })
 
-  describe('with messagesOverrides only', () => {
+  describe('with overrides only', () => {
     it('should apply country-specific messages', () => {
-      const messagesOverrides: PartialI18nMessages = {
-        [SupportedCountryCodes.US]: {
-          [SupportedLanguages.EN]: { welcome: 'Welcome to USA' },
-        },
-        [SupportedCountryCodes.EU]: {
-          [SupportedLanguages.EN]: { welcome: 'Welcome to Europe' },
-          [SupportedLanguages.DE]: { welcome: 'Willkommen in Europa' },
-          [SupportedLanguages.FR]: { welcome: 'Bienvenue en Europe' },
-        },
-      }
-
-      const result = createI18nMessages({ defaultMessages: {}, messagesOverrides })
+      const result = createI18nMessages({
+        defaultMessages: {},
+        messagesOverrides: {
+          [SupportedCountryCodes.US]: {
+            [SupportedLanguages.EN]: { welcome: 'Welcome to USA' },
+          },
+          [SupportedCountryCodes.EU]: {
+            [SupportedLanguages.EN]: { welcome: 'Welcome to Europe' },
+            [SupportedLanguages.DE]: { welcome: 'Willkommen in Europa' },
+            [SupportedLanguages.FR]: { welcome: 'Bienvenue en Europe' },
+          },
+        } as any,
+      })
 
       expect(result[SupportedCountryCodes.US]?.[SupportedLanguages.EN]).toEqual({
         welcome: 'Welcome to USA',
@@ -107,14 +108,15 @@ describe('createI18nMessages', () => {
     })
 
     it('should handle partial country messages', () => {
-      const messagesOverrides: PartialI18nMessages = {
-        [SupportedCountryCodes.US]: {
-          [SupportedLanguages.EN]: { welcome: 'Welcome to USA' },
-        },
-        // Missing other countries
-      }
-
-      const result = createI18nMessages({ defaultMessages: {}, messagesOverrides })
+      const result = createI18nMessages({
+        defaultMessages: {},
+        messagesOverrides: {
+          [SupportedCountryCodes.US]: {
+            [SupportedLanguages.EN]: { welcome: 'Welcome to USA' },
+          },
+          // Missing other countries
+        } as any,
+      })
 
       expect(result[SupportedCountryCodes.US]?.[SupportedLanguages.EN]).toEqual({
         welcome: 'Welcome to USA',
@@ -124,7 +126,7 @@ describe('createI18nMessages', () => {
     })
   })
 
-  describe('with both defaultMessages and messagesOverrides', () => {
+  describe('with both defaultMessages and overrides', () => {
     it('should merge messages with defaults, with overrides taking precedence', () => {
       const defaultMessages = {
         [SupportedLanguages.EN]: { hello: 'Hello', goodbye: 'Goodbye' },
@@ -212,13 +214,14 @@ describe('createI18nMessages', () => {
 
   describe('edge cases', () => {
     it('should handle missing country messages gracefully', () => {
-      const messagesOverrides: PartialI18nMessages = {
-        [SupportedCountryCodes.US]: {
-          [SupportedLanguages.EN]: { test: 'value' },
-        },
-      }
-
-      const result = createI18nMessages({ defaultMessages: {}, messagesOverrides })
+      const result = createI18nMessages({
+        defaultMessages: {},
+        messagesOverrides: {
+          [SupportedCountryCodes.US]: {
+            [SupportedLanguages.EN]: { test: 'value' },
+          },
+        } as any,
+      })
 
       expect(result[SupportedCountryCodes.US]?.[SupportedLanguages.EN]).toEqual({
         test: 'value',
@@ -227,7 +230,7 @@ describe('createI18nMessages', () => {
     })
 
     it('should maintain structure for all supported countries', () => {
-      const result = createI18nMessages()
+      const result = createI18nMessages({ defaultMessages: {} })
 
       // Verify all expected countries are present
       expect(result).toHaveProperty(SupportedCountryCodes.US)

--- a/src/utils/shared/i18n/createI18nMessages.ts
+++ b/src/utils/shared/i18n/createI18nMessages.ts
@@ -1,5 +1,9 @@
 import { getSupportedLanguagesForCountry } from '@/utils/shared/i18n/getSupportedLanguagesByCountry'
-import { I18nCountryMessages, I18nMessages } from '@/utils/shared/i18n/types'
+import {
+  I18nMessages,
+  SupportedLanguagesByCountryCode,
+  UniformShape,
+} from '@/utils/shared/i18n/types'
 import {
   ORDERED_SUPPORTED_COUNTRIES,
   SupportedCountryCodes,
@@ -10,77 +14,73 @@ import { SupportedLanguages } from '@/utils/shared/supportedLocales'
  * Creates a complete internationalization (i18n) messages object by merging default messages
  * with country/language-specific messages for all supported countries and languages.
  *
- * This function iterates through all supported countries and their respective supported languages,
- * creating a hierarchical structure where default messages serve as fallbacks and are overridden
- * by more specific language messages when provided.
+ * This function uses type-safe keys to ensure that all translation keys are valid across
+ * all languages. The defaultMessages parameter enforces that all language objects have
+ * identical keys through the UniformShape type.
  *
  * @param options - Configuration object for creating i18n messages
- * @param options.defaultMessages - Optional default messages that serve as fallbacks for all languages.
- *                                  These are applied first and can be overridden by specific language messages.
- * @param options.messagesOverrides - Optional country/language-specific messages that override default messages.
- *                                   Structure: { countryCode: { language?: ComponentMessages } }
- *                                   Languages within each country are optional, allowing partial overrides.
+ * @param options.defaultMessages - Default messages that serve as fallbacks for all languages.
+ *                                  All language objects must have the same keys.
+ * @param options.overrides - Optional country/language-specific messages that override default messages.
+ *                           Can only override keys that exist in defaultMessages.
  *
  * @returns A complete I18nMessages object structured as:
- *          { countryCode: { language: ComponentMessages } }
- *          where each language contains merged default and specific messages
+ *          { countryCode: { language: Messages } }
+ *          where each language contains merged default and override messages
  *
  * @example
  * ```typescript
  * const messages = createI18nMessages({
  *   defaultMessages: {
- *     en: { welcome: 'Welcome' }
+ *     en: { welcome: 'Welcome', test: 'Test' },
+ *     de: { welcome: 'Willkommen', test: 'Test' },
+ *     fr: { welcome: 'Bienvenue', test: 'Test' }
  *   },
- *   messagesOverrides: {
+ *   overrides: {
  *     us: {
- *       en: { welcome: 'Welcome to the US' }
- *     },
- *     eu: {
- *       // Only override French, other languages (en, de) will use defaults
- *       fr: { welcome: 'Bienvenue aux États-Unis' }
+ *       en: { welcome: 'Welcome to the US' } // Can only override 'welcome' or 'test'
  *     }
  *   }
  * });
- * // Result: { us: { en: { welcome: 'Welcome to the US' } }, eu: { fr: { welcome: 'Bienvenue aux États-Unis' }, en: { welcome: 'Welcome' }, de: { welcome: 'Welcome' } } }
  * ```
  */
 export function createI18nMessages<
-  TLanguageMessages extends Record<string, string>,
-  TMessages extends Partial<Record<SupportedLanguages, TLanguageMessages>>,
-  TRequired extends keyof TMessages[keyof TMessages] = never,
+  const TDefaultMessages extends Partial<Record<SupportedLanguages, Record<string, string>>>,
+  T extends Record<string, string> = NonNullable<TDefaultMessages[keyof TDefaultMessages]>,
 >({
-  defaultMessages = {} as TMessages,
-  messagesOverrides = {},
+  defaultMessages,
+  messagesOverrides,
 }: {
-  defaultMessages?: TMessages
-  messagesOverrides?: Partial<
-    Record<
-      SupportedCountryCodes,
-      Partial<{
-        [L in keyof TMessages]: Partial<Pick<TMessages[L], TRequired>> & Partial<TMessages[L]>
-      }>
-    >
-  >
-} = {}): I18nMessages {
-  const i18nMessages: I18nMessages = {}
+  defaultMessages: TDefaultMessages & UniformShape<TDefaultMessages>
+  messagesOverrides?: Partial<{
+    [Country in SupportedCountryCodes]?: Partial<{
+      [Lang in SupportedLanguagesByCountryCode[Country][number]]?: T extends infer U
+        ? Partial<Record<keyof U, string>>
+        : unknown
+    }>
+  }>
+}): I18nMessages<T> {
+  const i18nMessages: I18nMessages<T> = {}
 
   for (const countryCode of ORDERED_SUPPORTED_COUNTRIES) {
-    const messagesFromCountry = {} as I18nCountryMessages<typeof countryCode>
-
     const supportedLanguages = getSupportedLanguagesForCountry(countryCode)
-    const countryMessagesOverrides = messagesOverrides[countryCode]
+    const countryMessagesOverrides = messagesOverrides?.[countryCode]
+    const countryMessages: Record<string, Record<string, string>> = {}
 
     for (const language of supportedLanguages) {
       const languageMessagesOverrides =
         countryMessagesOverrides?.[language as keyof typeof countryMessagesOverrides]
 
-      messagesFromCountry[language] = {
-        ...defaultMessages?.[language],
-        ...languageMessagesOverrides,
+      const baseMessages = defaultMessages[language] ?? {}
+      const overrideMessages = languageMessagesOverrides ?? {}
+
+      countryMessages[language] = {
+        ...baseMessages,
+        ...overrideMessages,
       }
     }
 
-    i18nMessages[countryCode] = messagesFromCountry
+    i18nMessages[countryCode] = countryMessages
   }
 
   return i18nMessages

--- a/src/utils/shared/i18n/mergeI18nMessages.test.ts
+++ b/src/utils/shared/i18n/mergeI18nMessages.test.ts
@@ -69,11 +69,9 @@ describe('mergeI18nMessages', () => {
 
     it('should add new languages for existing countries', () => {
       const target: I18nMessages = {
-        // @ts-expect-error - This is a test
         eu: { en: { hello: 'Hello' } },
       }
       const source: I18nMessages = {
-        // @ts-expect-error - This is a test
         eu: { fr: { hello: 'Bonjour' }, de: { hello: 'Hallo' } },
       }
 

--- a/src/utils/shared/i18n/mergeI18nMessages.ts
+++ b/src/utils/shared/i18n/mergeI18nMessages.ts
@@ -45,18 +45,18 @@ import { I18nMessages } from './types'
  * - Source values always win in case of conflicts at any nesting level
  * - Maintains type safety with I18nMessages structure (country -> language -> messages)
  */
-export function mergeI18nMessages(
-  target: I18nMessages | undefined,
-  source: I18nMessages | undefined,
-): I18nMessages {
+export function mergeI18nMessages<
+  T extends Record<string, string>,
+  U extends Record<string, string>,
+>(target: I18nMessages<T> | undefined, source: I18nMessages<U> | undefined): I18nMessages<T & U> {
   if (!target && !source) {
     return {}
   }
   if (!target) {
-    return { ...source }
+    return { ...source } as I18nMessages<T & U>
   }
   if (!source) {
-    return { ...target }
+    return { ...target } as I18nMessages<T & U>
   }
 
   return mergeWith({}, target, source, (objValue, srcValue) => {

--- a/src/utils/shared/i18n/types.ts
+++ b/src/utils/shared/i18n/types.ts
@@ -13,12 +13,13 @@ export interface SupportedLanguagesByCountryCode {
   [SupportedCountryCodes.EU]: [SupportedLanguages.FR, SupportedLanguages.DE, SupportedLanguages.EN]
 }
 
+// Legacy types - kept for backward compatibility
 export type I18nCountryMessages<T extends SupportedCountryCodes> = {
   [K in SupportedLanguagesByCountryCode[T][number]]: ComponentMessages
 }
 
-export type I18nMessages = {
-  [K in SupportedCountryCodes]?: I18nCountryMessages<K>
+export type I18nMessages<T extends Record<string, string> = ComponentMessages> = {
+  [K in SupportedCountryCodes]?: LanguageMessages<T>
 }
 
 export type PartialI18nCountryMessages<T extends SupportedCountryCodes> = {
@@ -27,6 +28,24 @@ export type PartialI18nCountryMessages<T extends SupportedCountryCodes> = {
 
 export type PartialI18nMessages = {
   [K in SupportedCountryCodes]?: PartialI18nCountryMessages<K>
+}
+
+// New generic types with type-safe keys
+export type LanguageMessages<T extends Record<string, string>> = {
+  [K in SupportedLanguages]?: T
+}
+
+// Enforce that all objects in T have identical keys
+export type UniformShape<T> = {
+  [K in keyof T]: T[K] extends Record<string, string>
+    ? T[keyof T] extends Record<string, string>
+      ? keyof T[K] extends keyof T[keyof T]
+        ? keyof T[keyof T] extends keyof T[K]
+          ? T[K]
+          : never
+        : never
+      : T[K]
+    : T[K]
 }
 
 // Define our own types since FormatJS doesn't export these directly from the main package

--- a/src/utils/web/i18n/useTranslation.ts
+++ b/src/utils/web/i18n/useTranslation.ts
@@ -12,28 +12,33 @@ import {
 import { DEFAULT_EU_LANGUAGE } from '@/utils/shared/supportedLocales'
 
 /**
- * Hook to use translations in client components
+ * Hook to use translations in client components with type-safe keys
  *
- * @param i18nMessages - Object with the component translations
+ * @param i18nMessages - Object with the component translations (created with createI18nMessages)
  * @param contextName - Component name (optional)
- * @returns Object translator with t() method to translate
+ * @returns Object translator with type-safe t() method to translate
  *
  * @example
  * ```tsx
- * const i18nMessages = {
- *   en: { 'welcome': 'Welcome {name}!' },
- *   de: { 'welcome': 'Willkommen {name}!' },
- *   fr: { 'welcome': 'Bienvenue {name}!' }
- * }
+ * const i18nMessages = createI18nMessages({
+ *   defaultMessages: {
+ *     en: { 'welcome': 'Welcome {name}!' },
+ *     de: { 'welcome': 'Willkommen {name}!' },
+ *     fr: { 'welcome': 'Bienvenue {name}!' }
+ *   }
+ * })
  *
  * function MyComponent() {
  *   const { t } = useTranslation(i18nMessages)
  *
- *   return <h1>{t('welcome', { name: 'João' })}</h1>
+ *   return <h1>{t('welcome', { name: 'João' })}</h1> // 'welcome' is type-safe
  * }
  * ```
  */
-export function useTranslation(i18nMessages: I18nMessages, contextName: string = 'unknown') {
+export function useTranslation<T extends Record<string, string>>(
+  i18nMessages: I18nMessages<T>,
+  contextName: string = 'unknown',
+) {
   const pathname = usePathname()
 
   const language = useMemo(() => {
@@ -51,7 +56,12 @@ export function useTranslation(i18nMessages: I18nMessages, contextName: string =
   }, [pathname])
 
   const translator = useMemo(() => {
-    return createTranslator(i18nMessages, language, countryCode, contextName)
+    return createTranslator<T>({
+      messages: i18nMessages,
+      language,
+      countryCode,
+      contextName,
+    })
   }, [i18nMessages, language, countryCode, contextName])
 
   return {

--- a/src/validation/fields/zodGooglePlacesAutocompletePrediction.ts
+++ b/src/validation/fields/zodGooglePlacesAutocompletePrediction.ts
@@ -1,7 +1,6 @@
 import { object, string } from 'zod'
 
 import { createI18nMessages } from '@/utils/shared/i18n/createI18nMessages'
-import { Translator } from '@/utils/shared/i18n/createTranslator'
 
 export const zodGooglePlacesAutocompletePrediction = object(
   {
@@ -14,8 +13,10 @@ export const zodGooglePlacesAutocompletePrediction = object(
   },
 )
 
-export const createZodGooglePlacesAutocompletePredictionWithI18n = (t: Translator['t']) =>
-  object(
+export function createZodGooglePlacesAutocompletePredictionWithI18n(
+  t: (key: 'pleaseSelectAValidAddress') => string,
+) {
+  return object(
     {
       place_id: string(),
       description: string(),
@@ -25,6 +26,7 @@ export const createZodGooglePlacesAutocompletePredictionWithI18n = (t: Translato
       invalid_type_error: t('pleaseSelectAValidAddress'),
     },
   )
+}
 
 export const i18nMessages = createI18nMessages({
   defaultMessages: {

--- a/src/validation/forms/zodUserActionFormPetitionSignature.ts
+++ b/src/validation/forms/zodUserActionFormPetitionSignature.ts
@@ -1,7 +1,6 @@
 import z, { object, string } from 'zod'
 
 import { createI18nMessages } from '@/utils/shared/i18n/createI18nMessages'
-import { Translator } from '@/utils/shared/i18n/createTranslator'
 import { mergeI18nMessages } from '@/utils/shared/i18n/mergeI18nMessages'
 import { GenericErrorFormValues } from '@/utils/web/formUtils'
 import { zodAddress } from '@/validation/fields/zodAddress'
@@ -10,7 +9,16 @@ import {
   zodGooglePlacesAutocompletePredictionI18nMessages,
 } from '@/validation/fields/zodGooglePlacesAutocompletePrediction'
 
-export const createZodSchemaWithI18n = (t: Translator['t']) => {
+type I18nMessagesKeys =
+  | 'firstNameRequired'
+  | 'lastNameRequired'
+  | 'emailAddressInvalid'
+  | 'campaignNameRequired'
+  | 'addressRequired'
+  | 'addressCouldNotBeFound'
+  | 'pleaseSelectAValidAddress'
+
+export function createZodSchemaWithI18n(t: (key: I18nMessagesKeys) => string) {
   return object({
     firstName: string().min(1, t('firstNameRequired')),
     lastName: string().min(1, t('lastNameRequired')),
@@ -21,14 +29,15 @@ export const createZodSchemaWithI18n = (t: Translator['t']) => {
 }
 
 // For client-side form (uses GooglePlaceAutocompletePrediction)
-export const createUserActionFormPetitionSignature = (t: Translator['t']) =>
-  createZodSchemaWithI18n(t).extend({
+export function createUserActionFormPetitionSignature(t: (key: I18nMessagesKeys) => string) {
+  return createZodSchemaWithI18n(t).extend({
     address: createZodGooglePlacesAutocompletePredictionWithI18n(t).nullable(),
   })
+}
 
 // For server action (uses converted Address)
-export const createUserActionFormPetitionSignatureAction = (t: Translator['t']) =>
-  createZodSchemaWithI18n(t)
+export function createUserActionFormPetitionSignatureAction(t: (key: I18nMessagesKeys) => string) {
+  return createZodSchemaWithI18n(t)
     .extend({
       address: zodAddress.nullable(),
     })
@@ -40,6 +49,7 @@ export const createUserActionFormPetitionSignatureAction = (t: Translator['t']) 
       ...data,
       address: data.address!,
     }))
+}
 
 export type UserActionPetitionSignatureValues = z.infer<
   ReturnType<typeof createUserActionFormPetitionSignature>


### PR DESCRIPTION
## What changed? Why?

- Updated translation functions to use type-safe keys, ensuring that translation keys are validated at compile time.
- Modified components to accept more specific types for translation functions, improving overall type safety and reducing runtime errors.
- Refactored i18n message creation and merging functions to enforce consistent structure and type safety across different languages and countries.
- Improved documentation for translation utilities to clarify usage and examples.

## How has it been tested?

- [x] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
