### PR TITLE
feature: add translations to address input

### DIFF
--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -14,8 +14,10 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { usePreventMobileKeyboardOffset } from '@/hooks/usePreventMobileKeyboardOffset'
 import { useResizeObserver } from '@/hooks/useResizeObserver'
+import { createI18nMessages } from '@/utils/shared/i18n/createI18nMessages'
 import { trackClientAnalytic } from '@/utils/web/clientAnalytics'
 import { cn } from '@/utils/web/cn'
+import { useTranslation } from '@/utils/web/i18n/useTranslation'
 import {
   PrimitiveComponentAnalytics,
   trackPrimitiveComponentAnalytics,
@@ -39,6 +41,29 @@ interface ComboBoxProps<T>
   disablePreventMobileKeyboardOffset?: boolean
 }
 
+export const i18nMessages = createI18nMessages({
+  defaultMessages: {
+    en: {
+      a11yTitle: 'Search address',
+      placeholder: 'Filter status...',
+      noResults: 'No results found.',
+      enterAddress: 'Enter address to see results',
+    },
+    fr: {
+      a11yTitle: 'Rechercher une adresse',
+      placeholder: 'Filtrer les statuts...',
+      noResults: 'Aucun résultat trouvé.',
+      enterAddress: 'Entrez une adresse pour voir les résultats',
+    },
+    de: {
+      a11yTitle: 'Adresse rechercher',
+      placeholder: 'Filter status...',
+      noResults: 'Keine Ergebnisse gefunden.',
+      enterAddress: 'Adresse eingeben, um Ergebnisse zu sehen',
+    },
+  },
+})
+
 export function Combobox<T>({
   value,
   onChange,
@@ -54,6 +79,7 @@ export function Combobox<T>({
   disablePreventMobileKeyboardOffset = false,
   ...inputProps
 }: ComboBoxProps<T>) {
+  const { t } = useTranslation(i18nMessages, 'Combobox')
   usePreventMobileKeyboardOffset(open && !disablePreventMobileKeyboardOffset)
   const parentRef = React.useRef<HTMLButtonElement>(null)
   const isMobile = useIsMobile({ defaultState: false })
@@ -76,7 +102,7 @@ export function Combobox<T>({
       <Dialog analytics={wrappedAnalytics} onOpenChange={setOpen} open={open}>
         <DialogTrigger asChild>{formatPopoverTrigger({ value, open })}</DialogTrigger>
         <DialogContent
-          a11yTitle="Search address"
+          a11yTitle={t('a11yTitle')}
           className="min-h-[260px] p-0 pt-10"
           forceAutoFocus
         >
@@ -141,6 +167,7 @@ function StatusList<T>({
   | 'getOptionKey'
   | 'isLoading'
 >) {
+  const { t } = useTranslation(i18nMessages, 'Combobox')
   return (
     <Command shouldFilter={false}>
       <CommandInput
@@ -152,14 +179,14 @@ function StatusList<T>({
           onChangeInputValue('')
         }}
         onValueChange={onChangeInputValue}
-        placeholder="Filter status..."
+        placeholder={t('placeholder')}
         value={inputValue}
         {...inputProps}
       />
       <CommandList>
         {!options.length && (
           <p className={cn('py-6 text-center text-sm', isLoading && 'invisible')}>
-            {inputValue ? 'No results found.' : 'Enter address to see results'}
+            {inputValue ? t('noResults') : t('enterAddress')}
           </p>
         )}
         <CommandGroup>

--- a/src/components/ui/googlePlacesSelect/index.tsx
+++ b/src/components/ui/googlePlacesSelect/index.tsx
@@ -7,8 +7,10 @@ import { Combobox } from '@/components/ui/combobox'
 import { InputWithIcons, InputWithIconsProps } from '@/components/ui/inputWithIcons'
 import { Spinner } from '@/components/ui/spinner'
 import { useGoogleMapsScript } from '@/hooks/useGoogleMapsScript'
+import { createI18nMessages } from '@/utils/shared/i18n/createI18nMessages'
 import { cn } from '@/utils/web/cn'
 import { GooglePlaceAutocompletePrediction } from '@/utils/web/googlePlaceUtils'
+import { useTranslation } from '@/utils/web/i18n/useTranslation'
 
 export type GooglePlacesSelectProps = {
   value: GooglePlaceAutocompletePrediction | null
@@ -22,6 +24,23 @@ export type GooglePlacesSelectProps = {
    */
   shouldLimitUSAddresses?: boolean
 } & Omit<InputWithIconsProps, 'value' | 'onChange' | 'type'>
+
+export const i18nMessages = createI18nMessages({
+  defaultMessages: {
+    en: {
+      popoverPlaceholder: 'select a location',
+      placeholder: 'Type your address...',
+    },
+    de: {
+      popoverPlaceholder: 'Standort auswählen',
+      placeholder: 'Geben Sie Ihre Adresse ein...',
+    },
+    fr: {
+      popoverPlaceholder: 'sélectionner un lieu',
+      placeholder: 'Saisissez votre adresse...',
+    },
+  },
+})
 
 export const GooglePlacesSelect = React.forwardRef<
   React.ComponentRef<'input'>,
@@ -38,6 +57,7 @@ export const GooglePlacesSelect = React.forwardRef<
     disabled,
     ...inputProps
   } = props
+  const { t } = useTranslation(i18nMessages)
   const [open, setOpen] = React.useState(false)
   const {
     ready,
@@ -94,10 +114,12 @@ export const GooglePlacesSelect = React.forwardRef<
               />
             ) : undefined
           }
-          placeholder="select a location"
+          placeholder={t('popoverPlaceholder')}
           ref={ref}
           rightIcon={isLoadingSuggestions ? <Spinner /> : undefined}
-          value={triggerProps.value?.description || inputProps.placeholder || 'select a location'}
+          value={
+            triggerProps.value?.description || inputProps.placeholder || t('popoverPlaceholder')
+          }
           {...inputProps}
           readOnly
         />
@@ -110,7 +132,7 @@ export const GooglePlacesSelect = React.forwardRef<
       onChangeInputValue={setValue}
       open={open}
       options={placesAutoCompleteResult}
-      placeholder="Type your address..."
+      placeholder={t('placeholder')}
       setOpen={setOpen}
       value={propsValue}
     />


### PR DESCRIPTION
closes #2727 

## What changed? Why?

- Added translations to address picker input

## How has it been tested?

- [X] Locally
- [ ] Vercel Preview Branch
- [ ] Unit test
- [ ] Functional test
